### PR TITLE
Add tokencard recap, the year in review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
 
       - run: npm test
 
+      # Vercel builds apps/site on its own, with no root build to create
+      # packages/core/dist first. That is exactly how the first deploy failed, so the
+      # site has to be buildable from its own directory in a clean tree.
+      - name: Site builds standalone, as Vercel builds it
+        run: |
+          rm -rf packages/core/dist
+          npm run build --workspace=tokencard-site
+
       # The card is the product; a builder that renders nothing should fail the run.
       - name: Card renders
         run: |

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ upload, no server — the card is a file.
 ```bash
 npx @tokencard/cli init     # detect agents, write .tokencard.json
 npx @tokencard/cli sync     # render tokencard.svg
+npx @tokencard/cli recap    # render tokencard-recap.svg — the year in review
 ```
 
 ```markdown
 ![tokencard](./tokencard.svg)
+![tokencard recap](./tokencard-recap.svg)
 ```
 
 ## What it reads
@@ -58,7 +60,37 @@ tokencard sync
   --theme auto|light|dark
   --json                 print the aggregate instead of writing an SVG
   --dry-run              report what would be written, write nothing
+
+tokencard recap
+  --out <path>           default: tokencard-recap.svg
+  --year <yyyy>          label the recap with a different year
+  --theme auto|light|dark
+  --json                 print the recap model instead of writing an SVG
+  --dry-run
 ```
+
+## The recap
+
+`recap` renders a weekday-by-hour heatmap of when you actually work, alongside your totals,
+top model and streak — in the terminal and as a second committable SVG:
+
+```
+       00    06    12    18
+  MON  ▓▓     ░░▓▒░▓▓▒▒█▓▓▒░▒▓▒   71%
+  TUE  ▒▒░░  ░░ ░░█████▓▓█▓░      86%
+  WED  ░░        ░██▓░████▒░  ░   89%
+  SUN  ███▓░     █▓█▒▓█ ▒▒█▒▒▒▓  100%
+
+  peak 11:00-20:00  ·  37 active days
+```
+
+Cells are coloured by **rank across the distinct values**, the way GitHub's contribution
+graph works, not by magnitude. Token counts are violently skewed — one long session can hold
+more than a quiet week — so a linear scale paints a single square hot and leaves the rest
+indistinguishable.
+
+Codex only records a running total per session, so its hours land on the session's last
+turn. Claude Code and OpenCode are exact to the message.
 
 `sync` writes the SVG and stops — committing on your behalf is your call, not the tool's.
 

--- a/apps/site/components/card-section.tsx
+++ b/apps/site/components/card-section.tsx
@@ -17,9 +17,9 @@ const COMPACT_SVG = buildCardSvg({ ...SAMPLE, layout: "compact", theme: "light" 
 export function CardSection() {
   const { handle } = useSiteState();
 
-  const markdown =
-    `[![tokencard](https://tokencard.dev/api/card/${handle}.svg)]` +
-    `(https://tokencard.dev/u/${handle})`;
+  // A plain image, not a link. There is no per-user page to point at, and inventing one
+  // would mean hosting exactly the surface the committed-SVG design exists to avoid.
+  const markdown = `![tokencard](https://tokencard.dev/api/card/${handle}.svg)`;
 
   /* The panel shows the origin elided so the two tags fit without scrolling; the
      clipboard gets the full URLs, which is what a README actually needs. */

--- a/apps/site/components/recap.tsx
+++ b/apps/site/components/recap.tsx
@@ -1,7 +1,6 @@
 import { SectionHeading } from "@/components/section-heading";
 import {
   AGENT_BREAKDOWN,
-  DEFAULT_HANDLE,
   HEATMAP,
   HOUR_LABELS,
   PEAK_MASK,
@@ -22,7 +21,7 @@ export function Recap() {
     <section id="recap" className={styles.section}>
       <SectionHeading n={5} title="Year in review" tone="coral" />
       <p className={styles.intro}>
-        A static recap page at tokencard.dev/u/{DEFAULT_HANDLE}/2026. Same
+        <code>tokencard recap</code> renders this as a second committable SVG. Same
         data, no card constraints.
       </p>
 

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "prebuild": "tsc -p ../../packages/core/tsconfig.json",
+    "predev": "tsc -p ../../packages/core/tsconfig.json",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/packages/cli/src/commands/recap.ts
+++ b/packages/cli/src/commands/recap.ts
@@ -1,0 +1,117 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+
+import {
+  aggregate,
+  buildRecap,
+  buildRecapSvg,
+  sanitizeHandle,
+  type Theme,
+} from "@tokencard/core";
+import { readAll } from "@tokencard/core/adapters";
+
+import { flag, has, oneOf } from "../args.js";
+import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
+import { bold, dim, green, say, warn } from "../ui.js";
+
+const THEMES = ["auto", "light", "dark"] as const satisfies readonly Theme[];
+
+/** The ramp as blocks, so the terminal shows the same shape the SVG does. */
+const BLOCKS = [" ", "░", "▒", "▓", "█"] as const;
+
+export async function recap(argv: string[]): Promise<number> {
+  const config = (await readConfig()) ?? DEFAULT_CONFIG;
+
+  const rawHandle = flag(argv, "--handle") ?? config.handle;
+  const handle = sanitizeHandle(rawHandle);
+  const theme = oneOf(flag(argv, "--theme"), THEMES, "theme") ?? config.theme;
+  const out = flag(argv, "--out") ?? "tokencard-recap.svg";
+  const json = has(argv, "--json");
+  const dryRun = has(argv, "--dry-run");
+  const yearFlag = flag(argv, "--year");
+  const year = yearFlag ? Number(yearFlag) : undefined;
+
+  if (yearFlag && !Number.isInteger(year)) {
+    throw new Error(`--year must be a whole number (got "${yearFlag}")`);
+  }
+
+  const stats = await aggregate(readAll(config.agents));
+  if (stats.tokens === 0) {
+    warn("No usage found. Run `tokencard init` to see which agents were detected.");
+    return 1;
+  }
+
+  const r = buildRecap(stats, year !== undefined ? { year } : {});
+
+  if (json) {
+    say(JSON.stringify(r, null, 2));
+    return 0;
+  }
+
+  say();
+  say(`  ${bold(`@${handle}`)} ${dim("·")} ${bold(String(r.year))}`);
+  say();
+  say(
+    `  ${bold(r.tiles.totalTokens)} tokens  ${dim("·")}  ` +
+      `${bold(r.tiles.equivCost)} equiv. API cost  ${dim("·")}  ` +
+      `${bold(r.tiles.topModel)}  ${dim("·")}  ` +
+      `${bold(r.tiles.longestStreak)} streak`,
+  );
+  say();
+
+  // Hour ruler. Each label is written into the column it marks rather than joined, so a
+  // two-character label occupies its own column and the next one instead of shunting the
+  // rest of the ruler out of step with the grid.
+  const ruler = Array(24).fill(" ");
+  for (let h = 0; h < 24; h += 6) {
+    const label = String(h).padStart(2, "0");
+    ruler[h] = label[0] as string;
+    if (h + 1 < 24) ruler[h + 1] = label[1] as string;
+  }
+  say(`  ${dim(`     ${ruler.join("")}`)}`);
+
+  for (const row of r.rows) {
+    const grid = row.levels.map((l) => BLOCKS[l]).join("");
+    const label = row.busiest ? bold(row.day) : dim(row.day);
+    const share = `${String(row.share).padStart(3)}%`;
+    say(`  ${label}  ${grid}  ${dim(share)}`);
+  }
+
+  if (r.peak) {
+    say();
+    say(dim(`  peak ${pad(r.peak.from)}:00-${pad(r.peak.to + 1)}:00  ·  ${r.activeDays} active days`));
+  }
+
+  say();
+  for (const m of r.models) {
+    say(
+      `  ${m.model.padEnd(22)} ${m.tokens.padStart(8)} ${m.cost.padStart(12)}` +
+        (m.priced ? "" : dim("  no public price")),
+    );
+  }
+  say();
+
+  if (!rawHandle) {
+    warn(`No handle set — the recap says "${handle}". Add one to ${CONFIG_FILE}.`);
+  }
+
+  const svg = buildRecapSvg({ handle, recap: r, theme });
+  const target = resolve(process.cwd(), out);
+  const rel = relative(process.cwd(), target);
+
+  if (dryRun) {
+    say(dim(`  would write ${rel} (${svg.length} bytes)`));
+    return 0;
+  }
+
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, svg, "utf8");
+  say(`${green("✓")} wrote ${bold(rel)} ${dim(`(${svg.length} bytes)`)}`);
+  say();
+  say(`  ![tokencard recap](./${rel})`);
+  say();
+
+  return 0;
+}
+
+const pad = (h: number) => String(h).padStart(2, "0");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { createRequire } from "node:module";
 
 import { init } from "./commands/init.js";
+import { recap } from "./commands/recap.js";
 import { sync } from "./commands/sync.js";
 import { bold, dim, fail, muteSqliteWarning, say } from "./ui.js";
 
@@ -17,6 +18,13 @@ ${bold("tokencard")} — turn your local AI coding agent logs into a stat card
     --theme auto|light|dark
     --json                     print the aggregate instead of writing an SVG
     --dry-run                  report what would be written, write nothing
+
+  ${bold("tokencard recap")}             year in review: heatmap, models, totals
+    --out <path>               default: tokencard-recap.svg
+    --year <yyyy>              label the recap with a different year
+    --theme auto|light|dark
+    --json                     print the recap model instead of writing an SVG
+    --dry-run
 
 ${dim("Reads only local files. Makes no network requests.")}
 `;
@@ -42,6 +50,8 @@ async function main(): Promise<number> {
       return init(argv);
     case "sync":
       return sync(argv);
+    case "recap":
+      return recap(argv);
     default:
       fail(`unknown command: ${command}`);
       say(USAGE);

--- a/packages/core/src/aggregate.ts
+++ b/packages/core/src/aggregate.ts
@@ -17,6 +17,12 @@ export type Stats = {
   /** Local `YYYY-MM-DD` to tokens, ascending. */
   byDay: Map<string, number>;
   byModel: Map<string, number>;
+  /** Tokens per hour of the local day, 0-23. */
+  byHour: number[];
+  /** Tokens per weekday, Monday first. */
+  byWeekday: number[];
+  /** Tokens per [weekday][hour], Monday first — the recap heatmap. */
+  heat: number[][];
   byAgent: Map<AgentId, number>;
   /** Per-agent share of tokens, descending — feeds `segmentWidths()`. */
   mix: { agent: AgentId; pct: number }[];
@@ -54,6 +60,9 @@ export async function aggregate(
 
   const byDay = new Map<string, number>();
   const byModel = new Map<string, number>();
+  const byHour: number[] = Array(24).fill(0);
+  const byWeekday: number[] = Array(7).fill(0);
+  const heat: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0));
   const byAgent = new Map<AgentId, number>();
   const modelCost = new Map<string, number>();
   const pricedModels = new Set<string>();
@@ -82,6 +91,13 @@ export async function aggregate(
 
     const day = localDay(e.ts);
     byDay.set(day, (byDay.get(day) ?? 0) + n);
+
+    // Monday-first, because a week of work reads Mon-Sun; JS counts from Sunday.
+    const wd = (e.ts.getDay() + 6) % 7;
+    const hr = e.ts.getHours();
+    byHour[hr] = (byHour[hr] as number) + n;
+    byWeekday[wd] = (byWeekday[wd] as number) + n;
+    (heat[wd] as number[])[hr] = ((heat[wd] as number[])[hr] as number) + n;
     byModel.set(e.model, (byModel.get(e.model) ?? 0) + n);
     byAgent.set(e.agent, (byAgent.get(e.agent) ?? 0) + n);
 
@@ -113,6 +129,9 @@ export async function aggregate(
     lastDay: days[days.length - 1] ?? null,
     byDay: new Map(days.map((d) => [d, byDay.get(d) as number])),
     byModel: new Map([...byModel].sort((a, b) => b[1] - a[1])),
+    byHour,
+    byWeekday,
+    heat,
     byAgent,
     mix,
     windows,

--- a/packages/core/src/card-svg.ts
+++ b/packages/core/src/card-svg.ts
@@ -17,6 +17,8 @@
  *     origin, so it is sanitised to [A-Za-z0-9_-]{1,16} and XML-escaped.
  */
 
+import { DARK, esc, FONT, LIGHT, render, type Palette } from "./svg.js";
+
 export type Layout = "default" | "compact";
 export type Theme = "light" | "dark" | "auto";
 export type HideKey = "spend" | "streak" | "mix";
@@ -36,54 +38,11 @@ export type CardOptions = {
   hide?: HideKey[];
 };
 
-/* ── palettes ─────────────────────────────────────────────────────────────── */
 
-type Palette = {
-  frameFill: string;
-  frameStroke: string;
-  text: string;
-  hairline: string;
-  rule: string;
-  label: string;
-  legend: string;
-  footer: string;
-  segments: [string, string, string, string];
-};
 
-const LIGHT: Palette = {
-  frameFill: "#FFFFFF",
-  frameStroke: "#101010",
-  text: "#101010",
-  hairline: "#E4E2D8",
-  rule: "#F0EFE9",
-  label: "#A5A59D",
-  legend: "#55554E",
-  footer: "#C0BEB6",
-  segments: ["#C6FF3D", "#101010", "#8A8A82", "#D8D6CE"],
-};
 
-const DARK: Palette = {
-  frameFill: "#101010",
-  frameStroke: "#2E2E28",
-  text: "#FFFFFF",
-  hairline: "#2E2E28",
-  rule: "#2E2E28",
-  label: "#6E6E66",
-  legend: "#9A9A92",
-  footer: "#55554E",
-  segments: ["#C6FF3D", "#FFFFFF", "#6E6E66", "#3A3A34"],
-};
-
-const FONT = "'JetBrains Mono', ui-monospace, monospace";
 
 /* ── helpers ──────────────────────────────────────────────────────────────── */
-
-const esc = (s: string) =>
-  s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
 
 /**
  * GitHub handles are up to 39 characters, so that is the cap — truncating at 16 would put a
@@ -144,16 +103,7 @@ export function filterAgents(mix: MixEntry[], allow?: string[] | null): MixEntry
   return kept.length ? kept : mix;
 }
 
-type El = { tag: string; attrs: Record<string, string | number>; text?: string };
 
-const render = (el: El) => {
-  const attrs = Object.entries(el.attrs)
-    .map(([k, v]) => `${k}="${typeof v === "string" ? esc(v) : v}"`)
-    .join(" ");
-  return el.text !== undefined
-    ? `<${el.tag} ${attrs}>${esc(el.text)}</${el.tag}>`
-    : `<${el.tag} ${attrs}/>`;
-};
 
 /* ── geometry ─────────────────────────────────────────────────────────────── */
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,5 +10,7 @@
 export * from "./card-svg.js";
 export * from "./types.js";
 export * from "./aggregate.js";
+export * from "./recap.js";
+export * from "./recap-svg.js";
 export * from "./pricing.js";
 export * from "./format.js";

--- a/packages/core/src/recap-svg.ts
+++ b/packages/core/src/recap-svg.ts
@@ -1,0 +1,316 @@
+import { handleSize, sanitizeHandle, type Theme } from "./card-svg.js";
+import { RAMP, type Recap } from "./recap.js";
+import { DARK, esc, FONT, LIGHT, render } from "./svg.js";
+
+/**
+ * The year-in-review, as one committable SVG.
+ *
+ * 495 wide so it stacks with the card in a README without either looking orphaned. Height
+ * is fixed: a recap that grows with the data would reflow a reader's page every sync.
+ */
+const W = 495;
+const H = 330;
+const PAD = 28;
+const INNER = W - PAD * 2; // 439, same track the card uses
+
+/** Heatmap geometry. 24 columns of 12px on a 13px pitch leaves a 1px gutter. */
+const GRID = {
+  x: PAD + 30, // room for MON..SUN
+  y: 168,
+  cell: 12,
+  pitch: 13,
+  rowPitch: 15,
+  cols: 24,
+  rows: 7,
+};
+
+const gridRight = GRID.x + GRID.cols * GRID.pitch - 1;
+
+/**
+ * The coldest ramp step is a near-white that reads as a solid block on a dark ground, so
+ * dark cards swap it for the frame's own colour. The four warm steps carry across unchanged
+ * — they are the data, and recolouring them per theme would make two cards incomparable.
+ */
+const darkRamp = (): readonly string[] => ["#1C1C18", ...RAMP.slice(1)];
+
+export type RecapCardOptions = {
+  handle: string;
+  recap: Recap;
+  theme?: Theme;
+};
+
+export function buildRecapSvg(opts: RecapCardOptions): string {
+  const theme: Theme = opts.theme ?? "light";
+  const auto = theme === "auto";
+  const pal = theme === "dark" ? DARK : LIGHT;
+  const handle = sanitizeHandle(opts.handle);
+  const ramp = theme === "dark" ? darkRamp() : RAMP;
+  const r = opts.recap;
+
+  /* Classes exist only for theme=auto, where the media query needs them. Explicit themes
+     carry presentation attributes and no <style>, so they survive a sanitiser. */
+  const cls = (name: string): Record<string, string> => (auto ? { class: name } : {});
+
+  const parts: string[] = [];
+
+  parts.push(
+    render({
+      tag: "rect",
+      attrs: {
+        ...cls("fr"),
+        x: 1,
+        y: 1,
+        width: W - 2,
+        height: H - 2,
+        fill: pal.frameFill,
+        stroke: pal.frameStroke,
+        "stroke-width": 2,
+      },
+    }),
+  );
+
+  // title
+  parts.push(
+    render({
+      tag: "text",
+      attrs: {
+        ...cls("hd"),
+        x: PAD,
+        y: 44,
+        "font-family": FONT,
+        "font-size": handleSize(handle, 20, INNER - 60),
+        "font-weight": 800,
+        fill: pal.text,
+      },
+      text: `@${handle}`,
+    }),
+  );
+  parts.push(
+    render({
+      tag: "text",
+      attrs: {
+        ...cls("lb"),
+        x: W - PAD,
+        y: 44,
+        "text-anchor": "end",
+        "font-family": FONT,
+        "font-size": 13,
+        "font-weight": 700,
+        fill: pal.label,
+      },
+      text: String(r.year),
+    }),
+  );
+  parts.push(
+    render({
+      tag: "line",
+      attrs: { ...cls("hl"), x1: PAD, y1: 62, x2: W - PAD, y2: 62, stroke: pal.hairline, "stroke-width": 1 },
+    }),
+  );
+
+  // four tiles
+  const tiles: Array<[string, string]> = [
+    ["TOKENS", r.tiles.totalTokens],
+    ["EQUIV. COST", r.tiles.equivCost],
+    ["TOP MODEL", r.tiles.topModel],
+    ["STREAK", r.tiles.longestStreak],
+  ];
+  const tileW = INNER / tiles.length;
+
+  tiles.forEach(([label, value], i) => {
+    const x = PAD + i * tileW;
+    parts.push(
+      render({
+        tag: "text",
+        attrs: { ...cls("lb"), x, y: 88, "font-family": FONT, "font-size": 8, "font-weight": 700, "letter-spacing": 0.8, fill: pal.label },
+        text: label,
+      }),
+    );
+    // The model id is the one value that is text rather than a figure, so it gets a size
+    // that fits its column instead of the display size the numbers use.
+    const isModel = label === "TOP MODEL";
+    const size = isModel ? Math.min(11, (tileW - 8) / (value.length * 0.62)) : 19;
+    parts.push(
+      render({
+        tag: "text",
+        attrs: { ...cls("vl"), x, y: 114, "font-family": FONT, "font-size": size, "font-weight": 800, fill: pal.text },
+        text: value,
+      }),
+    );
+  });
+
+  parts.push(
+    render({
+      tag: "line",
+      attrs: { ...cls("rl"), x1: PAD, y1: 132, x2: W - PAD, y2: 132, stroke: pal.rule, "stroke-width": 1 },
+    }),
+  );
+
+  // hour ruler, every third hour
+  for (let h = 0; h < 24; h += 3) {
+    parts.push(
+      render({
+        tag: "text",
+        attrs: {
+          ...cls("lb"),
+          x: GRID.x + h * GRID.pitch,
+          y: 158,
+          "font-family": FONT,
+          "font-size": 7,
+          fill: pal.label,
+        },
+        text: String(h).padStart(2, "0"),
+      }),
+    );
+  }
+
+  // the peak stretch, drawn behind the grid as one continuous bar
+  if (r.peak) {
+    const from = GRID.x + r.peak.from * GRID.pitch;
+    const width = (r.peak.to - r.peak.from + 1) * GRID.pitch - 1;
+    parts.push(
+      render({
+        tag: "rect",
+        attrs: { x: from, y: GRID.y - 6, width, height: 3, fill: "#FF5C3D" },
+      }),
+    );
+  }
+
+  // heatmap
+  r.rows.forEach((row, ri) => {
+    const y = GRID.y + ri * GRID.rowPitch;
+
+    parts.push(
+      render({
+        tag: "text",
+        attrs: {
+          ...cls(row.busiest ? "vl" : "lb"),
+          x: PAD,
+          y: y + 9,
+          "font-family": FONT,
+          "font-size": 7.5,
+          "font-weight": row.busiest ? 700 : 400,
+          fill: row.busiest ? pal.text : pal.label,
+        },
+        text: row.day,
+      }),
+    );
+
+    row.levels.forEach((level, hi) => {
+      parts.push(
+        render({
+          tag: "rect",
+          attrs: {
+            ...cls(`q${level}`),
+            x: GRID.x + hi * GRID.pitch,
+            y,
+            width: GRID.cell,
+            height: GRID.cell,
+            fill: ramp[level] ?? ramp[0],
+          },
+        }),
+      );
+    });
+
+    // share of the busiest day, as a rule running to the right edge
+    const barX = gridRight + 10;
+    const barMax = W - PAD - barX;
+    parts.push(
+      render({
+        tag: "rect",
+        attrs: {
+          x: barX,
+          y: y + 4,
+          width: Math.max(1, Math.round((barMax * row.share) / 100)),
+          height: 4,
+          fill: row.busiest ? "#FF5C3D" : "#C6FF3D",
+        },
+      }),
+    );
+  });
+
+  // legend
+  const legendY = GRID.y + GRID.rows * GRID.rowPitch + 12;
+  parts.push(
+    render({
+      tag: "text",
+      attrs: { ...cls("lg"), x: PAD, y: legendY + 6, "font-family": FONT, "font-size": 7.5, fill: pal.legend },
+      text: "LESS",
+    }),
+  );
+  ramp.forEach((colour, i) => {
+    parts.push(
+      render({
+        tag: "rect",
+        attrs: { ...cls(`q${i}`), x: PAD + 30 + i * 11, y: legendY, width: 8, height: 8, fill: colour },
+      }),
+    );
+  });
+  parts.push(
+    render({
+      tag: "text",
+      attrs: { ...cls("lg"), x: PAD + 30 + ramp.length * 11 + 4, y: legendY + 6, "font-family": FONT, "font-size": 7.5, fill: pal.legend },
+      text: "MORE",
+    }),
+  );
+  parts.push(
+    render({
+      tag: "text",
+      attrs: {
+        ...cls("lg"),
+        x: W - PAD,
+        y: legendY + 6,
+        "text-anchor": "end",
+        "font-family": FONT,
+        "font-size": 7.5,
+        fill: pal.legend,
+      },
+      text: `${r.activeDays} ACTIVE DAYS`,
+    }),
+  );
+
+  // footer
+  parts.push(
+    render({
+      tag: "text",
+      attrs: { ...cls("ft"), x: PAD, y: H - 14, "font-family": FONT, "font-size": 8, "letter-spacing": 1, fill: pal.footer },
+      text: "TOKENCARD.DEV",
+    }),
+  );
+  parts.push(
+    render({
+      tag: "text",
+      attrs: {
+        ...cls("ft"),
+        x: W - PAD,
+        y: H - 14,
+        "text-anchor": "end",
+        "font-family": FONT,
+        "font-size": 8,
+        "letter-spacing": 1,
+        fill: pal.footer,
+      },
+      text: r.peak ? `PEAK ${pad(r.peak.from)}-${pad(r.peak.to + 1)}` : "NO ACTIVITY",
+    }),
+  );
+
+  const style = auto
+    ? `<style>@media (prefers-color-scheme:dark){` +
+      `.fr{fill:${DARK.frameFill};stroke:${DARK.frameStroke}}` +
+      `.hd,.vl{fill:${DARK.text}}` +
+      `.hl{stroke:${DARK.hairline}}.rl{stroke:${DARK.rule}}` +
+      `.lb{fill:${DARK.label}}.lg{fill:${DARK.legend}}.ft{fill:${DARK.footer}}` +
+      // The coldest ramp step is a near-white that vanishes on a dark ground.
+      `.q0{fill:#1C1C18}}</style>`
+    : "";
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" ` +
+    `role="img" aria-label="${esc(`${handle} token usage recap for ${r.year}`)}">` +
+    style +
+    parts.join("") +
+    `</svg>`
+  );
+}
+
+const pad = (h: number) => String(h).padStart(2, "0");

--- a/packages/core/src/recap.ts
+++ b/packages/core/src/recap.ts
@@ -1,0 +1,148 @@
+import type { Stats } from "./aggregate.js";
+import { formatTokens, formatUsd } from "./format.js";
+
+/** The design's five-step ramp, coldest first. */
+export const RAMP = ["#F5F4EE", "#E7F5BE", "#C6FF3D", "#FFD23D", "#FF5C3D"] as const;
+
+export const WEEKDAYS = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"] as const;
+
+export type RecapRow = {
+  day: string;
+  /** 24 ramp colours, one per hour. */
+  cells: string[];
+  /** 24 ramp levels 0-4 — the same data, for a terminal or a test. */
+  levels: number[];
+  tokens: number;
+  /** This day against the busiest day, 0-100. */
+  share: number;
+  busiest: boolean;
+};
+
+export type Recap = {
+  year: number;
+  tiles: {
+    totalTokens: string;
+    equivCost: string;
+    topModel: string;
+    longestStreak: string;
+  };
+  rows: RecapRow[];
+  /** Inclusive hour range holding the busiest stretch, or null when there is no data. */
+  peak: { from: number; to: number } | null;
+  agents: { agent: string; pct: number; tokens: string; cost: string }[];
+  models: { model: string; tokens: string; cost: string; priced: boolean }[];
+  activeDays: number;
+  tokens: number;
+};
+
+/**
+ * Colour each cell by the rank of its value, not by its magnitude.
+ *
+ * Token counts are violently skewed — a single long session can hold more tokens than a
+ * whole quiet week — so scaling linearly against the busiest cell paints one square hot and
+ * leaves everything else indistinguishable. Ranking across the distinct values is what
+ * GitHub's contribution graph does, it is what people already know how to read, and it
+ * guarantees a legible spread whether someone burns 40M tokens a year or 4B.
+ *
+ * Spreading across *distinct* values rather than quartile thresholds is what makes the
+ * busiest cell always reach the top of the ramp and the quietest active cell always sit at
+ * the bottom. Threshold bucketing put a lone active hour at the palest step, which reads as
+ * "barely used" for what is in fact the only thing that happened.
+ */
+function quantise(cells: number[], scale: number[]): number[] {
+  return cells.map((n) => {
+    if (n <= 0) return 0;
+    const i = scale.indexOf(n);
+    if (scale.length <= 1) return 4; // one intensity, and it is the busiest
+    return 1 + Math.round((3 * i) / (scale.length - 1));
+  });
+}
+
+/** The distinct non-zero cell values, ascending — the ranks the ramp is spread across. */
+function scaleOf(values: number[]): number[] {
+  return [...new Set(values.filter((n) => n > 0))].sort((a, b) => a - b);
+}
+
+/**
+ * Turn aggregated stats into the year-in-review model.
+ *
+ * Day totals come from the raw counts, never the quantised level. Quantising first collapses
+ * several days onto the same figure, which reads as a rendering bug rather than a fact.
+ */
+export function buildRecap(stats: Stats, opts: { year?: number; now?: Date } = {}): Recap {
+  const year = opts.year ?? (opts.now ?? new Date()).getFullYear();
+
+  const maxDay = Math.max(0, ...stats.byWeekday);
+  // One scale across the whole grid, so a cell's colour means the same thing on a Sunday as
+  // it does on a Tuesday.
+  const scale = scaleOf(stats.heat.flat());
+
+  const rows: RecapRow[] = WEEKDAYS.map((day, i) => {
+    const hours = stats.heat[i] ?? Array(24).fill(0);
+    const levels = quantise(hours, scale);
+    const tokens = stats.byWeekday[i] ?? 0;
+
+    return {
+      day,
+      cells: levels.map((l) => RAMP[l] ?? RAMP[0]),
+      levels,
+      tokens,
+      share: maxDay > 0 ? Math.round((tokens / maxDay) * 100) : 0,
+      busiest: tokens > 0 && tokens === maxDay,
+    };
+  });
+
+  const topModel = [...stats.byModel.keys()][0] ?? "—";
+
+  return {
+    year,
+    tiles: {
+      totalTokens: formatTokens(stats.tokens),
+      equivCost: stats.pricedShare > 0 ? formatUsd(stats.equivCostUsd, true) : "—",
+      topModel,
+      longestStreak: `${stats.streakDays}d`,
+    },
+    rows,
+    peak: peakWindow(stats.byHour),
+    agents: stats.mix.map((m) => {
+      const tokens = stats.byAgent.get(m.agent) ?? 0;
+      return {
+        agent: m.agent,
+        pct: m.pct,
+        tokens: formatTokens(tokens),
+        // Per-agent cost is not tracked separately; the models table carries the breakdown.
+        cost: "—",
+      };
+    }),
+    models: stats.models.map((m) => ({
+      model: m.model,
+      tokens: formatTokens(m.tokens),
+      cost: m.priced ? formatUsd(m.equivCostUsd, true) : "—",
+      priced: m.priced,
+    })),
+    activeDays: stats.activeDays,
+    tokens: stats.tokens,
+  };
+}
+
+/**
+ * The contiguous run of hours holding the bulk of the work.
+ *
+ * Widened from the busiest hour outward while each neighbour still clears a third of the
+ * peak, which tracks how a working day actually tails off. A fixed window would be wrong
+ * for anyone who does not keep office hours.
+ */
+function peakWindow(byHour: number[]): { from: number; to: number } | null {
+  const peak = Math.max(0, ...byHour);
+  if (peak <= 0) return null;
+
+  const centre = byHour.indexOf(peak);
+  const floor = peak / 3;
+
+  let from = centre;
+  let to = centre;
+  while (from > 0 && (byHour[from - 1] as number) >= floor) from -= 1;
+  while (to < 23 && (byHour[to + 1] as number) >= floor) to += 1;
+
+  return { from, to };
+}

--- a/packages/core/src/svg.ts
+++ b/packages/core/src/svg.ts
@@ -1,0 +1,64 @@
+/**
+ * Primitives shared by every SVG this package renders.
+ *
+ * Extracted from card-svg.ts unchanged when the recap builder arrived — two builders using
+ * two copies of a palette is how a card and a recap end up subtly different colours.
+ */
+
+export type Palette = {
+  frameFill: string;
+  frameStroke: string;
+  text: string;
+  hairline: string;
+  rule: string;
+  label: string;
+  legend: string;
+  footer: string;
+  segments: [string, string, string, string];
+};
+
+export const LIGHT: Palette = {
+  frameFill: "#FFFFFF",
+  frameStroke: "#101010",
+  text: "#101010",
+  hairline: "#E4E2D8",
+  rule: "#F0EFE9",
+  label: "#A5A59D",
+  legend: "#55554E",
+  footer: "#C0BEB6",
+  segments: ["#C6FF3D", "#101010", "#8A8A82", "#D8D6CE"],
+};
+
+export const DARK: Palette = {
+  frameFill: "#101010",
+  frameStroke: "#2E2E28",
+  text: "#FFFFFF",
+  hairline: "#2E2E28",
+  rule: "#2E2E28",
+  label: "#6E6E66",
+  legend: "#9A9A92",
+  footer: "#55554E",
+  segments: ["#C6FF3D", "#FFFFFF", "#6E6E66", "#3A3A34"],
+};
+
+export const FONT = "'JetBrains Mono', ui-monospace, monospace";
+
+export const esc = (s: string) =>
+  s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+/** One SVG element: a tag, its attributes, and optional text content. */
+export type El = { tag: string; attrs: Record<string, string | number>; text?: string };
+
+/** Serialise an element, escaping both attribute values and text. */
+export const render = (el: El) => {
+  const attrs = Object.entries(el.attrs)
+    .map(([k, v]) => `${k}="${typeof v === "string" ? esc(v) : v}"`)
+    .join(" ");
+  return el.text !== undefined
+    ? `<${el.tag} ${attrs}>${esc(el.text)}</${el.tag}>`
+    : `<${el.tag} ${attrs}/>`;
+};

--- a/packages/core/test/recap.test.js
+++ b/packages/core/test/recap.test.js
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { aggregate, buildRecap, buildRecapSvg, RAMP, WEEKDAYS } from "../dist/index.js";
+
+/** An event at a given local weekday-and-hour. 2026-05-18 is a Monday. */
+const at = (mondayOffset, hour, tokens = 1000) => ({
+  agent: "claude-code",
+  ts: new Date(2026, 4, 18 + mondayOffset, hour, 0, 0),
+  model: "claude-opus-5",
+  input: tokens,
+  output: 0,
+  cacheWrite: 0,
+  cacheRead: 0,
+});
+
+const NOW = new Date(2026, 4, 25, 12, 0, 0);
+
+test("the grid is Monday-first and bucketed by local hour", async () => {
+  const stats = await aggregate([at(0, 9), at(6, 23)], { now: NOW });
+
+  assert.equal(stats.heat[0][9], 1000, "Monday 09:00");
+  assert.equal(stats.heat[6][23], 1000, "Sunday 23:00");
+  assert.equal(stats.byWeekday[0], 1000);
+  assert.equal(stats.byHour[9], 1000);
+  assert.equal(WEEKDAYS[0], "MON");
+});
+
+test("cells are ranked across distinct values, not scaled against the busiest", async () => {
+  // One violently dominant cell plus a spread of smaller ones. A linear scale against the
+  // max would flatten every small cell to level 0 and make the grid unreadable.
+  const events = [at(0, 10, 10_000_000)];
+  for (let h = 0; h < 8; h++) events.push(at(1, h, (h + 1) * 100));
+
+  const recap = buildRecap(await aggregate(events, { now: NOW }), { year: 2026 });
+  const used = new Set(recap.rows.flatMap((r) => r.levels).filter((l) => l > 0));
+
+  assert.ok(used.size >= 3, `expected a spread of levels, saw ${[...used].join(",")}`);
+  assert.equal(Math.max(...used), 4, "the dominant cell still tops the ramp");
+});
+
+test("an empty hour is always level zero", async () => {
+  const recap = buildRecap(await aggregate([at(0, 10)], { now: NOW }), { year: 2026 });
+
+  assert.equal(recap.rows[0].levels[10], 4, "the only active hour is the hottest");
+  assert.equal(recap.rows[0].levels[11], 0);
+  assert.equal(recap.rows[1].levels.every((l) => l === 0), true, "an empty day stays cold");
+});
+
+test("the peak window widens from the busiest hour while neighbours stay substantial", async () => {
+  const events = [
+    ...Array.from({ length: 5 }, () => at(0, 14, 1000)), // 5000 at 14:00
+    ...Array.from({ length: 3 }, () => at(0, 15, 1000)), // 3000 at 15:00 — above a third
+    at(0, 16, 100), // well below a third, so the window stops before it
+    at(0, 3, 2000), // above the one-third floor but not contiguous, so it must stay out
+  ];
+
+  const recap = buildRecap(await aggregate(events, { now: NOW }), { year: 2026 });
+
+  assert.deepEqual(recap.peak, { from: 14, to: 15 });
+});
+
+test("no activity means no peak rather than a bogus one", async () => {
+  const recap = buildRecap(await aggregate([], { now: NOW }), { year: 2026 });
+
+  assert.equal(recap.peak, null);
+  assert.equal(recap.rows.length, 7);
+  assert.equal(recap.rows.every((r) => r.levels.every((l) => l === 0)), true);
+  assert.equal(recap.tiles.equivCost, "—", "no priced tokens means a dash, not $0");
+});
+
+test("exactly one day is marked busiest", async () => {
+  const recap = buildRecap(
+    await aggregate([at(0, 10, 5000), at(1, 10, 1000)], { now: NOW }),
+    { year: 2026 },
+  );
+
+  assert.deepEqual(
+    recap.rows.filter((r) => r.busiest).map((r) => r.day),
+    ["MON"],
+  );
+  assert.equal(recap.rows[1].share, 20, "Tuesday is a fifth of Monday");
+});
+
+test("the recap SVG renders and stays inside its frame", async () => {
+  const recap = buildRecap(await aggregate([at(0, 10), at(3, 16)], { now: NOW }), { year: 2026 });
+  const svg = buildRecapSvg({ handle: "octocat", recap, theme: "light" });
+
+  assert.ok(svg.startsWith("<svg") && svg.endsWith("</svg>"));
+  assert.match(svg, /@octocat/);
+  assert.match(svg, /2026/);
+
+  // Nothing may be drawn past the 495x330 frame.
+  for (const [, x] of svg.matchAll(/\sx="([\d.]+)"/g)) assert.ok(Number(x) <= 495, `x=${x}`);
+  for (const [, y] of svg.matchAll(/\sy="([\d.]+)"/g)) assert.ok(Number(y) <= 330, `y=${y}`);
+});
+
+test("dark recaps swap the coldest ramp step so empty cells are not near-white", async () => {
+  const recap = buildRecap(await aggregate([at(0, 10)], { now: NOW }), { year: 2026 });
+
+  const light = buildRecapSvg({ handle: "octocat", recap, theme: "light" });
+  const dark = buildRecapSvg({ handle: "octocat", recap, theme: "dark" });
+
+  assert.ok(light.includes(RAMP[0]), "light keeps the design's coldest step");
+  assert.ok(!dark.includes(RAMP[0]), "dark must not paint near-white cells");
+  assert.ok(dark.includes("#1C1C18"));
+});


### PR DESCRIPTION
`docs/research.md` §8 asked which of four candidate differentiators to lead with.
Local-commit and honest cost are built. **The recap is the third, and the one
viberank has no equivalent of** — and the site has had a designed section for it
since the handoff, filled entirely with placeholder data.

```
  @iyashjayesh · 2026

  4.36B tokens  ·  $2,877.29 equiv. API cost  ·  claude-opus-5  ·  10d streak

       00    06    12    18
  MON  ▓▓     ░░▓▒░▓▓▒▒█▓▓▒░▒▓▒   71%
  TUE  ▒▒░░  ░░ ░░█████▓▓█▓░      86%
  WED  ░░        ░██▓░████▒░  ░   89%
  THU  ░░         ░▒▒▒▒░▒▒░ ░▓▒   22%
  FRI            ░░▓▒▓▓▓▒██▒▓█▓   69%
  SAT  ██▓        ░▓█░▓▓░▒█▒ ▓▒   78%
  SUN  ███▓░     █▓█▒▓█ ▒▒█▒▒▒▓  100%

  peak 11:00-20:00  ·  37 active days
```

Same thing renders as a second committable SVG at 495 wide, so it stacks with the
card in a README rather than looking orphaned beside it.

## Ranking, not scaling

Cells are coloured by **rank across the distinct values**, the way GitHub's
contribution graph works. Token counts are violently skewed — on real data a
single session held more tokens than a quiet week — and scaling linearly against
the busiest cell produced a grid with one hot square and nothing else legible.

## Two bugs the tests caught

- **Threshold bucketing put a lone active hour at the palest step**, reading as
  "barely used" for the only thing that happened. Spreading across distinct values
  means the busiest cell always tops the ramp and the quietest active one always
  sits at the bottom.
- **Explicit dark recaps painted empty cells in the light ramp's near-white**,
  which is a solid block on a dark ground. Dark swaps the coldest step only; the
  four warm steps carry across unchanged, so two cards stay comparable.

The peak window widens outward from the busiest hour while each neighbour still
clears a third of it, which tracks how a working day tails off. A fixed window
would be wrong for anyone who does not keep office hours.

## Shared primitives

Palette, escaping and element rendering moved to `svg.ts` so both builders use one
copy — two builders with two palettes is how a card and a recap end up subtly
different colours. **Verified byte-identical output across all six card variants**
before and after the move.

## Two dead links dropped

The embed snippet pointed at `tokencard.dev/u/<handle>` and the recap section
promised a page at `/u/<handle>/2026`. Neither route exists, so the markdown people
copy off the page linked to a 404. Building them would mean hosting the per-user
surface the committed-SVG design exists to avoid, so the snippet is now a plain
image.

## Verification

27 tests pass, up from 19. Both themes rendered and inspected. A test asserts
nothing is drawn outside the 495×330 frame, since a recap that overflows its own
card is the failure mode a unit test would otherwise miss.

**Known coarseness:** Codex only records a running total per session, so its hours
land on the session's last turn. Claude Code and OpenCode are exact to the message.
This is called out in the README rather than papered over.
