### PR TITLE
Put the board on real data

### DIFF
--- a/apps/site/app/api/submissions/route.ts
+++ b/apps/site/app/api/submissions/route.ts
@@ -3,7 +3,9 @@ import { NextResponse } from "next/server";
 import { validatePayload, type Payload } from "@tokencard/core";
 
 import { userFromRequest } from "@/lib/auth";
-import { pool, transaction } from "@/lib/db";
+import { DEFAULT_WINDOW, isWindow } from "@/lib/board";
+import { readBoard } from "@/lib/board-query";
+import { transaction } from "@/lib/db";
 
 export const dynamic = "force-dynamic";
 
@@ -83,10 +85,21 @@ export async function POST(req: Request) {
       await client.query("DELETE FROM user_days WHERE user_id = $1", [user.id]);
       if (payload.days.length > 0) {
         await client.query(
-          `INSERT INTO user_days (user_id, day, tokens)
-           SELECT $1, d.day::date, d.tokens::bigint
-           FROM jsonb_to_recordset($2::jsonb) AS d(day text, tokens bigint)`,
-          [user.id, JSON.stringify(payload.days)],
+          `INSERT INTO user_days (user_id, day, agent, tokens, cost_usd)
+           SELECT $1, d.day::date, d.agent, d.tokens::bigint, d.cost::numeric
+           FROM jsonb_to_recordset($2::jsonb)
+                AS d(day text, agent text, tokens bigint, cost numeric)`,
+          [
+            user.id,
+            JSON.stringify(
+              payload.days.map((d) => ({
+                day: d.day,
+                agent: d.agent,
+                tokens: d.tokens,
+                cost: d.equivCostUsd,
+              })),
+            ),
+          ],
         );
       }
 
@@ -111,36 +124,17 @@ export async function POST(req: Request) {
 }
 
 /**
- * The board, as far as it goes in this change: enough to prove the write path end to end.
- * `window` sums the daily series rather than reading a stored aggregate, which is why
- * user_days exists.
+ * The board. The query itself lives in lib/board-query.ts because the server-rendered page
+ * runs the same one — see the note there on why the page does not fetch this endpoint.
  */
 export async function GET(req: Request) {
   const url = new URL(req.url);
-  const days = Math.min(3650, Math.max(1, Number(url.searchParams.get("days") ?? 365)));
-  const limit = Math.min(100, Math.max(1, Number(url.searchParams.get("limit") ?? 20)));
+  const requested = url.searchParams.get("window");
+  const window = isWindow(requested) ? requested : DEFAULT_WINDOW;
+  const limit = Math.min(100, Math.max(1, Number(url.searchParams.get("limit") ?? 25)));
 
   try {
-    const { rows } = await pool.query(
-      `SELECT u.handle, u.tier, SUM(d.tokens)::bigint AS tokens
-       FROM users u
-       JOIN user_days d ON d.user_id = u.id
-       WHERE d.day >= (CURRENT_DATE - $1::int)
-       GROUP BY u.handle, u.tier
-       ORDER BY tokens DESC
-       LIMIT $2`,
-      [days, limit],
-    );
-
-    return NextResponse.json({
-      window: `${days}d`,
-      rows: rows.map((r, i) => ({
-        rank: i + 1,
-        handle: r.handle,
-        tier: r.tier,
-        tokens: Number(r.tokens),
-      })),
-    });
+    return NextResponse.json({ window, rows: await readBoard(window, limit) });
   } catch (err) {
     console.error("board query failed", err);
     return NextResponse.json({ error: "could not read board" }, { status: 500 });

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -3,6 +3,8 @@ import { SiteHeader } from "@/components/site-header";
 import { Hero } from "@/components/hero";
 import { CardSection } from "@/components/card-section";
 import { Leaderboard } from "@/components/leaderboard";
+import { DEFAULT_WINDOW } from "@/lib/board";
+import { readBoard } from "@/lib/board-query";
 import { Verification } from "@/components/verification";
 import { Privacy } from "@/components/privacy";
 import { Recap } from "@/components/recap";
@@ -14,13 +16,23 @@ import { SiteFooter } from "@/components/site-footer";
  * remain RSC and ship no JavaScript. Only the header, hero, card section and board
  * are client components.
  */
-export default function Page() {
+/**
+ * Revalidated rather than rendered per request. The board is the only live part of the page
+ * and the copy promises a row goes stale "within the hour", so five minutes is comfortably
+ * inside what was advertised while keeping the marketing page effectively static.
+ */
+export const revalidate = 300;
+
+export default async function Page() {
+  // Failing to read the board should cost the reader the table, not the whole page.
+  const rows = await readBoard(DEFAULT_WINDOW).catch(() => []);
+
   return (
     <SiteStateProvider>
       <SiteHeader />
       <Hero />
       <CardSection />
-      <Leaderboard />
+      <Leaderboard initialRows={rows} initialWindow={DEFAULT_WINDOW} />
       <Verification />
       <Privacy />
       <Recap />

--- a/apps/site/components/leaderboard.module.css
+++ b/apps/site/components/leaderboard.module.css
@@ -155,6 +155,38 @@
   font-weight: 800;
 }
 
+/* Self-reported. Deliberately quieter than .verified — no lime, no tick — so the two are
+   never mistaken for each other at a glance, which is the one thing this board must not do. */
+.unverified {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 16px;
+  padding: 0 4px;
+  flex: none;
+  background: var(--surface-alt);
+  border: 1.5px solid var(--card-footer);
+  color: var(--text-dim);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.empty {
+  margin: 0 0 24px;
+  padding: 28px 24px;
+  border: 2px dashed var(--hairline);
+  font-size: 13px;
+  line-height: 1.75;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.strong {
+  color: var(--ink);
+  font-weight: 700;
+}
+
 .bar {
   display: flex;
   height: 12px;

--- a/apps/site/components/leaderboard.tsx
+++ b/apps/site/components/leaderboard.tsx
@@ -1,21 +1,62 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
 import { SectionHeading } from "@/components/section-heading";
 import { useSiteState } from "@/components/site-state";
-import { BOARD_ROWS, MEDALS, WINDOWS, type Window } from "@/lib/sample-data";
+import { formatTokens, formatUsd } from "@tokencard/core";
+import type { BoardRow } from "@/lib/board";
+import { WINDOWS, type BoardWindow } from "@/lib/board";
 import styles from "./leaderboard.module.css";
 
+/** Gold, silver, bronze. Only the top three; everyone else takes the default fill. */
+const MEDALS = ["#FFD23D", "#E4E2D8", "#F0B37E"] as const;
+
+/** The three segment classes, in the order the mix is drawn. */
+const SEGMENTS = [styles.seg0, styles.seg1, styles.seg2] as const;
+
 /**
- * Section 02 — the public opt-in board.
+ * Section 02 — the public opt-in board, on real data.
  *
- * The window filter is cosmetic: it selects a label, not a query. It stays local
- * state because nothing outside this section reads it; the signed-in handle, which
- * decides which row is tinted, comes from site state so the hero input drives it live.
+ * The window buttons are a real query now, not a label. Every column in a row is summed over
+ * the same window, which is why `user_days` carries an agent and a cost: a row whose tokens
+ * covered a week while its cost covered a year reads as one figure and gets quoted as one.
+ *
+ * Rows are handed in from the server so the table is populated on first paint; changing the
+ * window refetches on the client and keeps the old rows on screen while it does, because a
+ * table that empties and refills makes the whole page jump.
  */
-export function Leaderboard() {
+export function Leaderboard({ initialRows, initialWindow }: {
+  initialRows: BoardRow[];
+  initialWindow: BoardWindow;
+}) {
   const { handle } = useSiteState();
-  const [activeWindow, setActiveWindow] = useState<Window>("this year");
+  const [activeWindow, setActiveWindow] = useState<BoardWindow>(initialWindow);
+  const [rows, setRows] = useState<BoardRow[]>(initialRows);
+  const [stale, setStale] = useState(false);
+
+  useEffect(() => {
+    if (activeWindow === initialWindow) return;
+
+    let cancelled = false;
+    setStale(true);
+
+    fetch(`/api/submissions?window=${activeWindow}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(String(res.status)))))
+      .then((data: { rows: BoardRow[] }) => {
+        if (!cancelled) setRows(data.rows);
+      })
+      // A board that fails to load should leave the previous window on screen rather than
+      // replace real figures with an error. The dimming stops, so it stops looking pending.
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setStale(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeWindow, initialWindow]);
 
   return (
     <section id="board" className={styles.section}>
@@ -24,75 +65,104 @@ export function Leaderboard() {
       </SectionHeading>
 
       <p className={styles.intro}>
-        Public ranking of signed-in developers who chose to publish. Sign in with GitHub,
-        flip one switch, and you are on it. Leave and your row disappears within the hour.
+        Public ranking of developers who chose to publish. Run{" "}
+        <span className={styles.strong}>tokencard publish</span> and you are on it. Stop
+        publishing and your row goes stale, then falls out of the window on its own.
       </p>
 
       <div className={styles.filters}>
         {WINDOWS.map((w) => (
           <button
-            key={w}
+            key={w.key}
             type="button"
-            onClick={() => setActiveWindow(w)}
-            className={w === activeWindow ? styles.filterActive : styles.filter}
+            onClick={() => setActiveWindow(w.key)}
+            className={w.key === activeWindow ? styles.filterActive : styles.filter}
           >
-            {w}
+            {w.label}
           </button>
         ))}
       </div>
 
-      <div className={styles.tableWrap}>
-        <table className={styles.table}>
-          <thead>
-            <tr className={styles.head}>
-              <th className={styles.wRank}>rank</th>
-              <th>developer</th>
-              <th className={styles.wMix}>agent mix</th>
-              <th className={`${styles.wTokens} ${styles.num}`}>tokens</th>
-              <th className={`${styles.wSpend} ${styles.num}`}>equiv. cost</th>
-              <th className={`${styles.wStreak} ${styles.num}`}>streak</th>
-            </tr>
-          </thead>
-          <tbody>
-            {BOARD_ROWS.map((r, i) => {
-              const own = r.user === handle;
-              // Medals outrank the own-row lime; both outrank the default white fill.
-              const medalBg = i < 3 ? MEDALS[i] : own ? "var(--lime)" : "var(--surface)";
-              return (
-                <tr key={r.user} className={own ? styles.rowOwn : styles.row}>
-                  <td>
-                    <span className={styles.rank} style={{ background: medalBg }}>
-                      {i + 1}
-                    </span>
-                  </td>
-                  <td>
-                    <div className={styles.dev}>
-                      <span className={styles.handle}>@{r.user}</span>
-                      <span className={styles.verified} title="GitHub identity verified">
-                        ✓
+      {rows.length === 0 ? (
+        <p className={styles.empty}>
+          Nobody has published in this window yet.{" "}
+          <span className={styles.strong}>npx @tokencard/cli publish</span> and the board is
+          yours.
+        </p>
+      ) : (
+        <div className={styles.tableWrap} style={stale ? { opacity: 0.55 } : undefined}>
+          <table className={styles.table}>
+            <thead>
+              <tr className={styles.head}>
+                <th className={styles.wRank}>rank</th>
+                <th>developer</th>
+                <th className={styles.wMix}>agent mix</th>
+                <th className={`${styles.wTokens} ${styles.num}`}>tokens</th>
+                <th className={`${styles.wSpend} ${styles.num}`}>equiv. cost</th>
+                <th className={`${styles.wStreak} ${styles.num}`}>streak</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, i) => {
+                const own = r.handle.toLowerCase() === handle.toLowerCase();
+                // Medals outrank the own-row lime; both outrank the default white fill.
+                const medalBg = i < 3 ? MEDALS[i] : own ? "var(--lime)" : "var(--surface)";
+                // Largest agent first, so the bar reads consistently row to row.
+                const mix = Object.entries(r.mix).sort((a, b) => b[1] - a[1]);
+
+                return (
+                  <tr key={r.handle} className={own ? styles.rowOwn : styles.row}>
+                    <td>
+                      <span className={styles.rank} style={{ background: medalBg }}>
+                        {r.rank}
                       </span>
-                    </div>
-                  </td>
-                  <td>
-                    <div className={styles.bar}>
-                      <span className={styles.seg0} style={{ flex: r.mix[0] }} />
-                      <span className={styles.seg1} style={{ flex: r.mix[1] }} />
-                      <span className={styles.seg2} style={{ flex: r.mix[2] }} />
-                    </div>
-                  </td>
-                  <td className={`${styles.num} ${styles.tokens}`}>{r.tokens}</td>
-                  <td className={styles.num}>{r.spend}</td>
-                  <td className={`${styles.num} ${styles.streak}`}>{r.streak}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
+                    </td>
+                    <td>
+                      <div className={styles.dev}>
+                        <span className={styles.handle}>@{r.handle}</span>
+                        {/* Tier-driven. Marking an unverified row with the same tick as a
+                            verified one is the single thing this board must never do. */}
+                        {r.tier === "verified" ? (
+                          <span className={styles.verified} title="GitHub identity verified">
+                            ✓
+                          </span>
+                        ) : (
+                          <span className={styles.unverified} title="Self-reported; the handle is unproven">
+                            cli
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td>
+                      <div className={styles.bar}>
+                        {mix.map(([agent, tokens], si) => (
+                          <span
+                            key={agent}
+                            className={SEGMENTS[Math.min(si, SEGMENTS.length - 1)]}
+                            style={{ flex: tokens }}
+                            title={`${agent} · ${formatTokens(tokens)}`}
+                          />
+                        ))}
+                      </div>
+                    </td>
+                    <td className={`${styles.num} ${styles.tokens}`}>
+                      {formatTokens(r.tokens)}
+                    </td>
+                    <td className={styles.num}>{formatUsd(r.equivCostUsd)}</td>
+                    <td className={`${styles.num} ${styles.streak}`}>{r.streakDays}d</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
 
       <p className={styles.foot}>
-        Rank is total tokens over the selected window. It is a usage count, not a skill
-        score. Every listed developer has a verified GitHub identity.
+        Rank is total tokens over the selected window; cost and agent mix cover the same
+        window. Streak is the current run of active days, which is not a windowed figure. A{" "}
+        <span className={styles.strong}>cli</span> badge means the numbers were self-reported
+        without a GitHub sign-in.
       </p>
     </section>
   );

--- a/apps/site/db/migrations/004_day_agent.sql
+++ b/apps/site/db/migrations/004_day_agent.sql
@@ -1,0 +1,26 @@
+-- Split the daily series by agent, and carry cost alongside tokens.
+--
+-- The board has four window filters. Before this, only tokens could be windowed: cost and
+-- agent mix were lifetime totals on the submission, so "last 7d" would have shown a week of
+-- tokens beside a year of spend in the same row. Now every column windows on the same range.
+--
+-- Dropped rather than migrated because user_days is derived data — every submission replaces
+-- it in full, so the next publish rebuilds it.
+DROP TABLE IF EXISTS user_days;
+
+CREATE TABLE user_days (
+  user_id  bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  day      date   NOT NULL,
+  agent    text   NOT NULL,
+  tokens   bigint NOT NULL CHECK (tokens >= 0),
+  -- Four decimals, not two: one agent-day is often fractions of a cent, and rounding each
+  -- row to cents would drift the summed total away from the headline figure.
+  cost_usd numeric(12,4) NOT NULL CHECK (cost_usd >= 0),
+  PRIMARY KEY (user_id, day, agent)
+);
+
+CREATE INDEX user_days_day ON user_days (day);
+
+-- Same reasoning as 003: Supabase exposes public tables through PostgREST with the anon key,
+-- and a new table starts with RLS off.
+ALTER TABLE user_days ENABLE ROW LEVEL SECURITY;

--- a/apps/site/lib/board-query.ts
+++ b/apps/site/lib/board-query.ts
@@ -1,0 +1,66 @@
+import "server-only";
+
+import { pool } from "@/lib/db";
+import { WINDOW_DAYS, type BoardRow, type BoardWindow } from "@/lib/board";
+
+/**
+ * Read the board for one window.
+ *
+ * Shared by the route handler and the server-rendered page rather than having the page fetch
+ * its own API over HTTP: a self-request would be a needless round trip, and in development it
+ * would have to name an origin, which means either hardcoding localhost or accidentally
+ * reading production.
+ *
+ * Every column is summed over the same window. That is the entire reason `user_days` carries
+ * an agent and a cost — a row whose tokens covered a week while its cost covered a year reads
+ * as one figure and gets quoted as one.
+ *
+ * Streak is the exception and is deliberately not windowed: it is a current-streak count, and
+ * "your streak, but only counting last week" is not something anyone means.
+ */
+export async function readBoard(window: BoardWindow, limit = 25): Promise<BoardRow[]> {
+  const { rows } = await pool.query(
+    `WITH windowed AS (
+       SELECT d.user_id, d.agent,
+              SUM(d.tokens)   AS tokens,
+              SUM(d.cost_usd) AS cost
+       FROM user_days d
+       WHERE d.day >= CURRENT_DATE - $1::int
+       GROUP BY d.user_id, d.agent
+     ),
+     totals AS (
+       SELECT user_id,
+              SUM(tokens) AS tokens,
+              SUM(cost)   AS cost,
+              jsonb_object_agg(agent, tokens) AS mix
+       FROM windowed
+       GROUP BY user_id
+     ),
+     latest AS (
+       SELECT DISTINCT ON (user_id) user_id, streak_days, flagged
+       FROM submissions
+       ORDER BY user_id, received_at DESC
+     )
+     SELECT u.handle, u.tier, t.tokens, t.cost, t.mix,
+            COALESCE(l.streak_days, 0) AS streak_days
+     FROM totals t
+     JOIN users u ON u.id = t.user_id
+     LEFT JOIN latest l ON l.user_id = t.user_id
+     WHERE COALESCE(l.flagged, false) = false
+     ORDER BY t.tokens DESC
+     LIMIT $2`,
+    [WINDOW_DAYS[window], limit],
+  );
+
+  return rows.map((r, i) => ({
+    rank: i + 1,
+    handle: r.handle,
+    tier: r.tier,
+    tokens: Number(r.tokens),
+    equivCostUsd: Number(r.cost),
+    streakDays: Number(r.streak_days),
+    mix: Object.fromEntries(
+      Object.entries(r.mix as Record<string, string>).map(([a, n]) => [a, Number(n)]),
+    ),
+  }));
+}

--- a/apps/site/lib/board.ts
+++ b/apps/site/lib/board.ts
@@ -1,0 +1,39 @@
+/**
+ * Board types and window definitions.
+ *
+ * Deliberately free of any database import so the client component can share these with the
+ * route handler — importing the pool here would drag `pg` into the browser bundle, which is
+ * the same mistake that broke the first Vercel build.
+ */
+export type BoardRow = {
+  rank: number;
+  handle: string;
+  tier: string;
+  tokens: number;
+  equivCostUsd: number;
+  streakDays: number;
+  /** Agent id to tokens, over the same window as the rest of the row. */
+  mix: Record<string, number>;
+};
+
+export const WINDOWS = [
+  { key: "year", label: "this year" },
+  { key: "30d", label: "last 30d" },
+  { key: "7d", label: "last 7d" },
+  { key: "all", label: "all time" },
+] as const;
+
+export type BoardWindow = (typeof WINDOWS)[number]["key"];
+
+export const DEFAULT_WINDOW: BoardWindow = "year";
+
+/** How many days each window covers. `all` is a decade, which outlives the project. */
+export const WINDOW_DAYS: Record<BoardWindow, number> = {
+  "7d": 7,
+  "30d": 30,
+  year: 365,
+  all: 3650,
+};
+
+export const isWindow = (value: string | null): value is BoardWindow =>
+  value !== null && value in WINDOW_DAYS;

--- a/apps/site/lib/sample-data.ts
+++ b/apps/site/lib/sample-data.ts
@@ -13,31 +13,6 @@ export const DEFAULT_HANDLE = "dlacey";
 export const RAMP = ["#F5F4EE", "#E7F5BE", "#C6FF3D", "#FFD23D", "#FF5C3D"] as const;
 
 /** Rank 1–3 medal fills. */
-export const MEDALS = ["#FFD23D", "#E4E2D8", "#F0B37E"] as const;
-
-export const WINDOWS = ["this year", "last 30d", "last 7d", "all time"] as const;
-export type Window = (typeof WINDOWS)[number];
-
-export type BoardRow = {
-  user: string;
-  tokens: string;
-  spend: string;
-  streak: string;
-  /** Agent-mix percentages, in claude-code / codex / opencode order. */
-  mix: [number, number, number];
-};
-
-export const BOARD_ROWS: BoardRow[] = [
-  { user: "mirak",    tokens: "8.91B", spend: "$2,740", streak: "211d", mix: [64, 18, 18] },
-  { user: "p-han",    tokens: "7.32B", spend: "$2,118", streak: "96d",  mix: [41, 34, 25] },
-  { user: "sunnyv",   tokens: "6.05B", spend: "$1,802", streak: "154d", mix: [72, 9, 19] },
-  { user: "dlacey",   tokens: "4.24B", spend: "$1,284", streak: "63d",  mix: [58, 21, 21] },
-  { user: "ottoline", tokens: "3.88B", spend: "$1,090", streak: "41d",  mix: [30, 44, 26] },
-  { user: "kmerrit",  tokens: "3.10B", spend: "$946",   streak: "88d",  mix: [55, 20, 25] },
-  { user: "bex_c",    tokens: "2.47B", spend: "$714",   streak: "129d", mix: [48, 12, 40] },
-  { user: "nlundq",   tokens: "1.96B", spend: "$538",   streak: "22d",  mix: [22, 51, 27] },
-];
-
 export const QUERY_OPTIONS = [
   { key: "layout", def: "default", note: "default (495px) or compact (340px)" },
   { key: "theme",  def: "auto",    note: "auto follows GitHub dark mode; force light or dark" },

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -15,7 +15,8 @@
     "next": "16.3.4",
     "pg": "^8.23.0",
     "react": "19.2.8",
-    "react-dom": "19.2.8"
+    "react-dom": "19.2.8",
+    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "next": "16.3.4",
         "pg": "^8.23.0",
         "react": "19.2.8",
-        "react-dom": "19.2.8"
+        "react-dom": "19.2.8",
+        "server-only": "^0.0.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -5377,6 +5378,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/packages/core/src/aggregate.ts
+++ b/packages/core/src/aggregate.ts
@@ -17,6 +17,14 @@ export type Stats = {
   /** Local `YYYY-MM-DD` to tokens, ascending. */
   byDay: Map<string, number>;
   byModel: Map<string, number>;
+  /**
+   * Local day -> agent -> that agent's usage on that day.
+   *
+   * Exists so the board's window filters can be honest. Windowing tokens from a per-day
+   * series while cost and agent mix come from lifetime totals would put a week of tokens
+   * beside a year of spend in the same row.
+   */
+  dayAgent: Map<string, Map<AgentId, { tokens: number; equivCostUsd: number }>>;
   /** Tokens per hour of the local day, 0-23. */
   byHour: number[];
   /** Tokens per weekday, Monday first. */
@@ -60,6 +68,7 @@ export async function aggregate(
 
   const byDay = new Map<string, number>();
   const byModel = new Map<string, number>();
+  const dayAgent = new Map<string, Map<AgentId, { tokens: number; equivCostUsd: number }>>();
   const byHour: number[] = Array(24).fill(0);
   const byWeekday: number[] = Array(7).fill(0);
   const heat: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0));
@@ -91,6 +100,17 @@ export async function aggregate(
 
     const day = localDay(e.ts);
     byDay.set(day, (byDay.get(day) ?? 0) + n);
+
+    let agents = dayAgent.get(day);
+    if (!agents) {
+      agents = new Map();
+      dayAgent.set(day, agents);
+    }
+    const cell = agents.get(e.agent) ?? { tokens: 0, equivCostUsd: 0 };
+    cell.tokens += n;
+    // An unpriced model contributes tokens and no cost, exactly as it does in the headline.
+    cell.equivCostUsd += cost ?? 0;
+    agents.set(e.agent, cell);
 
     // Monday-first, because a week of work reads Mon-Sun; JS counts from Sunday.
     const wd = (e.ts.getDay() + 6) % 7;
@@ -128,6 +148,7 @@ export async function aggregate(
     firstDay: days[0] ?? null,
     lastDay: days[days.length - 1] ?? null,
     byDay: new Map(days.map((d) => [d, byDay.get(d) as number])),
+    dayAgent: new Map(days.map((d) => [d, dayAgent.get(d) as Map<AgentId, { tokens: number; equivCostUsd: number }>])),
     byModel: new Map([...byModel].sort((a, b) => b[1] - a[1])),
     byHour,
     byWeekday,

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -1,5 +1,6 @@
 import type { Stats } from "./aggregate.js";
 import { sanitizeHandle } from "./card-svg.js";
+import type { AgentId } from "./types.js";
 
 /**
  * What leaves the machine, and nothing else.
@@ -23,7 +24,14 @@ export type Payload = {
   lastDay: string;
   agents: { agent: string; tokens: number }[];
   models: { model: string; tokens: number; equivCostUsd: number; priced: boolean }[];
-  days: { day: string; tokens: number }[];
+  /**
+   * One row per day per agent, carrying both tokens and cost.
+   *
+   * Split this finely so the board can window every column on the same range. A lifetime
+   * cost total beside a seven-day token total is the kind of mismatch people misread and
+   * then quote at each other.
+   */
+  days: { day: string; agent: AgentId; tokens: number; equivCostUsd: number }[];
   clientVersion: string;
 };
 
@@ -55,7 +63,14 @@ export function buildPayload(
       equivCostUsd: round(m.equivCostUsd, 2),
       priced: m.priced,
     })),
-    days: [...stats.byDay.entries()].map(([day, tokens]) => ({ day, tokens })),
+    days: [...stats.dayAgent.entries()].flatMap(([day, agents]) =>
+      [...agents.entries()].map(([agent, cell]) => ({
+        day,
+        agent,
+        tokens: cell.tokens,
+        equivCostUsd: round(cell.equivCostUsd, 4),
+      })),
+    ),
     clientVersion: opts.clientVersion,
   };
 }

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -75,7 +75,13 @@ export function validatePayload(p: Payload, now: Date = new Date()): string[] {
   const cutoff = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
   const cutoffDay = cutoff.toISOString().slice(0, 10);
 
+  // Days arrive split by agent, so a day's ceiling has to be checked against the day as a
+  // whole. Comparing each agent row on its own would let three agents each sit just under
+  // the limit while the day together sits far above it.
+  const perDay = new Map<string, number>();
   let daySum = 0;
+  let dayCost = 0;
+
   for (const d of p.days) {
     if (!DATE.test(d.day)) {
       fail(`day "${d.day}" must be YYYY-MM-DD`);
@@ -83,16 +89,39 @@ export function validatePayload(p: Payload, now: Date = new Date()): string[] {
     }
     if (d.day > cutoffDay) fail(`day ${d.day} is in the future (past ${cutoffDay})`);
     if (!Number.isFinite(d.tokens) || d.tokens < 0) fail(`day ${d.day} has negative tokens`);
-    if (d.tokens > LIMITS.maxTokensPerDay) {
-      fail(`day ${d.day} reports ${d.tokens} tokens, over the ${LIMITS.maxTokensPerDay} daily ceiling`);
+    if (!Number.isFinite(d.equivCostUsd) || d.equivCostUsd < 0) {
+      fail(`day ${d.day} has negative cost`);
     }
+    if (!d.agent) fail(`day ${d.day} has no agent`);
+
+    perDay.set(d.day, (perDay.get(d.day) ?? 0) + d.tokens);
     daySum += d.tokens;
+    dayCost += d.equivCostUsd;
+  }
+
+  for (const [day, tokens] of perDay) {
+    if (tokens > LIMITS.maxTokensPerDay) {
+      fail(`day ${day} reports ${tokens} tokens, over the ${LIMITS.maxTokensPerDay} daily ceiling`);
+    }
   }
 
   // The daily series is what the board actually sums, so a headline that disagrees with it
   // would put one number on the card and a different one on the board.
   if (p.days.length > 0 && daySum !== p.tokens) {
     fail(`daily tokens sum to ${daySum} but the total says ${p.tokens}`);
+  }
+
+  // Cost is compared with a tolerance rather than exactly: rows carry four decimals and the
+  // headline two, so a long series accumulates cents of rounding that are not a discrepancy.
+  // The bound stays far tighter than any fabrication would be.
+  if (p.days.length > 0) {
+    const tolerance = 0.01 + p.days.length * 0.0001;
+    if (Math.abs(dayCost - p.equivCostUsd) > tolerance) {
+      fail(
+        `daily costs sum to ${dayCost.toFixed(4)} but the total says ${p.equivCostUsd} ` +
+          `(tolerance ${tolerance.toFixed(4)})`,
+      );
+    }
   }
 
   if (p.equivCostUsd > LIMITS.maxCostTotal) {

--- a/packages/core/test/dayagent.test.js
+++ b/packages/core/test/dayagent.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { aggregate, buildPayload, validatePayload } from "../dist/index.js";
+
+const at = (agent, day, tokens, model = "claude-opus-5") => ({
+  agent,
+  ts: new Date(2026, 4, day, 12, 0, 0),
+  model,
+  input: tokens,
+  output: 0,
+  cacheWrite: 0,
+  cacheRead: 0,
+});
+
+const NOW = new Date(2026, 4, 25, 12, 0, 0);
+const payloadOf = async (events) =>
+  buildPayload(await aggregate(events, { now: NOW }), {
+    handle: "octocat",
+    clientVersion: "test",
+  });
+
+test("days are split by agent, carrying tokens and cost", async () => {
+  const p = await payloadOf([at("claude-code", 20, 1000), at("codex", 20, 500)]);
+
+  assert.equal(p.days.length, 2, "one row per agent per day");
+  assert.deepEqual(
+    p.days.map((d) => [d.day, d.agent, d.tokens]).sort(),
+    [
+      ["2026-05-20", "claude-code", 1000],
+      ["2026-05-20", "codex", 500],
+    ],
+  );
+  for (const d of p.days) assert.ok(d.equivCostUsd > 0, `${d.agent} has no cost`);
+});
+
+test("day rows reconcile with the headline", async () => {
+  const p = await payloadOf([
+    at("claude-code", 20, 1000),
+    at("codex", 20, 500),
+    at("opencode", 21, 250),
+  ]);
+
+  assert.equal(
+    p.days.reduce((a, d) => a + d.tokens, 0),
+    p.tokens,
+  );
+  assert.deepEqual(validatePayload(p, NOW), []);
+});
+
+test("the daily ceiling is checked per day, not per agent row", async () => {
+  // Three agents at 100M each: every row is comfortably under the 2B ceiling on its own,
+  // but this is what a day summing over the limit has to be caught by.
+  const over = Math.floor(2_000_000_000 / 2);
+  const p = await payloadOf([
+    at("claude-code", 20, over),
+    at("codex", 20, over),
+    at("opencode", 20, over),
+  ]);
+
+  const errors = validatePayload(p, NOW);
+  assert.ok(
+    errors.some((e) => e.includes("daily ceiling")),
+    `expected a daily-ceiling rejection, got ${JSON.stringify(errors)}`,
+  );
+});
+
+test("a cost that disagrees with its day rows is rejected", async () => {
+  const p = await payloadOf([at("claude-code", 20, 1000)]);
+  p.equivCostUsd = p.equivCostUsd + 5;
+
+  assert.ok(
+    validatePayload(p, NOW).some((e) => e.includes("daily costs sum")),
+    "an inflated headline cost must not pass",
+  );
+});
+
+test("per-row rounding does not trip the cost check", async () => {
+  // Many small rows are where four-decimal rounding accumulates; the tolerance exists for
+  // exactly this and must not be so tight that an honest payload fails.
+  const events = [];
+  for (let day = 1; day <= 20; day++) {
+    for (const agent of ["claude-code", "codex", "opencode"]) {
+      events.push(at(agent, day, 333));
+    }
+  }
+  const p = await payloadOf(events);
+
+  assert.equal(p.days.length, 60);
+  assert.deepEqual(validatePayload(p, NOW), []);
+});


### PR DESCRIPTION
The board rendered eight invented developers from `sample-data.ts` while a working
endpoint sat behind it with a real row in it. It now reads the database.

## Wiring it exposed a data problem

The section has four window filters and six columns, but **only tokens could be
windowed**. Cost and agent mix were lifetime totals on the submission, so "last 7d"
would have shown a week of tokens beside a year of spend in the same row — the kind
of mismatch people read as one figure and quote as one.

So `user_days` carries an agent and a cost per day, and every column sums over the
same range. On real data that is 38 rows and 6.1 KB, against 3.8 KB before:

```
all / year   4,356,735,362   $2877.29   mix: claude-code, codex, opencode
30d          3,659,240,095   $2410.28   mix: claude-code
7d           2,236,506,935   $1380.60   mix: claude-code
```

Tokens, cost and mix now move together. **Streak stays unwindowed** and the footnote
says so — "your streak, but only counting last week" is not a thing anyone means.

## Two details the change turned up

- **The daily token ceiling has to sum a day's agents before comparing.** Checking
  each agent row on its own would let three agents each sit under the limit while
  the day together sat far above it. Pinned by a test.
- **Day costs carry four decimals against a two-decimal headline**, so they are
  compared with a tolerance rather than for equality. Real drift is `$0.0034` across
  38 rows; the bound stays far tighter than any fabrication would be. Also pinned,
  in both directions — an inflated headline is rejected, honest rounding is not.

## The tick is now tier-driven

It was unconditional. An unverified `cli` row would have carried the same tick as a
verified one, which is the single thing this board must never do. `cli` rows get a
deliberately quieter badge — no lime, no tick — and the footnote explains it.

## Rendering

The page server-renders the default window and revalidates every five minutes, so the
table is populated on first paint rather than flashing empty. Changing the window
refetches on the client and **keeps the previous rows on screen** while it does, since
a table that empties and refills makes the page jump. A failed refetch leaves the last
good data up rather than replacing real figures with an error.

The page does **not** fetch its own API — the query lives in `lib/board-query.ts` and
both callers share it. A self-request would be a needless round trip, and it would have
to name an origin, which in development means either hardcoding localhost or accidentally
reading production.

## Verified

40 tests. Beyond those: published for real and confirmed in Supabase that `user_days`
holds one row per day per agent and still reconciles with the headline; checked all four
windows scale together; rendered at 1440 and 390 with both badge states visible and the
medals intact; confirmed the placeholder developers appear nowhere in the served HTML and
the real row does.

**Not exercised live:** the empty state. Triggering it meant deleting every row, which was
correctly blocked as a bulk delete, so it is verified by reading the code rather than by
running it.

## Known, not fixed

With one agent at 98.7% of tokens, the mix bar renders as a solid block — the other
segments are sub-pixel. Accurate, but it conveys little until the board has more varied
users. Widening small segments would misrepresent the proportions, so I left it; hovering
gives the per-agent breakdown.
