### PR TITLE
Rate limit the write endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,27 @@ Serverless functions open a connection per invocation and exhaust a direct conne
 quickly; Supavisor exists for exactly that. The pool in `apps/site/lib/db.ts` is capped at 5
 to match.
 
+### Rate limits
+
+Writes are limited per hour, in Postgres rather than in memory — serverless functions share
+no memory, so an in-process counter would reset on every cold start and count separately per
+instance.
+
+| bucket | limit |
+| --- | --- |
+| anonymous publish, per IP | 10/h |
+| signed-in publish, per user | 60/h |
+| publish, per handle | 30/h |
+| sign-in, per IP | 20/h |
+| board reads, per IP | 300/h |
+
+Signed-in callers get more headroom than anonymous ones: they have proved who they are and
+their rows carry their name. The per-handle bucket exists because the per-IP one alone is
+defeated by spreading requests across addresses.
+
+Every response carries `x-ratelimit-limit` and `x-ratelimit-remaining`, refusals add
+`retry-after`, and the CLI prints the wait rather than a bare status code.
+
 ### Notes on the database
 
 - **`003_rls.sql` is not optional on Supabase.** Supabase exposes every `public` table

--- a/apps/site/app/api/auth/github/route.ts
+++ b/apps/site/app/api/auth/github/route.ts
@@ -3,6 +3,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { NextResponse } from "next/server";
 
 import { transaction } from "@/lib/db";
+import { clientIp, hit, limitHeaders, LIMITS } from "@/lib/rate-limit";
 
 export const dynamic = "force-dynamic";
 
@@ -17,6 +18,16 @@ export const dynamic = "force-dynamic";
  * never logged, and never written to the client's disk either.
  */
 export async function POST(req: Request) {
+  // Before the GitHub call, not after: an unlimited sign-in endpoint is a way to spend our
+  // outbound rate limit with GitHub as well as our own function budget.
+  const verdict = await hit(`auth:ip:${clientIp(req)}`, LIMITS.auth);
+  if (!verdict.allowed) {
+    return NextResponse.json(
+      { error: `too many sign-in attempts — try again in ${verdict.retryAfter}s` },
+      { status: 429, headers: limitHeaders(verdict) },
+    );
+  }
+
   let githubToken: string;
   try {
     const body = (await req.json()) as { githubToken?: unknown };

--- a/apps/site/app/api/submissions/route.ts
+++ b/apps/site/app/api/submissions/route.ts
@@ -6,6 +6,15 @@ import { userFromRequest } from "@/lib/auth";
 import { DEFAULT_WINDOW, isWindow } from "@/lib/board";
 import { readBoard } from "@/lib/board-query";
 import { transaction } from "@/lib/db";
+import {
+  clientIp,
+  hit,
+  limitHeaders,
+  LIMITS,
+  sweep,
+  type Limit,
+  type Verdict,
+} from "@/lib/rate-limit";
 
 export const dynamic = "force-dynamic";
 
@@ -17,6 +26,8 @@ export const dynamic = "force-dynamic";
  * rather than in the command.
  */
 export async function POST(req: Request) {
+  sweep();
+
   let payload: Payload;
   try {
     payload = (await req.json()) as Payload;
@@ -43,6 +54,37 @@ export async function POST(req: Request) {
       { error: `signed in as @${auth.handle}, cannot publish as @${payload.handle}` },
       { status: 403 },
     );
+  }
+
+  // Checked after authentication so a signed-in caller gets their own, larger allowance
+  // rather than sharing an address with everyone behind the same NAT or CI runner.
+  const handle = (auth?.handle ?? payload.handle).toLowerCase();
+  const buckets: [string, Limit][] = [
+    auth
+      ? [`publish:user:${auth.handle.toLowerCase()}`, LIMITS.publishUser]
+      : [`publish:ip:${clientIp(req)}`, LIMITS.publishAnonIp],
+    [`publish:handle:${handle}`, LIMITS.publishHandle],
+  ];
+
+  // Kept so the success response can report the tightest remaining allowance: a client that
+  // only learns its budget by being refused cannot slow down before it is.
+  let tightest: Verdict | null = null;
+
+  for (const [bucket, limit] of buckets) {
+    const verdict = await hit(bucket, limit);
+    if (!tightest || verdict.remaining < tightest.remaining) tightest = verdict;
+    if (!verdict.allowed) {
+      return NextResponse.json(
+        {
+          error: "rate limited",
+          reasons: [
+            `too many submissions — the limit is ${verdict.limit} per hour. ` +
+              `Try again in ${verdict.retryAfter}s.`,
+          ],
+        },
+        { status: 429, headers: limitHeaders(verdict) },
+      );
+    }
   }
 
   try {
@@ -115,7 +157,7 @@ export async function POST(req: Request) {
         tokens: payload.tokens,
         days: payload.days.length,
       },
-      { status: 201 },
+      { status: 201, headers: tightest ? limitHeaders(tightest) : undefined },
     );
   } catch (err) {
     console.error("submission failed", err);
@@ -128,13 +170,24 @@ export async function POST(req: Request) {
  * runs the same one — see the note there on why the page does not fetch this endpoint.
  */
 export async function GET(req: Request) {
+  const read = await hit(`board:ip:${clientIp(req)}`, LIMITS.read);
+  if (!read.allowed) {
+    return NextResponse.json(
+      { error: "rate limited" },
+      { status: 429, headers: limitHeaders(read) },
+    );
+  }
+
   const url = new URL(req.url);
   const requested = url.searchParams.get("window");
   const window = isWindow(requested) ? requested : DEFAULT_WINDOW;
   const limit = Math.min(100, Math.max(1, Number(url.searchParams.get("limit") ?? 25)));
 
   try {
-    return NextResponse.json({ window, rows: await readBoard(window, limit) });
+      return NextResponse.json(
+      { window, rows: await readBoard(window, limit) },
+      { headers: limitHeaders(read) },
+    );
   } catch (err) {
     console.error("board query failed", err);
     return NextResponse.json({ error: "could not read board" }, { status: 500 });

--- a/apps/site/db/migrations/005_rate_limits.sql
+++ b/apps/site/db/migrations/005_rate_limits.sql
@@ -1,0 +1,21 @@
+-- Fixed-window rate limiting, in Postgres.
+--
+-- Serverless functions share no memory, so an in-process counter would reset on every cold
+-- start and count separately per instance. Postgres is already here, a submission is already
+-- a write, and the extra round trip is one upsert — cheaper than adding Redis as a second
+-- service to provision, monitor and keep inside a free tier.
+--
+-- A fixed window rather than a sliding one: sliding needs a row per request, and the burst
+-- this exists to stop is "somebody found the endpoint", not a carefully paced overrun.
+CREATE TABLE rate_limits (
+  -- "<scope>:<subject>", e.g. "publish:ip:1.2.3.4" or "publish:handle:octocat".
+  bucket       text        PRIMARY KEY,
+  window_start timestamptz NOT NULL DEFAULT now(),
+  count        integer     NOT NULL DEFAULT 0
+);
+
+-- Stale buckets are swept opportunistically rather than by a scheduled job, so the behaviour
+-- is identical on any Postgres instead of depending on pg_cron being available.
+CREATE INDEX rate_limits_window_start ON rate_limits (window_start);
+
+ALTER TABLE rate_limits ENABLE ROW LEVEL SECURITY;

--- a/apps/site/lib/rate-limit.ts
+++ b/apps/site/lib/rate-limit.ts
@@ -1,0 +1,103 @@
+import "server-only";
+
+import { pool } from "@/lib/db";
+
+export type Limit = { limit: number; windowSeconds: number };
+
+/**
+ * What each route allows, and why.
+ *
+ * Publishing is not a frequent act — a developer syncs a few times a day, not a few times a
+ * minute — so these are generous for anyone real and still stop a script.
+ *
+ * Signed-in callers get more headroom than anonymous ones because they have proved who they
+ * are and their rows carry their name. An anonymous caller can claim any unclaimed handle,
+ * which is exactly the surface worth keeping narrow.
+ */
+export const LIMITS = {
+  /** Anonymous publishing, keyed by IP. The tightest bucket in the system. */
+  publishAnonIp: { limit: 10, windowSeconds: 3600 },
+  /** Signed-in publishing, keyed by user. */
+  publishUser: { limit: 60, windowSeconds: 3600 },
+  /** Per handle, so one name cannot be rewritten endlessly from many addresses. */
+  publishHandle: { limit: 30, windowSeconds: 3600 },
+  /** Sign-in makes an outbound call to GitHub, so it is worth its own bucket. */
+  auth: { limit: 20, windowSeconds: 3600 },
+  /** Reads are cheap but not free; this only exists to blunt a flood. */
+  read: { limit: 300, windowSeconds: 3600 },
+} as const satisfies Record<string, Limit>;
+
+export type Verdict = {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  /** Seconds until the window rolls over, for `Retry-After`. */
+  retryAfter: number;
+};
+
+/**
+ * Count one hit against a bucket and say whether it is allowed.
+ *
+ * Rejected requests still increment. That is deliberate: the counter measures attempts, so
+ * hammering a closed door does not quietly earn back allowance.
+ */
+export async function hit(bucket: string, { limit, windowSeconds }: Limit): Promise<Verdict> {
+  const { rows } = await pool.query<{ count: number; expires_in: number }>(
+    `INSERT INTO rate_limits (bucket, window_start, count)
+     VALUES ($1, now(), 1)
+     ON CONFLICT (bucket) DO UPDATE SET
+       count = CASE
+         WHEN rate_limits.window_start < now() - make_interval(secs => $2::int)
+         THEN 1 ELSE rate_limits.count + 1 END,
+       window_start = CASE
+         WHEN rate_limits.window_start < now() - make_interval(secs => $2::int)
+         THEN now() ELSE rate_limits.window_start END
+     RETURNING count,
+               CEIL(EXTRACT(EPOCH FROM
+                 (window_start + make_interval(secs => $2::int)) - now()))::int AS expires_in`,
+    [bucket, windowSeconds],
+  );
+
+  const row = rows[0]!;
+  return {
+    allowed: row.count <= limit,
+    limit,
+    remaining: Math.max(0, limit - row.count),
+    retryAfter: Math.max(1, row.expires_in),
+  };
+}
+
+/**
+ * The caller's address, as far as it can be known.
+ *
+ * `x-forwarded-for` is only trustworthy because Vercel overwrites it at the edge; the first
+ * entry is the client. Falling back to a shared "unknown" bucket is deliberate — if the
+ * header is missing, everyone lands in one bucket and gets limited together, which fails
+ * closed rather than handing out an unlimited lane to anyone who can strip a header.
+ */
+export function clientIp(req: Request): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0]!.trim();
+  return req.headers.get("x-real-ip")?.trim() || "unknown";
+}
+
+/**
+ * Delete windows that can no longer matter.
+ *
+ * Run opportunistically on roughly one request in fifty rather than on a schedule, so the
+ * behaviour does not depend on pg_cron being available. Failures are swallowed: housekeeping
+ * must never be the reason a submission is rejected.
+ */
+export function sweep(): void {
+  if (Math.random() > 0.02) return;
+  void pool
+    .query("DELETE FROM rate_limits WHERE window_start < now() - interval '1 day'")
+    .catch(() => {});
+}
+
+/** Headers every rate-limited response carries, allowed or not. */
+export const limitHeaders = (v: Verdict): Record<string, string> => ({
+  "x-ratelimit-limit": String(v.limit),
+  "x-ratelimit-remaining": String(v.remaining),
+  ...(v.allowed ? {} : { "retry-after": String(v.retryAfter) }),
+});

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -105,6 +105,11 @@ export async function login(argv: string[]): Promise<number> {
   // would be trivially forgeable. It is never written to disk on this machine.
   const res = await post(`${api}/api/auth/github`, JSON.stringify({ githubToken }));
 
+  if (res.status === 429) {
+    fail(String(res.body?.["error"] ?? "too many sign-in attempts — try again shortly"));
+    return 1;
+  }
+
   if (!res.ok) {
     fail(`${api} rejected the sign-in (${res.status})`);
     if (res.body?.["error"]) say(dim(`  ${String(res.body["error"])}`));

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -70,6 +70,12 @@ export async function publish(argv: string[], version: string): Promise<number> 
 
   const res = await post(`${api}/api/submissions`, body, auth?.token);
 
+  if (res.status === 429) {
+    // The server names the wait; repeating it beats a bare "rejected (429)".
+    fail(res.reasons?.[0] ?? "rate limited — try again shortly");
+    return 1;
+  }
+
   if (!res.ok) {
     fail(`rejected by ${api} (${res.status})`);
     for (const reason of res.reasons ?? []) say(`  ${yellow("·")} ${reason}`);


### PR DESCRIPTION
Anyone could publish unlimited rows under any unclaimed handle. The plausibility
bounds stop absurd *numbers*, not volume — creating a squatting row took seconds
during earlier testing.

## Counters in Postgres, not memory

Serverless functions share no memory, so an in-process counter resets on every cold
start and counts separately per instance. Postgres is already here and a submission
is already a write, so the cost is one upsert — cheaper than adding Redis as a second
service to provision, monitor and keep inside a free tier.

Fixed windows rather than sliding: sliding needs a row per request, and the burst this
exists to stop is "somebody found the endpoint", not a carefully paced overrun.

| bucket | limit |
| --- | --- |
| anonymous publish, per IP | 10/h |
| signed-in publish, per user | 60/h |
| publish, per handle | 30/h |
| sign-in, per IP | 20/h |
| board reads, per IP | 300/h |

Signed-in callers get more headroom because they have proved who they are and their
rows carry their name.

## Verified by actually doing the attack

```
anonymous, 13 attempts against 10/h
 1..10  201
 11..13 429  retry-after: 3595  x-ratelimit-remaining: 0

a different IP, same moment
 1 201 remaining=9   2 201 remaining=8   3 201 remaining=7
the first IP, same moment                              429

per-handle, one name from 34 different addresses
 30 × 201, then 429 429 429 429

sign-in, 22 attempts against 20/h
 20 × 401 (GitHub rejecting the token, i.e. working), then 429 429
```

That third case is the point of the per-handle bucket: a per-IP limit alone is defeated
by spreading requests across addresses, so I spread them across 34 and watched it stop
at 30.

## Details worth knowing

- **Sign-in is limited before the GitHub call**, not after. An unlimited endpoint there
  spends our outbound allowance with GitHub as well as our own function budget.
- **Rejected requests still increment**, so hammering a closed door does not quietly
  earn back allowance.
- **A missing `x-forwarded-for` falls into one shared bucket**, not an unlimited lane —
  it fails closed rather than rewarding anyone who can strip a header.
- **Stale windows are swept opportunistically**, roughly one request in fifty, rather
  than by `pg_cron`, so the behaviour is identical on any Postgres.
- **Limit headers are on successful responses too**, not only refusals: a client that
  only learns its budget by being refused cannot slow down before it is. The CLI prints
  the wait the server names rather than a bare `429`.

40 tests still pass; the test users created during this were removed.

## Not covered

This limits volume, not sophistication — a distributed client with many addresses
publishing under many handles still gets through, and no rate limit fixes that. The
remaining lever is the `flagged` column that already exists on `submissions`, and the
admin endpoint to set it, which research §5 pairs with exactly these bounds.
