### PR TITLE
Prepare both packages for npm

### DIFF
--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yash Chauhan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,78 @@
+# @tokenstats/cli
+
+Turn your local AI coding agent logs into an embeddable stat card for your GitHub README.
+
+Reads the transcripts **Claude Code**, **Codex** and **OpenCode** already write to your disk,
+totals them, and renders an SVG you commit to your own repo. No account, no upload, no server
+— the card is a file.
+
+```bash
+npx @tokenstats/cli init     # detect agents, write .tokenstats.json
+npx @tokenstats/cli sync     # render tokenstats.svg
+```
+
+```markdown
+![tokenstats](./tokenstats.svg)
+```
+
+## What it reads
+
+| Agent | Source |
+| --- | --- |
+| Claude Code | `~/.claude/projects/**/*.jsonl` |
+| Codex | `~/.codex/sessions/**/rollout-*.jsonl` |
+| OpenCode | `~/.local/share/opencode/opencode.db` |
+
+**Copilot CLI and Gemini CLI are detected but cannot be counted.** Copilot records only a
+live context-window gauge, never a cumulative total; Gemini's chat transcripts carry no token
+counts at all. `init` says so out loud rather than silently omitting them.
+
+Nothing but token counts, model ids and timestamps is read. No prompts, no completions, no
+file contents, and no paths — not hashed, not truncated, absent.
+
+## Commands
+
+```
+tokenstats init            detect agents, write .tokenstats.json
+  --handle <name>          GitHub handle (default: guessed from your origin remote)
+
+tokenstats sync            render the card
+  --out <path>             default: tokenstats.svg
+  --layout default|compact
+  --theme auto|light|dark
+  --json                   print the aggregate instead of writing an SVG
+  --dry-run
+
+tokenstats recap           year in review: heatmap, models, totals
+  --out <path>             default: tokenstats-recap.svg
+  --year <yyyy>
+
+tokenstats login           prove your GitHub handle (device flow, no password)
+tokenstats logout
+tokenstats whoami
+
+tokenstats publish         the only command that uploads anything
+  --dry-run                print the exact bytes and send nothing
+  --api <url>
+```
+
+## Equivalent API cost is not spend
+
+The dollar figure is **what your tokens would cost at list API rates** — not what you paid.
+Most agent usage runs under a subscription where no per-token charge ever happens. Models
+with no public price are counted in the token total and left out of the cost, and `sync`
+tells you what share of tokens the figure covers.
+
+## Publishing is opt-in
+
+`sync` and `recap` are local forever. `publish` is the only command that sends anything, and
+there is deliberately no config switch to change that: `.tokenstats.json` is a committed
+file, and a committed file must never be able to cause a network call on someone else's
+machine.
+
+`--dry-run` prints the exact bytes that would be uploaded — the same string, not a rendering
+of it, which a test in this package enforces by comparing against what a real publish puts on
+the wire.
+
+Requires Node 22 or newer. MIT licensed. Source, issues and the full documentation:
+[github.com/iyashjayesh/tokenstats](https://github.com/iyashjayesh/tokenstats).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,24 +2,50 @@
   "name": "@tokenstats/cli",
   "version": "0.1.0",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
+  "keywords": [
+    "tokens",
+    "usage",
+    "claude-code",
+    "codex",
+    "opencode",
+    "ai-agents",
+    "cli",
+    "readme-badge",
+    "leaderboard"
+  ],
   "license": "MIT",
+  "author": "Yash Chauhan (https://github.com/iyashjayesh)",
+  "homepage": "https://github.com/iyashjayesh/tokenstats#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iyashjayesh/tokenstats.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/iyashjayesh/tokenstats/issues"
+  },
   "type": "module",
   "bin": {
     "tokenstats": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "engines": {
     "node": ">=22"
   },
-  "dependencies": {
-    "@tokenstats/core": "0.1.0"
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "test": "node --test test/*.test.js"
+    "test": "node --test test/*.test.js",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@tokenstats/core": "0.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yash Chauhan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,63 @@
+# @tokenstats/core
+
+The engine behind [`@tokenstats/cli`](https://www.npmjs.com/package/@tokenstats/cli): local
+agent-log adapters, usage aggregation, a vendored price table, and the SVG builders for the
+stat card and the year-in-review recap.
+
+Published so the website and the CLI render through one copy — a card built here looks
+identical wherever it is drawn. Most people want the CLI, not this.
+
+```bash
+npm install @tokenstats/core
+```
+
+## Two entry points
+
+```ts
+// Isomorphic: no filesystem, safe in a browser bundle.
+import { buildCardSvg, buildRecapSvg, aggregate, buildRecap,
+         formatTokens, formatUsd, validatePayload } from "@tokenstats/core";
+
+// Node only: reads local agent logs.
+import { adapters, readAll, claudeCode, codex, opencode } from "@tokenstats/core/adapters";
+```
+
+The split is deliberate. The adapters import `node:fs` and `node:sqlite`; re-exporting them
+from the main entry would drag Node built-ins into any web bundle that imports the card
+builder, which is exactly how the first deploy of the site broke.
+
+## Example
+
+```ts
+import { aggregate, buildCardSvg, formatTokens, formatUsd } from "@tokenstats/core";
+import { readAll } from "@tokenstats/core/adapters";
+
+const stats = await aggregate(readAll());
+
+const svg = buildCardSvg({
+  handle: "octocat",
+  tokens: formatTokens(stats.tokens),
+  spend: formatUsd(stats.equivCostUsd),
+  streak: `${stats.streakDays}d`,
+  mix: stats.mix,
+  syncedAt: new Date(),
+});
+```
+
+## Things worth knowing
+
+- **Claude Code repeats messages across session files.** The adapter deduplicates on
+  `(message.id, requestId)`. On a real 298 MB corpus, 11,499 usage rows collapse to 6,185
+  distinct messages — skipping this nearly doubles every figure.
+- **Codex reports running totals**, not per-turn deltas. Each session file contributes its
+  final cumulative value; summing the events overcounts by orders of magnitude.
+- **Days are bucketed by local date**, not UTC, so a streak is not broken for anyone whose
+  evening sessions land on the next UTC day.
+- **Prices are vendored**, never fetched. The card renders the same on a plane as online.
+- `costOf` returns `null` for models with no public price. Callers must exclude them from a
+  cost figure rather than treat them as free.
+
+Requires Node 22 or newer — the OpenCode adapter uses the built-in `node:sqlite`.
+
+MIT licensed. Source and issues:
+[github.com/iyashjayesh/tokenstats](https://github.com/iyashjayesh/tokenstats).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,28 @@
   "name": "@tokenstats/core",
   "version": "0.1.0",
   "description": "Local agent-log adapters, usage aggregation and the tokenstats SVG builder.",
+  "keywords": [
+    "tokens",
+    "usage",
+    "claude-code",
+    "codex",
+    "opencode",
+    "ai-agents",
+    "svg",
+    "readme-badge",
+    "cli"
+  ],
   "license": "MIT",
+  "author": "Yash Chauhan (https://github.com/iyashjayesh)",
+  "homepage": "https://github.com/iyashjayesh/tokenstats#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iyashjayesh/tokenstats.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/iyashjayesh/tokenstats/issues"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -17,15 +38,20 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "engines": {
     "node": ">=22"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
-    "test": "node --test test/*.test.js"
+    "test": "node --test test/*.test.js",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
Everything needed before `npm publish`, verified by packing and installing rather than by
reading the manifest.

## What was actually broken

- **Neither package would have shipped a README or a licence.** npm packs only the package
  directory, so the repo-root copies never reach the tarball — both would have published
  with a blank page and no licence text.
- **No `publishConfig`.** Scoped packages default to `restricted`, which fails outright on a
  free account. Relying on remembering `--access public` at the prompt is a trap; it is set
  in the manifest now.
- Missing everything npm renders on a package page: keywords, repository, homepage, bugs,
  author.
- **Sourcemaps pointed nowhere.** The build emits `.js.map` and `.d.ts.map` referencing
  `src`, which `files` excluded. A sourcemap that resolves to nothing is worse than none, so
  `src` ships alongside `dist`.
- `prepublishOnly` now builds, so a stale `dist` cannot be published.

## Verified by installing, not by inspection

```
npm pack both → install into an empty project → run it

✓ wrote .tokenstats.json (3 agents)
  4.36B tokens · $2,877 equiv. API cost · 10d streak · 37 active days
✓ wrote tokenstats.svg (2830 bytes)
✓ wrote tokenstats-recap.svg (17944 bytes)
  core entry OK: true 1.23B
```

The bin resolves, `init`/`sync`/`recap` all work, and the isomorphic entry imports cleanly
without dragging in `node:fs`.

```
@tokenstats/core   65.7 kB packed, 90 files
@tokenstats/cli    31.3 kB packed, 63 files
```

40 tests still pass.

## Publish order matters

`@tokenstats/cli` depends on `@tokenstats/core@0.1.0` exactly, so **core publishes first** or
the CLI install resolves nothing.
