### PR TITLE
Rename the project to tokenstats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npm ci
 
       # Builds core, then the CLI, then the site. The site build is what catches a Node
-      # built-in leaking into the client bundle through @tokencard/core.
+      # built-in leaking into the client bundle through @tokenstats/core.
       - run: npm run build
 
       - run: npm test
@@ -31,7 +31,7 @@ jobs:
       - name: Site builds standalone, as Vercel builds it
         run: |
           rm -rf packages/core/dist
-          npm run build --workspace=tokencard-site
+          npm run build --workspace=tokenstats-site
 
       # The card is the product; a builder that renders nothing should fail the run.
       - name: Card renders

--- a/.tokenstats.json
+++ b/.tokenstats.json
@@ -5,7 +5,7 @@
     "codex",
     "opencode"
   ],
-  "output": "tokencard.svg",
+  "output": "tokenstats.svg",
   "layout": "default",
   "theme": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# tokencard
+# tokenstats
 
 Turn your local AI coding agent logs into an embeddable stat card for your GitHub README.
 
-tokencard reads the transcripts **Claude Code**, **Codex** and **OpenCode** already write to
+tokenstats reads the transcripts **Claude Code**, **Codex** and **OpenCode** already write to
 your disk, totals them, and renders an SVG you commit to your own repo. No account, no
 upload, no server — the card is a file.
 
 ```bash
-npx @tokencard/cli init     # detect agents, write .tokencard.json
-npx @tokencard/cli sync     # render tokencard.svg
-npx @tokencard/cli recap    # render tokencard-recap.svg — the year in review
+npx @tokenstats/cli init     # detect agents, write .tokenstats.json
+npx @tokenstats/cli sync     # render tokenstats.svg
+npx @tokenstats/cli recap    # render tokenstats-recap.svg — the year in review
 ```
 
 ```markdown
-![tokencard](./tokencard.svg)
-![tokencard recap](./tokencard-recap.svg)
+![tokenstats](./tokenstats.svg)
+![tokenstats recap](./tokenstats-recap.svg)
 ```
 
 ## What it reads
@@ -51,27 +51,27 @@ a network request.
 ## Commands
 
 ```
-tokencard init
+tokenstats init
   --handle <name>        GitHub handle (default: guessed from your origin remote)
 
-tokencard sync
-  --out <path>           where to write it (default: tokencard.svg)
+tokenstats sync
+  --out <path>           where to write it (default: tokenstats.svg)
   --layout default|compact
   --theme auto|light|dark
   --json                 print the aggregate instead of writing an SVG
   --dry-run              report what would be written, write nothing
 
-tokencard login          prove your GitHub handle (device flow, no password)
-tokencard logout         forget this machine
-tokencard whoami         who this machine is signed in as
+tokenstats login          prove your GitHub handle (device flow, no password)
+tokenstats logout         forget this machine
+tokenstats whoami         who this machine is signed in as
 
-tokencard publish        the only command that uploads anything
+tokenstats publish        the only command that uploads anything
   --dry-run              print the exact bytes and send nothing
-  --api <url>            default https://tokencard-site.vercel.app
+  --api <url>            default https://tokenstats-site.vercel.app
   --handle <name>
 
-tokencard recap
-  --out <path>           default: tokencard-recap.svg
+tokenstats recap
+  --out <path>           default: tokenstats-recap.svg
   --year <yyyy>          label the recap with a different year
   --theme auto|light|dark
   --json                 print the recap model instead of writing an SVG
@@ -106,7 +106,7 @@ turn. Claude Code and OpenCode are exact to the message.
 ## Publishing to the board
 
 `publish` is the **only** command that sends anything anywhere. `sync` and `recap` are local
-forever, and there is deliberately no config switch to change that: `.tokencard.json` is a
+forever, and there is deliberately no config switch to change that: `.tokenstats.json` is a
 committed file, and a committed file must never be able to cause a network call on somebody
 else's machine.
 
@@ -118,7 +118,7 @@ and model ids. No prompts, no replies, no branch names, no paths.
 ## Signing in
 
 ```
-$ tokencard login
+$ tokenstats login
   Open https://github.com/login/device
   and enter  WDJB-MJHT
 ✓ signed in as @octocat
@@ -134,8 +134,8 @@ and numeric id are all we need.
 The GitHub token is handed to the server **once**, so that the server — not the client — is
 what asks GitHub who you are; a client that simply asserted `{"handle": "octocat"}` would be
 forgeable. It is then discarded, never written to disk on either side. What you keep is a
-tokencard API key in `~/.config/tokencard/auth.json`, mode `0600`, stored server-side only as
-a SHA-256 hash. Never in `.tokencard.json`, which is committed.
+tokenstats API key in `~/.config/tokenstats/auth.json`, mode `0600`, stored server-side only as
+a SHA-256 hash. Never in `.tokenstats.json`, which is committed.
 
 Without signing in, submissions land as the unverified `cli` tier. Those rows appear on the
 board with a badge rather than being hidden — a transparency signal, not a gate. Signing in
@@ -151,8 +151,8 @@ cp apps/site/.env.example apps/site/.env.local   # then fill in the password
 npm run db:migrate                               # idempotent; safe to re-run
 npm run dev
 
-npx @tokencard/cli login   --api http://localhost:3000
-npx @tokencard/cli publish --api http://localhost:3000
+npx @tokenstats/cli login   --api http://localhost:3000
+npx @tokenstats/cli publish --api http://localhost:3000
 ```
 
 `.env.local` is gitignored; `apps/site/.env.example` documents the shape. Next reads
@@ -206,7 +206,7 @@ Every response carries `x-ratelimit-limit` and `x-ratelimit-remaining`, refusals
 ```
 apps/site/          Next.js marketing site + the board API
 packages/core/      adapters, aggregation, price table, SVG builder
-packages/cli/       the tokencard binary
+packages/cli/       the tokenstats binary
 docs/research.md    positioning, competitive landscape, infrastructure decisions
 ```
 

--- a/apps/site/app/api/auth/github/route.ts
+++ b/apps/site/app/api/auth/github/route.ts
@@ -8,7 +8,7 @@ import { clientIp, hit, limitHeaders, LIMITS } from "@/lib/rate-limit";
 export const dynamic = "force-dynamic";
 
 /**
- * Exchange a GitHub access token for a tokencard API key.
+ * Exchange a GitHub access token for a tokenstats API key.
  *
  * The identity check happens **here**, not in the CLI. A client that simply posted
  * `{ handle: "octocat" }` would be trivially forgeable, so the server takes the GitHub token
@@ -45,7 +45,7 @@ export async function POST(req: Request) {
       headers: {
         authorization: `Bearer ${githubToken}`,
         accept: "application/vnd.github+json",
-        "user-agent": "tokencard",
+        "user-agent": "tokenstats",
       },
       cache: "no-store",
     });

--- a/apps/site/app/api/card/[handle]/route.ts
+++ b/apps/site/app/api/card/[handle]/route.ts
@@ -5,7 +5,7 @@ import {
   type HideKey,
   type Layout,
   type Theme,
-} from "@tokencard/core";
+} from "@tokenstats/core";
 import { OWN_STATS } from "@/lib/sample-data";
 
 /** Cache window printed on the card. Clamped 4h–24h, same as the rest of the genre. */

--- a/apps/site/app/api/submissions/route.ts
+++ b/apps/site/app/api/submissions/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { validatePayload, type Payload } from "@tokencard/core";
+import { validatePayload, type Payload } from "@tokenstats/core";
 
 import { userFromRequest } from "@/lib/auth";
 import { DEFAULT_WINDOW, isWindow } from "@/lib/board";

--- a/apps/site/app/globals.css
+++ b/apps/site/app/globals.css
@@ -1,5 +1,5 @@
 /* ── Design tokens ──────────────────────────────────────────────────────────
-   Source: design_handoff_tokencard_site/README.md § Design tokens.
+   Source: design_handoff_tokenstats_site/README.md § Design tokens.
    Border radius is 0 everywhere. Shadows are hard offsets only (Npx Npx 0 c). */
 :root {
   --ink: #101010;

--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -19,9 +19,9 @@ const mono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "tokencard — receipts for your robots",
+  title: "tokenstats — receipts for your robots",
   description:
-    "tokencard reads your local Claude Code, Codex, Gemini CLI, Copilot CLI and OpenCode logs and prints one embeddable card.",
+    "tokenstats reads your local Claude Code, Codex, Gemini CLI, Copilot CLI and OpenCode logs and prints one embeddable card.",
 };
 
 export default function RootLayout({

--- a/apps/site/components/card-section.tsx
+++ b/apps/site/components/card-section.tsx
@@ -3,7 +3,7 @@
 import { CopyButton } from "@/components/copy-button";
 import { SectionHeading } from "@/components/section-heading";
 import { useSiteState } from "@/components/site-state";
-import { buildCardSvg } from "@tokencard/core";
+import { buildCardSvg } from "@tokenstats/core";
 import { DEFAULT_HANDLE, OWN_STATS, QUERY_OPTIONS } from "@/lib/sample-data";
 import { SITE_URL } from "@/lib/site";
 import styles from "./card-section.module.css";
@@ -20,7 +20,7 @@ export function CardSection() {
 
   // A plain image, not a link. There is no per-user page to point at, and inventing one
   // would mean hosting exactly the surface the committed-SVG design exists to avoid.
-  const markdown = `![tokencard](${SITE_URL}/api/card/${handle}.svg)`;
+  const markdown = `![tokenstats](${SITE_URL}/api/card/${handle}.svg)`;
 
   /* The panel shows the origin elided so the two tags fit without scrolling; the
      clipboard gets the full URLs, which is what a README actually needs. */

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -5,9 +5,9 @@ import { StatCard } from "./stat-card";
 import { useSiteState } from "./site-state";
 import styles from "./hero.module.css";
 
-// Scoped, because the bare `tokencard` name on npm is a 2018 tombstone: it was published
+// Scoped, because the bare `tokenstats` name on npm is a 2018 tombstone: it was published
 // and unpublished within a fortnight, and npm never lets an unpublished name be reused.
-const INSTALL = "npx @tokencard/cli init";
+const INSTALL = "npx @tokenstats/cli init";
 
 export function Hero() {
   const { handle, setHandle } = useSiteState();
@@ -28,7 +28,7 @@ export function Hero() {
         </h1>
 
         <p className={styles.lede}>
-          tokencard reads your local Claude Code, Codex and OpenCode logs and renders one
+          tokenstats reads your local Claude Code, Codex and OpenCode logs and renders one
           embeddable card straight into your repo. Nothing is uploaded — the card is a file
           you commit.
         </p>

--- a/apps/site/components/leaderboard.tsx
+++ b/apps/site/components/leaderboard.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 
 import { SectionHeading } from "@/components/section-heading";
 import { useSiteState } from "@/components/site-state";
-import { formatTokens, formatUsd } from "@tokencard/core";
+import { formatTokens, formatUsd } from "@tokenstats/core";
 import type { BoardRow } from "@/lib/board";
 import { WINDOWS, type BoardWindow } from "@/lib/board";
 import styles from "./leaderboard.module.css";
@@ -66,7 +66,7 @@ export function Leaderboard({ initialRows, initialWindow }: {
 
       <p className={styles.intro}>
         Public ranking of developers who chose to publish. Run{" "}
-        <span className={styles.strong}>tokencard publish</span> and you are on it. Stop
+        <span className={styles.strong}>tokenstats publish</span> and you are on it. Stop
         publishing and your row goes stale, then falls out of the window on its own.
       </p>
 
@@ -86,7 +86,7 @@ export function Leaderboard({ initialRows, initialWindow }: {
       {rows.length === 0 ? (
         <p className={styles.empty}>
           Nobody has published in this window yet.{" "}
-          <span className={styles.strong}>npx @tokencard/cli publish</span> and the board is
+          <span className={styles.strong}>npx @tokenstats/cli publish</span> and the board is
           yours.
         </p>
       ) : (

--- a/apps/site/components/recap.tsx
+++ b/apps/site/components/recap.tsx
@@ -21,7 +21,7 @@ export function Recap() {
     <section id="recap" className={styles.section}>
       <SectionHeading n={5} title="Year in review" tone="coral" />
       <p className={styles.intro}>
-        <code>tokencard recap</code> renders this as a second committable SVG. Same
+        <code>tokenstats recap</code> renders this as a second committable SVG. Same
         data, no card constraints.
       </p>
 

--- a/apps/site/components/site-footer.tsx
+++ b/apps/site/components/site-footer.tsx
@@ -1,9 +1,9 @@
 import styles from "./site-footer.module.css";
 
 const LINKS = [
-  { label: "github.com/tokencard", href: "https://github.com/tokencard" },
-  { label: "npm / tokencard", href: "https://npmjs.com/package/tokencard" },
-  { label: "self-host docs", href: "https://github.com/tokencard#self-hosting" },
+  { label: "github.com/tokenstats", href: "https://github.com/tokenstats" },
+  { label: "npm / tokenstats", href: "https://npmjs.com/package/tokenstats" },
+  { label: "self-host docs", href: "https://github.com/tokenstats#self-hosting" },
 ];
 
 export function SiteFooter() {
@@ -17,7 +17,7 @@ export function SiteFooter() {
             </a>
           ))}
         </div>
-        <div className={styles.legal}>MIT License · © 2026 tokencard contributors</div>
+        <div className={styles.legal}>MIT License · © 2026 tokenstats contributors</div>
       </div>
     </footer>
   );

--- a/apps/site/components/site-header.tsx
+++ b/apps/site/components/site-header.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { GithubMark } from "./github-mark";
 import styles from "./site-header.module.css";
 
-const LOGIN = "npx @tokencard/cli login";
+const LOGIN = "npx @tokenstats/cli login";
 
 const NAV = [
   { href: "#card", label: "card" },
@@ -46,7 +46,7 @@ export function SiteHeader() {
   return (
     <header className={styles.header}>
       <div className={styles.brand}>
-        <span className={styles.wordmark}>tokencard</span>
+        <span className={styles.wordmark}>tokenstats</span>
         <span className={styles.version}>v0.4.1 · MIT</span>
       </div>
 

--- a/apps/site/components/site-state.tsx
+++ b/apps/site/components/site-state.tsx
@@ -18,7 +18,7 @@ import { DEFAULT_HANDLE, sanitizeHandle } from "@/lib/sample-data";
  * local to their own components and deliberately not in here.
  *
  * Handle only. There was a `signedIn` flag here driving a header pill, but nothing ever
- * set it from a real session — identity is established by `tokencard login` in the terminal,
+ * set it from a real session — identity is established by `tokenstats login` in the terminal,
  * and the site has no per-user surface for a browser session to unlock.
  *
  * hosted endpoint and opts into the public board — wire this seam to a real GitHub

--- a/apps/site/components/stat-card.tsx
+++ b/apps/site/components/stat-card.tsx
@@ -52,7 +52,7 @@ export function StatCard() {
       </div>
 
       <div className={styles.footer}>
-        <span>TOKENCARD.DEV</span>
+        <span>TOKENSTATS.APP</span>
         <span>{OWN_STATS.syncedAt}</span>
       </div>
     </div>

--- a/apps/site/db/migrations/002_auth.sql
+++ b/apps/site/db/migrations/002_auth.sql
@@ -7,7 +7,7 @@ CREATE TABLE api_tokens (
   user_id      bigint      NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   -- SHA-256 of the token. A database leak must not hand out working credentials.
   token_hash   text        NOT NULL UNIQUE,
-  -- Shown in `tokencard whoami` so a user can tell two machines apart before revoking one.
+  -- Shown in `tokenstats whoami` so a user can tell two machines apart before revoking one.
   label        text        NOT NULL DEFAULT 'cli',
   created_at   timestamptz NOT NULL DEFAULT now(),
   last_used_at timestamptz

--- a/apps/site/lib/db.ts
+++ b/apps/site/lib/db.ts
@@ -6,20 +6,20 @@ import pg from "pg";
  * Next's dev server re-evaluates modules on every edit; without the global, each reload
  * would leak a pool and Postgres would run out of connections within a few saves.
  */
-const globalForDb = globalThis as unknown as { tokencardPool?: pg.Pool };
+const globalForDb = globalThis as unknown as { tokenstatsPool?: pg.Pool };
 
 export const pool: pg.Pool =
-  globalForDb.tokencardPool ??
+  globalForDb.tokenstatsPool ??
   new pg.Pool({
     connectionString:
-      process.env["DATABASE_URL"] ?? "postgres://tokencard:tokencard@localhost:5432/tokencard",
+      process.env["DATABASE_URL"] ?? "postgres://tokenstats:tokenstats@localhost:5432/tokenstats",
     // A leaderboard write is short; a connection held open longer than this is a bug.
     connectionTimeoutMillis: 5_000,
     idleTimeoutMillis: 30_000,
     max: 5,
   });
 
-if (process.env.NODE_ENV !== "production") globalForDb.tokencardPool = pool;
+if (process.env.NODE_ENV !== "production") globalForDb.tokenstatsPool = pool;
 
 /** Run `fn` inside a transaction, rolling back on any throw. */
 export async function transaction<T>(fn: (client: pg.PoolClient) => Promise<T>): Promise<T> {

--- a/apps/site/lib/sample-data.ts
+++ b/apps/site/lib/sample-data.ts
@@ -121,7 +121,7 @@ export const PEAK_MASK = Array.from({ length: 24 }, (_, i) =>
 );
 
 /** Re-exported so components have one import for placeholder data and handle rules alike. */
-export { sanitizeHandle } from "@tokencard/core";
+export { sanitizeHandle } from "@tokenstats/core";
 
 /**
  * Year-in-review tiles. Kept separate from OWN_STATS because the recap page has no

--- a/apps/site/lib/site.ts
+++ b/apps/site/lib/site.ts
@@ -2,12 +2,12 @@
  * The site's own public origin, used wherever the page hands someone a URL to copy.
  *
  * One constant because these strings end up in other people's READMEs: a stale one there is
- * a broken image on a repo we do not control and cannot fix. When tokencard.dev is attached,
+ * a broken image on a repo we do not control and cannot fix. When tokenstats.dev is attached,
  * change it here and in packages/cli/src/api.ts — those two are the only places that must be
  * true rather than aspirational.
  *
- * The `TOKENCARD.DEV` wordmark printed on the card itself is deliberately not driven by this.
- * It is a signature at 8px, not a link, and "TOKENCARD-SITE.VERCEL.APP" would neither fit the
+ * The `TOKENSTATS.APP` wordmark printed on the card itself is deliberately not driven by this.
+ * It is a signature at 8px, not a link, and a vercel.app subdomain would neither fit the
  * design nor read as a brand.
  */
 export const SITE_URL = "https://tokencard-site.vercel.app";

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tokencard-site",
+  "name": "tokenstats-site",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -11,7 +11,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@tokencard/core": "0.1.0",
+    "@tokenstats/core": "0.1.0",
     "next": "16.3.4",
     "pg": "^8.23.0",
     "react": "19.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tokencard",
+  "name": "tokenstats",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tokencard",
+      "name": "tokenstats",
       "version": "0.0.0",
       "license": "MIT",
       "workspaces": [
@@ -17,10 +17,10 @@
       }
     },
     "apps/site": {
-      "name": "tokencard-site",
+      "name": "tokenstats-site",
       "version": "0.1.0",
       "dependencies": {
-        "@tokencard/core": "0.1.0",
+        "@tokenstats/core": "0.1.0",
         "next": "16.3.4",
         "pg": "^8.23.0",
         "react": "19.2.8",
@@ -1334,11 +1334,11 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@tokencard/cli": {
+    "node_modules/@tokenstats/cli": {
       "resolved": "packages/cli",
       "link": true
     },
-    "node_modules/@tokencard/core": {
+    "node_modules/@tokenstats/core": {
       "resolved": "packages/core",
       "link": true
     },
@@ -5882,7 +5882,7 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tokencard-site": {
+    "node_modules/tokenstats-site": {
       "resolved": "apps/site",
       "link": true
     },
@@ -6333,14 +6333,14 @@
       }
     },
     "packages/cli": {
-      "name": "@tokencard/cli",
+      "name": "@tokenstats/cli",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@tokencard/core": "0.1.0"
+        "@tokenstats/core": "0.1.0"
       },
       "bin": {
-        "tokencard": "dist/index.js"
+        "tokenstats": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -6361,7 +6361,7 @@
       }
     },
     "packages/core": {
-      "name": "@tokencard/core",
+      "name": "@tokenstats/core",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tokencard",
+  "name": "tokenstats",
   "version": "0.0.0",
   "private": true,
   "description": "Turn your local AI coding agent logs into an embeddable stat card.",
@@ -12,10 +12,10 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "npm run build -w @tokencard/core && npm run build -w @tokencard/cli && npm run build -w tokencard-site",
-    "build:core": "npm run build -w @tokencard/core",
-    "dev": "npm run dev -w tokencard-site",
-    "test": "npm run build:core && npm run build -w @tokencard/cli && npm run test -w @tokencard/core && npm run test -w @tokencard/cli",
+    "build": "npm run build -w @tokenstats/core && npm run build -w @tokenstats/cli && npm run build -w tokenstats-site",
+    "build:core": "npm run build -w @tokenstats/core",
+    "dev": "npm run dev -w tokenstats-site",
+    "test": "npm run build:core && npm run build -w @tokenstats/cli && npm run test -w @tokenstats/core && npm run test -w @tokenstats/cli",
     "cli": "node packages/cli/dist/index.js",
     "db:migrate": "node apps/site/db/migrate.mjs"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@tokencard/cli",
+  "name": "@tokenstats/cli",
   "version": "0.1.0",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "license": "MIT",
   "type": "module",
   "bin": {
-    "tokencard": "./dist/index.js"
+    "tokenstats": "./dist/index.js"
   },
   "files": [
     "dist"
@@ -14,7 +14,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@tokencard/core": "0.1.0"
+    "@tokenstats/core": "0.1.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,10 +1,10 @@
 /**
  * Where the CLI talks to, unless told otherwise.
  *
- * Points at the Vercel URL rather than tokencard.dev because the domain is not attached yet
+ * Points at the Vercel URL rather than tokenstats.dev because the domain is not attached yet
  * and a default that does not resolve makes `publish` fail for everyone who does not pass
  * `--api`. Swap this the day the domain is live; the site's own copy already says
- * tokencard.dev, and this is the one place that has to be true rather than aspirational.
+ * tokenstats.dev, and this is the one place that has to be true rather than aspirational.
  *
  * Defined once because it was previously duplicated across login and publish, which is how
  * two defaults end up disagreeing.
@@ -13,4 +13,4 @@ export const DEFAULT_API = "https://tokencard-site.vercel.app";
 
 /** Resolve the API base: explicit flag, then environment, then the default. */
 export const resolveApi = (flagValue: string | undefined): string =>
-  (flagValue ?? process.env["TOKENCARD_API"] ?? DEFAULT_API).replace(/\/$/, "");
+  (flagValue ?? process.env["TOKENSTATS_API"] ?? DEFAULT_API).replace(/\/$/, "");

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -3,15 +3,15 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 /**
- * Where the tokencard API key lives.
+ * Where the tokenstats API key lives.
  *
- * Deliberately not `.tokencard.json` — that file is committed. Credentials belong in the
+ * Deliberately not `.tokenstats.json` — that file is committed. Credentials belong in the
  * user's config directory, on their machine, and nowhere a `git add -A` can reach.
  */
 const authPath = (): string =>
   join(
     process.env["XDG_CONFIG_HOME"] ?? join(homedir(), ".config"),
-    "tokencard",
+    "tokenstats",
     "auth.json",
   );
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,8 +1,8 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-import { type AgentId } from "@tokencard/core";
-import { adapters, unsupported } from "@tokencard/core/adapters";
+import { type AgentId } from "@tokenstats/core";
+import { adapters, unsupported } from "@tokenstats/core/adapters";
 
 import { flag } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig, writeConfig, type Config } from "../config.js";
@@ -78,11 +78,11 @@ export async function init(argv: string[]): Promise<number> {
 
   if (!handle) {
     say();
-    warn(`No handle set. Add one to ${CONFIG_FILE}, or run: tokencard init --handle <you>`);
+    warn(`No handle set. Add one to ${CONFIG_FILE}, or run: tokenstats init --handle <you>`);
   }
 
   say();
-  say(`  Next: ${bold("tokencard sync")}`);
+  say(`  Next: ${bold("tokenstats sync")}`);
   say();
 
   return 0;

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -9,7 +9,7 @@ import { bold, dim, fail, green, say, warn } from "../ui.js";
  * to ship an OAuth client inside a CLI that anybody can read. Overridable so the flow can be
  * pointed at a throwaway app during development.
  */
-const CLIENT_ID = process.env["TOKENCARD_CLIENT_ID"] ?? "Ov23liSMxVycJS63ZqN5";
+const CLIENT_ID = process.env["TOKENSTATS_CLIENT_ID"] ?? "Ov23liSMxVycJS63ZqN5";
 
 const DEVICE_CODE_URL = "https://github.com/login/device/code";
 const TOKEN_URL = "https://github.com/login/oauth/access_token";
@@ -33,8 +33,8 @@ export async function login(argv: string[]): Promise<number> {
   if (existing && !argv.includes("--force")) {
     say();
     say(`Already signed in as ${bold(`@${existing.handle}`)} ${dim(`(${existing.api})`)}`);
-    say(dim("  tokencard login --force   sign in again"));
-    say(dim("  tokencard logout          forget this machine"));
+    say(dim("  tokenstats login --force   sign in again"));
+    say(dim("  tokenstats logout          forget this machine"));
     say();
     return 0;
   }
@@ -84,7 +84,7 @@ export async function login(argv: string[]): Promise<number> {
       continue;
     }
     if (error === "expired_token") {
-      fail("The code expired. Run `tokencard login` again.");
+      fail("The code expired. Run `tokenstats login` again.");
       return 1;
     }
     if (error === "access_denied") {
@@ -141,7 +141,7 @@ export async function login(argv: string[]): Promise<number> {
   }
 
   say();
-  say(`  Next: ${bold("tokencard publish")} ${dim("— your rows will be marked verified")}`);
+  say(`  Next: ${bold("tokenstats publish")} ${dim("— your rows will be marked verified")}`);
   say();
 
   return 0;
@@ -156,7 +156,7 @@ export async function logout(): Promise<number> {
 export async function whoami(): Promise<number> {
   const auth = await readAuth();
   if (!auth) {
-    say("Not signed in. Run `tokencard login`.");
+    say("Not signed in. Run `tokenstats login`.");
     return 1;
   }
   say(`@${auth.handle} ${dim(`· ${auth.api} · since ${auth.createdAt.slice(0, 10)}`)}`);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -4,8 +4,8 @@ import {
   sanitizeHandle,
   serializePayload,
   validatePayload,
-} from "@tokencard/core";
-import { readAll } from "@tokencard/core/adapters";
+} from "@tokenstats/core";
+import { readAll } from "@tokenstats/core/adapters";
 
 import { resolveApi } from "../api.js";
 import { flag, has } from "../args.js";
@@ -19,7 +19,7 @@ import { post } from "../net.js";
  * The only command that sends anything anywhere.
  *
  * Kept separate from `sync` on purpose, and with no config switch to make `sync` do it:
- * `.tokencard.json` is a committed file, and a committed file must never be able to cause a
+ * `.tokenstats.json` is a committed file, and a committed file must never be able to cause a
  * network call on somebody else's machine.
  */
 export async function publish(argv: string[], version: string): Promise<number> {
@@ -40,7 +40,7 @@ export async function publish(argv: string[], version: string): Promise<number> 
 
   const stats = await aggregate(readAll(config.agents));
   if (stats.tokens === 0) {
-    warn("No usage found. Run `tokencard init` to see which agents were detected.");
+    warn("No usage found. Run `tokenstats init` to see which agents were detected.");
     return 1;
   }
 
@@ -88,7 +88,7 @@ export async function publish(argv: string[], version: string): Promise<number> 
   if ((res.body?.tier ?? "cli") === "cli" && !auth) {
     say();
     say(dim("  This row is marked unverified on the board — nothing has proved the handle"));
-    say(dim("  is yours. Run `tokencard login` to upgrade it."));
+    say(dim("  is yours. Run `tokenstats login` to upgrade it."));
   }
   say();
 

--- a/packages/cli/src/commands/recap.ts
+++ b/packages/cli/src/commands/recap.ts
@@ -7,8 +7,8 @@ import {
   buildRecapSvg,
   sanitizeHandle,
   type Theme,
-} from "@tokencard/core";
-import { readAll } from "@tokencard/core/adapters";
+} from "@tokenstats/core";
+import { readAll } from "@tokenstats/core/adapters";
 
 import { flag, has, oneOf } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
@@ -25,7 +25,7 @@ export async function recap(argv: string[]): Promise<number> {
   const rawHandle = flag(argv, "--handle") ?? config.handle;
   const handle = sanitizeHandle(rawHandle);
   const theme = oneOf(flag(argv, "--theme"), THEMES, "theme") ?? config.theme;
-  const out = flag(argv, "--out") ?? "tokencard-recap.svg";
+  const out = flag(argv, "--out") ?? "tokenstats-recap.svg";
   const json = has(argv, "--json");
   const dryRun = has(argv, "--dry-run");
   const yearFlag = flag(argv, "--year");
@@ -37,7 +37,7 @@ export async function recap(argv: string[]): Promise<number> {
 
   const stats = await aggregate(readAll(config.agents));
   if (stats.tokens === 0) {
-    warn("No usage found. Run `tokencard init` to see which agents were detected.");
+    warn("No usage found. Run `tokenstats init` to see which agents were detected.");
     return 1;
   }
 
@@ -108,7 +108,7 @@ export async function recap(argv: string[]): Promise<number> {
   await writeFile(target, svg, "utf8");
   say(`${green("✓")} wrote ${bold(rel)} ${dim(`(${svg.length} bytes)`)}`);
   say();
-  say(`  ![tokencard recap](./${rel})`);
+  say(`  ![tokenstats recap](./${rel})`);
   say();
 
   return 0;

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -11,8 +11,8 @@ import {
   toCardOptions,
   type Layout,
   type Theme,
-} from "@tokencard/core";
-import { readAll } from "@tokencard/core/adapters";
+} from "@tokenstats/core";
+import { readAll } from "@tokenstats/core/adapters";
 
 import { flag, has, oneOf } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
@@ -38,7 +38,7 @@ export async function sync(argv: string[]): Promise<number> {
   const stats = await aggregate(readAll(config.agents));
 
   if (stats.tokens === 0) {
-    warn("No usage found. Run `tokencard init` to see which agents were detected.");
+    warn("No usage found. Run `tokenstats init` to see which agents were detected.");
     return 1;
   }
 
@@ -112,11 +112,11 @@ export async function sync(argv: string[]): Promise<number> {
 
   say();
   say(dim("  Embed it:"));
-  say(`  ![tokencard](./${rel})`);
+  say(`  ![tokenstats](./${rel})`);
   say();
   // Committing on the user's behalf is not ours to decide — a tool that reads your logs
   // should not also decide what lands in your history on its first run.
-  say(dim(`  Then: git add ${rel} && git commit -m "chore: update tokencard"`));
+  say(dim(`  Then: git add ${rel} && git commit -m "chore: update tokenstats"`));
   say();
 
   return 0;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,9 +1,9 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
-import type { AgentId, Layout, Theme } from "@tokencard/core";
+import type { AgentId, Layout, Theme } from "@tokenstats/core";
 
-export const CONFIG_FILE = ".tokencard.json";
+export const CONFIG_FILE = ".tokenstats.json";
 
 export type Config = {
   /** GitHub handle shown on the card. */
@@ -19,7 +19,7 @@ export type Config = {
 export const DEFAULT_CONFIG: Config = {
   handle: "",
   agents: [],
-  output: "tokencard.svg",
+  output: "tokenstats.svg",
   layout: "default",
   theme: "auto",
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,29 +9,29 @@ import { sync } from "./commands/sync.js";
 import { bold, dim, fail, muteSqliteWarning, say } from "./ui.js";
 
 const USAGE = `
-${bold("tokencard")} — turn your local AI coding agent logs into a stat card
+${bold("tokenstats")} — turn your local AI coding agent logs into a stat card
 
-  ${bold("tokencard init")}              detect agents, write .tokencard.json
+  ${bold("tokenstats init")}              detect agents, write .tokenstats.json
     --handle <name>            GitHub handle (default: guessed from origin remote)
 
-  ${bold("tokencard sync")}              render the card into your repo
-    --out <path>               where to write it (default: tokencard.svg)
+  ${bold("tokenstats sync")}              render the card into your repo
+    --out <path>               where to write it (default: tokenstats.svg)
     --layout default|compact
     --theme auto|light|dark
     --json                     print the aggregate instead of writing an SVG
     --dry-run                  report what would be written, write nothing
 
-  ${bold("tokencard login")}             prove your GitHub handle (device flow, no password)
-  ${bold("tokencard logout")}            forget this machine
-  ${bold("tokencard whoami")}            who this machine is signed in as
+  ${bold("tokenstats login")}             prove your GitHub handle (device flow, no password)
+  ${bold("tokenstats logout")}            forget this machine
+  ${bold("tokenstats whoami")}            who this machine is signed in as
 
-  ${bold("tokencard publish")}           the only command that uploads anything
+  ${bold("tokenstats publish")}           the only command that uploads anything
     --dry-run                  print the exact bytes and send nothing
-    --api <url>                default https://tokencard-site.vercel.app
+    --api <url>                default https://tokenstats-site.vercel.app
     --handle <name>
 
-  ${bold("tokencard recap")}             year in review: heatmap, models, totals
-    --out <path>               default: tokencard-recap.svg
+  ${bold("tokenstats recap")}             year in review: heatmap, models, totals
+    --out <path>               default: tokenstats-recap.svg
     --year <yyyy>              label the recap with a different year
     --theme auto|light|dark
     --json                     print the recap model instead of writing an SVG

--- a/packages/cli/src/net.ts
+++ b/packages/cli/src/net.ts
@@ -6,7 +6,7 @@
  * scanning the source for network calls outside this file. Keeping the surface to one small
  * module is what makes that claim checkable rather than aspirational.
  *
- * Nothing here is imported unless `tokencard publish` runs.
+ * Nothing here is imported unless `tokenstats publish` runs.
  */
 
 export type PostResult = {
@@ -84,7 +84,7 @@ export async function postForm(
       headers: {
         "content-type": "application/x-www-form-urlencoded",
         accept: "application/json",
-        "user-agent": "tokencard-cli",
+        "user-agent": "tokenstats-cli",
       },
       body: new URLSearchParams(fields).toString(),
       signal: controller.signal,

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -21,7 +21,7 @@ export const fail = (s: string) => process.stderr.write(`${red("✗")} ${s}\n`);
 
 /**
  * Node 22 prints an ExperimentalWarning the first time `node:sqlite` loads. It is true but
- * not actionable by the person running `tokencard sync`, and it lands in the middle of the
+ * not actionable by the person running `tokenstats sync`, and it lands in the middle of the
  * output. Every other warning is re-emitted so nothing real is swallowed.
  */
 export function muteSqliteWarning(): void {

--- a/packages/cli/test/auth.test.js
+++ b/packages/cli/test/auth.test.js
@@ -16,8 +16,8 @@ const SRC = join(HERE, "..", "src");
 const FIXTURE_HOME = join(HERE, "fixtures", "home");
 
 async function sandbox() {
-  const home = await mkdtemp(join(tmpdir(), "tokencard-home-"));
-  const cwd = await mkdtemp(join(tmpdir(), "tokencard-cwd-"));
+  const home = await mkdtemp(join(tmpdir(), "tokenstats-home-"));
+  const cwd = await mkdtemp(join(tmpdir(), "tokenstats-cwd-"));
   return { home, cwd };
 }
 
@@ -32,7 +32,7 @@ test("credentials live outside the repo, never in the committed config", async (
 
   // init writes the file that gets committed. It must never gain a credential field.
   await cli(["init", "--handle", "octocat"], { ...box, home: FIXTURE_HOME });
-  const config = JSON.parse(await readFile(join(box.cwd, ".tokencard.json"), "utf8"));
+  const config = JSON.parse(await readFile(join(box.cwd, ".tokenstats.json"), "utf8"));
 
   assert.deepEqual(
     Object.keys(config).sort(),
@@ -57,7 +57,7 @@ test("the auth file is owner-only and lives under the config directory", async (
   });
 
   assert.equal(path, authFile());
-  assert.ok(path.includes(join(".config", "tokencard")), `unexpected location: ${path}`);
+  assert.ok(path.includes(join(".config", "tokenstats")), `unexpected location: ${path}`);
 
   // 0600. A world-readable credential on a shared machine is the same as no credential.
   const mode = (await stat(path)).mode & 0o777;

--- a/packages/cli/test/privacy.test.js
+++ b/packages/cli/test/privacy.test.js
@@ -24,9 +24,9 @@ const CORE_SRC = join(HERE, "..", "..", "core", "src");
 
 /** Run the CLI in a sandbox whose HOME contains only the fixture transcripts. */
 async function cli(args, extraEnv = {}) {
-  const cwd = await mkdtemp(join(tmpdir(), "tokencard-test-"));
+  const cwd = await mkdtemp(join(tmpdir(), "tokenstats-test-"));
   await writeFile(
-    join(cwd, ".tokencard.json"),
+    join(cwd, ".tokenstats.json"),
     JSON.stringify({ handle: "canary", agents: ["claude-code"], output: "c.svg", layout: "default", theme: "auto" }),
   );
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@tokencard/core",
+  "name": "@tokenstats/core",
   "version": "0.1.0",
-  "description": "Local agent-log adapters, usage aggregation and the tokencard SVG builder.",
+  "description": "Local agent-log adapters, usage aggregation and the tokenstats SVG builder.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/scripts/refresh-prices.mjs
+++ b/packages/core/scripts/refresh-prices.mjs
@@ -2,7 +2,7 @@
 /**
  * Regenerate `src/prices.json` from LiteLLM's public price map.
  *
- * Run by a maintainer, never by the CLI. tokencard's whole claim is that it reads local
+ * Run by a maintainer, never by the CLI. tokenstats's whole claim is that it reads local
  * files and talks to nobody, so the price table ships vendored — a card must render the
  * same on a plane as it does online, and a pricing lookup at sync time would be a network
  * call users did not ask for.

--- a/packages/core/src/adapters/unsupported.ts
+++ b/packages/core/src/adapters/unsupported.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 /**
  * Agents we can detect but cannot total.
  *
- * These are reported by `tokencard init` rather than quietly omitted. A user with Copilot
+ * These are reported by `tokenstats init` rather than quietly omitted. A user with Copilot
  * CLI installed will otherwise assume detection is broken, and the honest answer — the data
  * simply is not written to disk — is more useful than silence. If either tool starts
  * recording cumulative usage, these become real adapters.

--- a/packages/core/src/card-svg.ts
+++ b/packages/core/src/card-svg.ts
@@ -376,7 +376,7 @@ export function buildCardSvg(opts: CardOptions): string {
     render({
       tag: "text",
       attrs: { ...cls("ft"), x: g.footer.left, y: g.footer.y, ...footAttrs },
-      text: "TOKENCARD.DEV",
+      text: "TOKENSTATS.APP",
     }),
   );
   parts.push(
@@ -398,7 +398,7 @@ export function buildCardSvg(opts: CardOptions): string {
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${g.w} ${g.h}" ` +
     `width="${g.w}" height="${g.h}" role="img" ` +
-    `aria-label="tokencard stats for @${esc(handle)}">` +
+    `aria-label="tokenstats stats for @${esc(handle)}">` +
     style +
     parts.join("") +
     `</svg>`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * Isomorphic entry point: the card builder, the price table and the aggregation, none of
  * which touch the filesystem.
  *
- * The adapters live behind `@tokencard/core/adapters` precisely because they import
+ * The adapters live behind `@tokenstats/core/adapters` precisely because they import
  * `node:fs` and `node:sqlite`. Re-exporting them here would drag Node built-ins into the
  * site's client bundle the moment a component imports `buildCardSvg`, which is exactly what
  * happened the first time this was one barrel.

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -12,7 +12,7 @@ export type Price = {
 
 const PRICES = table.prices as Record<string, Price>;
 
-/** The day the vendored table was generated, for `tokencard sync --json` and the docs. */
+/** The day the vendored table was generated, for `tokenstats sync --json` and the docs. */
 export const PRICES_GENERATED: string = table.$generated;
 
 /**

--- a/packages/core/src/recap-svg.ts
+++ b/packages/core/src/recap-svg.ts
@@ -274,7 +274,7 @@ export function buildRecapSvg(opts: RecapCardOptions): string {
     render({
       tag: "text",
       attrs: { ...cls("ft"), x: PAD, y: H - 14, "font-family": FONT, "font-size": 8, "letter-spacing": 1, fill: pal.footer },
-      text: "TOKENCARD.DEV",
+      text: "TOKENSTATS.APP",
     }),
   );
   parts.push(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,7 +26,7 @@ export type Detection = "ready" | "installed-no-data" | "absent";
 
 export type Adapter = {
   id: AgentId;
-  /** Display name, as it appears on the card and in `tokencard init`. */
+  /** Display name, as it appears on the card and in `tokenstats init`. */
   name: string;
   /** Where this adapter reads from, shown by `init` so nothing is hidden. */
   source: string;


### PR DESCRIPTION
`tokencard` was blocked from several directions at once: the bare npm name is a
2018 tombstone npm never lets anyone reuse, `github.com/tokencard` is an existing
crypto org, and both `tokencard.dev` and `tokencard.app` are registered.

## The thing worth knowing

While checking alternatives I found **`@tokencard` was not available either.**

```
registry.npmjs.org/-/org/angular/user     200   (real org, control)
registry.npmjs.org/-/org/zzqxwvnope/user  404   (control)
registry.npmjs.org/-/org/tokencard/user   200   ← owned
registry.npmjs.org/-/org/tokenstats/user  404   ← free
```

The scoped fallback this repo already depended on **would have failed on publish
day.** I had checked whether the *package* `@tokencard/cli` existed (404) and not
whether the *scope* was claimable — different endpoint, different answer.

## Where it lands

```
npm      @tokenstats/cli, @tokenstats/core
github   iyashjayesh/tokenstats
domain   tokenstats.app, once bought
```

Deliberately no GitHub org: a solo project doesn't need one, and requiring a free
org name was over-constraining the search.

## What did not move, and why

**`SITE_URL` and the CLI's `DEFAULT_API` still point at the existing Vercel host**,
because that is the host that answers. A default that doesn't resolve breaks
`publish` for everyone who doesn't pass `--api` — the exact mistake this rename
exists to stop repeating. Renaming the Vercel project changes those two strings;
buying the domain replaces them. They are the only two places that must be true
rather than aspirational, and each says so in a comment.

The **`TOKENSTATS.APP` wordmark** on the card and recap *does* move now — it is a
signature at 8px, not a link, so it can lead the domain rather than trail it.

**`design_handoff_tokencard_site/` and `docs/research.md` are untouched.** Rewriting
a design handoff and a dated research report to say something they never said is not
a rename. Code that references the handoff path still points at the real directory.

## Two bugs this turned up in my own work

- My rename script used `lstrip('./')`, which strips the leading dot from
  `.github/...`, so `open()` failed and a `try/except` swallowed it. **CI was
  silently skipped** and still named `--workspace=tokencard-site`, a workspace that
  no longer exists. That would have failed on the first run.
- The script's extension list omitted `.js`, so the test files kept the old config
  filename and four tests failed until I caught it.

## Verified

40 tests pass, all three packages build, and the CI steps were run locally exactly
as the workflow does them — including the standalone site build with
`packages/core/dist` deleted. `npm pack --dry-run` produces `tokenstats-cli-0.1.0.tgz`
and `tokenstats-core-0.1.0.tgz`.

Local state is carried across rather than orphaned: `.tokencard.json` →
`.tokenstats.json`, `~/.config/tokencard` → `~/.config/tokenstats`. An existing
session keeps working — `whoami` and `publish --dry-run` both still do.
