### PR TITLE
Replace the site's fake sign-in with the real one

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ media queries, and the blinking `▌` after the install command is the only anim
 
 ## Not built, deliberately
 
-A leaderboard backend, GitHub OAuth, spend-based tier ladders, pricing, a blog, a site
-dark-mode toggle, and scheduled-Action automation. Sign-in on the site is local client state
-behind `useSiteState()`, ready for a real provider if one is ever needed.
+Spend-based tier ladders, pricing, a blog, a site dark-mode toggle, and scheduled-Action
+automation.
+
+**A browser session, deliberately.** Sign-in happens in the terminal, and nothing on the site
+is per-user — no settings, no upload form, no private page. Identity exists to stamp a row on
+the board, and only the CLI can produce a row. Adding browser OAuth would mean GitHub's web
+flow, which is the one flow that needs a client secret, in exchange for a header pill.

--- a/apps/site/components/site-header.module.css
+++ b/apps/site/components/site-header.module.css
@@ -75,45 +75,6 @@
   transform: translate(4px, 4px);
 }
 
-.pill {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 5px 6px 5px 10px;
-  background: var(--surface);
-  border: 2px solid var(--ink);
-  box-shadow: 3px 3px 0 var(--lime);
-}
 
-.who {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
 
-.check {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 15px;
-  height: 15px;
-  background: var(--lime);
-  border: 1.5px solid var(--ink);
-  font-size: 9px;
-}
 
-.out {
-  padding: 4px 7px;
-  background: var(--ink);
-  border: 0;
-  color: #fff;
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  cursor: pointer;
-}

--- a/apps/site/components/site-header.tsx
+++ b/apps/site/components/site-header.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
+
 import { GithubMark } from "./github-mark";
-import { useSiteState } from "./site-state";
 import styles from "./site-header.module.css";
+
+const LOGIN = "npx @tokencard/cli login";
 
 const NAV = [
   { href: "#card", label: "card" },
@@ -12,8 +15,33 @@ const NAV = [
   { href: "#recap", label: "recap" },
 ];
 
+/**
+ * The header's one action.
+ *
+ * This was a "sign in with GitHub" button that called `setSignedIn(true)` and did nothing
+ * else — it put a ✓ and a handle in the header for an account nobody had proved. On a site
+ * whose whole argument is that a tick should mean something, that was the wrong thing to
+ * ship, so it now hands over the command that actually establishes identity.
+ *
+ * There is deliberately no browser session. Nothing on this site is per-user: no settings, no
+ * upload form, no private page. Identity exists to stamp a row on the board, and only the CLI
+ * can produce a row.
+ */
 export function SiteHeader() {
-  const { handle, signedIn, signIn, signOut } = useSiteState();
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(LOGIN).catch(() => {});
+    setCopied(true);
+    if (timer.current) clearTimeout(timer.current);
+    // 1400ms, the same swap the copy buttons in the card section use.
+    timer.current = setTimeout(() => setCopied(false), 1400);
+  };
 
   return (
     <header className={styles.header}>
@@ -31,21 +59,15 @@ export function SiteHeader() {
           ))}
         </nav>
 
-        {signedIn ? (
-          <div className={styles.pill}>
-            <span className={styles.who}>
-              <span className={styles.check}>✓</span>@{handle}
-            </span>
-            <button type="button" onClick={signOut} className={styles.out}>
-              out
-            </button>
-          </div>
-        ) : (
-          <button type="button" onClick={signIn} className={styles.signIn}>
-            <GithubMark size={15} />
-            sign in with github
-          </button>
-        )}
+        <button
+          type="button"
+          onClick={copy}
+          className={styles.signIn}
+          title={`Copy "${LOGIN}" — verification happens in your terminal`}
+        >
+          <GithubMark size={15} />
+          {copied ? "copied · run it in your terminal" : "verify with the cli"}
+        </button>
       </div>
     </header>
   );

--- a/apps/site/components/site-state.tsx
+++ b/apps/site/components/site-state.tsx
@@ -17,23 +17,22 @@ import { DEFAULT_HANDLE, sanitizeHandle } from "@/lib/sample-data";
  * highlighted row in the board. The window filter and the copy-button timers are
  * local to their own components and deliberately not in here.
  *
- * `signedIn` is local state: signing in proves the account is real, enables the
+ * Handle only. There was a `signedIn` flag here driving a header pill, but nothing ever
+ * set it from a real session — identity is established by `tokencard login` in the terminal,
+ * and the site has no per-user surface for a browser session to unlock.
+ *
  * hosted endpoint and opts into the public board — wire this seam to a real GitHub
  * OAuth flow when there is one. Nothing else in the app should read auth directly.
  */
 type SiteState = {
   handle: string;
   setHandle: (raw: string) => void;
-  signedIn: boolean;
-  signIn: () => void;
-  signOut: () => void;
 };
 
 const Ctx = createContext<SiteState | null>(null);
 
 export function SiteStateProvider({ children }: { children: ReactNode }) {
   const [handle, setHandleRaw] = useState(DEFAULT_HANDLE);
-  const [signedIn, setSignedIn] = useState(false);
 
   const setHandle = useCallback((raw: string) => {
     setHandleRaw(sanitizeHandle(raw));
@@ -43,11 +42,8 @@ export function SiteStateProvider({ children }: { children: ReactNode }) {
     () => ({
       handle,
       setHandle,
-      signedIn,
-      signIn: () => setSignedIn(true),
-      signOut: () => setSignedIn(false),
     }),
-    [handle, setHandle, signedIn],
+    [handle, setHandle],
   );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;


### PR DESCRIPTION
Reported as "login is not working on the deployed side". There are two logins, and
it is not the one you would expect.

## The CLI login was never broken

Verified against production before changing anything: the identity exchange returns
`tier: verified`, and an authenticated `tokencard publish` with no flags lands a
verified row on the live board.

## The site's button was never real

```js
signIn: () => setSignedIn(true)
```

That is the entire implementation. No OAuth, no network call, and the flag it set
was read by exactly one thing — the header pill itself. Clicking it put **`✓ @dlacey`**
in the header: a verification tick beside a handle nobody had proved.

Inert would have been bad. Mimicking verification, on a site whose whole argument is
that a tick should mean something, is worse.

## What it does now

Hands over the command that actually establishes identity — copies
`npx @tokencard/cli login` with the same 1400ms label swap the card section's copy
buttons use. The coral press physics stay; it is the one button in the design that
has them.

```
[ tokencard ]   CARD BOARD VERIFY PRIVACY RECAP   [ ⌗ VERIFY WITH THE CLI ]
```

## No browser session, deliberately

Nothing on this site is per-user: no settings, no upload form, no private page.
Identity exists to stamp a row on the board, and **only the CLI can produce a row** —
it has to read local agent logs. A browser session would unlock nothing.

Adding one would mean GitHub's *web* flow, which is the single flow that needs a
client secret. That secret has been dead weight so far, which is why rotating it
costs nothing; wiring browser OAuth would make it load-bearing, in exchange for a
header pill. Worth revisiting only if the site grows pages worth signing into.

`signedIn` and the pill's now-dead styles go with it, and the README records the
decision rather than leaving it as an unexplained gap.
