### PR TITLE
Add LICENSE and CI, fix the install command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Node 22 is the floor: the OpenCode adapter uses the built-in node:sqlite.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      # Builds core, then the CLI, then the site. The site build is what catches a Node
+      # built-in leaking into the client bundle through @tokencard/core.
+      - run: npm run build
+
+      - run: npm test
+
+      # The card is the product; a builder that renders nothing should fail the run.
+      - name: Card renders
+        run: |
+          node --input-type=module -e "
+            import { buildCardSvg } from './packages/core/dist/index.js';
+            const svg = buildCardSvg({
+              handle: 'octocat', tokens: '1.20B', spend: '\$412', streak: '17d',
+              mix: [{ agent: 'claude-code', pct: 100 }], syncedAt: 'SYNCED 1H AGO',
+            });
+            if (!svg.startsWith('<svg') || !svg.endsWith('</svg>')) throw new Error('malformed SVG');
+            console.log('card renders,', svg.length, 'bytes');
+          "
+
+      # Every adapter must survive a machine with no agent logs at all — the state a CI
+      # runner is in, and the state a new user's laptop may be in.
+      - name: Adapters degrade on a bare machine
+        run: |
+          node --input-type=module -e "
+            import { adapters } from './packages/core/dist/adapters/index.js';
+            for (const a of adapters) {
+              const state = await a.detect();
+              let n = 0;
+              for await (const _ of a.read()) n++;
+              console.log(a.id, state, n, 'events');
+            }
+          "

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yash Chauhan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -5,7 +5,9 @@ import { StatCard } from "./stat-card";
 import { useSiteState } from "./site-state";
 import styles from "./hero.module.css";
 
-const INSTALL = "npx tokencard init";
+// Scoped, because the bare `tokencard` name on npm is a 2018 tombstone: it was published
+// and unpublished within a fortnight, and npm never lets an unpublished name be reused.
+const INSTALL = "npx @tokencard/cli init";
 
 export function Hero() {
   const { handle, setHandle } = useSiteState();


### PR DESCRIPTION
Three things standing between the repo and being publishable. Publishing to npm
is deliberately not part of this.

## The install command on the site could never work

`hero.tsx` told visitors to run `npx tokencard init`. The bare `tokencard` name
on npm is a tombstone — published 2018-07-14, unpublished 2018-07-27, and npm
does not allow an unpublished name to be reused by anyone, including its
original owner. The README had already moved to `npx @tokencard/cli init`; the
site had not. It is the first thing anyone copies off the page.

The scoped name is free and becomes correct the moment the package ships.

## No LICENSE file

`package.json` claimed MIT and nothing in the repo backed it. For an open source
project that is the difference between MIT and unlicensed.

## No CI

Only GitGuardian ran on #1, so nothing would have caught a broken build. This
runs build and test on every pull request, plus two checks chosen for failures
this project has actually had or would not otherwise notice:

- **the card renders** and is well-formed, since it is the product
- **adapters degrade quietly on a machine with no agent logs** — the state a
  runner is in, and possibly the state a new user's laptop is in

The site build is in the pipeline on purpose: it is what caught a Node built-in
leaking into the client bundle through `@tokencard/core` during the last change.

Every step was run locally first, including the bare-machine case with an empty
`HOME`, where all three adapters correctly report `absent` and yield nothing.
