### PR TITLE
Point the site's embed snippets at the Vercel URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ to match.
 ## Repo layout
 
 ```
-apps/site/          Next.js marketing site (tokencard.dev)
+apps/site/          Next.js marketing site + the board API
 packages/core/      adapters, aggregation, price table, SVG builder
 packages/cli/       the tokencard binary
 docs/research.md    positioning, competitive landscape, infrastructure decisions

--- a/apps/site/components/card-section.tsx
+++ b/apps/site/components/card-section.tsx
@@ -5,6 +5,7 @@ import { SectionHeading } from "@/components/section-heading";
 import { useSiteState } from "@/components/site-state";
 import { buildCardSvg } from "@tokencard/core";
 import { DEFAULT_HANDLE, OWN_STATS, QUERY_OPTIONS } from "@/lib/sample-data";
+import { SITE_URL } from "@/lib/site";
 import styles from "./card-section.module.css";
 
 /* The three variant cards are fixed artefacts of the sample handle, not the live one —
@@ -19,7 +20,7 @@ export function CardSection() {
 
   // A plain image, not a link. There is no per-user page to point at, and inventing one
   // would mean hosting exactly the surface the committed-SVG design exists to avoid.
-  const markdown = `![tokencard](https://tokencard.dev/api/card/${handle}.svg)`;
+  const markdown = `![tokencard](${SITE_URL}/api/card/${handle}.svg)`;
 
   /* The panel shows the origin elided so the two tags fit without scrolling; the
      clipboard gets the full URLs, which is what a README actually needs. */
@@ -27,8 +28,8 @@ export function CardSection() {
     `<img height="195" src="…/card/${handle}.svg">\n` +
     `<img height="195" src="…/card/${handle}.svg?layout=compact">`;
   const htmlCopied =
-    `<img height="195" src="https://tokencard.dev/api/card/${handle}.svg">\n` +
-    `<img height="195" src="https://tokencard.dev/api/card/${handle}.svg?layout=compact">`;
+    `<img height="195" src="${SITE_URL}/api/card/${handle}.svg">\n` +
+    `<img height="195" src="${SITE_URL}/api/card/${handle}.svg?layout=compact">`;
 
   return (
     <section id="card" className={styles.section}>

--- a/apps/site/lib/site.ts
+++ b/apps/site/lib/site.ts
@@ -1,0 +1,13 @@
+/**
+ * The site's own public origin, used wherever the page hands someone a URL to copy.
+ *
+ * One constant because these strings end up in other people's READMEs: a stale one there is
+ * a broken image on a repo we do not control and cannot fix. When tokencard.dev is attached,
+ * change it here and in packages/cli/src/api.ts — those two are the only places that must be
+ * true rather than aspirational.
+ *
+ * The `TOKENCARD.DEV` wordmark printed on the card itself is deliberately not driven by this.
+ * It is a signature at 8px, not a link, and "TOKENCARD-SITE.VERCEL.APP" would neither fit the
+ * design nor read as a brand.
+ */
+export const SITE_URL = "https://tokencard-site.vercel.app";


### PR DESCRIPTION
The markdown and HTML snippets in section 01 are **copy-paste targets** — the string
someone lifts off that page lands in their own README. `tokencard.dev` does not
resolve, so anyone who copied one got a broken image in a repo we don't control
and can't fix.

```
before  ![tokencard](https://tokencard.dev/api/card/dlacey.svg)
after   ![tokencard](https://tokencard-site.vercel.app/api/card/dlacey.svg)
```

The origin now lives in one constant (`apps/site/lib/site.ts`) alongside the CLI's
(`packages/cli/src/api.ts`). Attaching the domain later is two one-line changes
rather than a search across the repo.

## Left alone deliberately

The **`TOKENCARD.DEV` wordmark** printed on the card and the recap. It is a
signature at 8px, not a link — `TOKENCARD-SITE.VERCEL.APP` would neither fit the
design nor read as a brand, and it would need reverting the day the domain lands.

## Checked

The new URL is 17 characters longer, so I rendered the page to confirm the
markdown snippet still fits its box without overflowing. It does. 35 tests pass.
