### PR TITLE
Add release automation and widen CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Grouped and monthly on purpose: a solo open-source project does not want a pull request
+  # per patch bump, and an unreviewed dependency PR sitting open is worse than a slightly
+  # older dependency.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      all:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,33 +5,35 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  build:
+  test:
+    name: test (node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 22 is the floor the packages declare. 24 is here because the OpenCode adapter uses
+        # node:sqlite, which is experimental on 22 and stable on 24 — the exact place the two
+        # are most likely to disagree, and a disagreement would be silent without this.
+        node: [22, 24]
+
     steps:
       - uses: actions/checkout@v4
 
-      # Node 22 is the floor: the OpenCode adapter uses the built-in node:sqlite.
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node }}
           cache: npm
 
       - run: npm ci
 
-      # Builds core, then the CLI, then the site. The site build is what catches a Node
-      # built-in leaking into the client bundle through @tokenstats/core.
+      # Builds core, then the CLI, then the site.
       - run: npm run build
 
       - run: npm test
-
-      # Vercel builds apps/site on its own, with no root build to create
-      # packages/core/dist first. That is exactly how the first deploy failed, so the
-      # site has to be buildable from its own directory in a clean tree.
-      - name: Site builds standalone, as Vercel builds it
-        run: |
-          rm -rf packages/core/dist
-          npm run build --workspace=tokenstats-site
 
       # The card is the product; a builder that renders nothing should fail the run.
       - name: Card renders
@@ -46,8 +48,8 @@ jobs:
             console.log('card renders,', svg.length, 'bytes');
           "
 
-      # Every adapter must survive a machine with no agent logs at all — the state a CI
-      # runner is in, and the state a new user's laptop may be in.
+      # Every adapter must survive a machine with no agent logs at all — the state a runner
+      # is in, and the state a new user's laptop may be in.
       - name: Adapters degrade on a bare machine
         run: |
           node --input-type=module -e "
@@ -59,3 +61,47 @@ jobs:
               console.log(a.id, state, n, 'events');
             }
           "
+
+      # The tarball is what people actually install, and it is a different artifact from the
+      # working tree: a wrong `files`, `exports` or `bin` only shows up here.
+      - name: Packed tarballs install and run
+        run: |
+          mkdir -p /tmp/packtest
+          # Packed from the repo, installed somewhere else. `npm pack <dir> --workspace`
+          # packs the root package instead of the workspace, which quietly tests nothing.
+          npm pack -w @tokenstats/core --pack-destination /tmp/packtest
+          npm pack -w @tokenstats/cli  --pack-destination /tmp/packtest
+          cd /tmp/packtest && npm init -y >/dev/null
+          npm install ./tokenstats-core-*.tgz ./tokenstats-cli-*.tgz >/dev/null
+          ./node_modules/.bin/tokenstats --version
+          node --input-type=module -e "
+            import { buildCardSvg } from '@tokenstats/core';
+            if (typeof buildCardSvg !== 'function') throw new Error('core entry point broken');
+            console.log('installed package resolves');
+          "
+
+  site:
+    name: site
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm run lint -w tokenstats-site
+
+      # Vercel builds apps/site on its own, with no root build to create
+      # packages/core/dist first. That is exactly how the first deploy failed, so the site
+      # has to be buildable from its own directory in a clean tree.
+      - name: Site builds standalone, as Vercel builds it
+        run: |
+          rm -rf packages/core/dist
+          npm run build --workspace=tokenstats-site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: release
+
+# Tag-driven rather than push-driven: publishing is irreversible on npm — an unpublished
+# name can never be reused by anyone — so it should take a deliberate act, not a merge.
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for npm provenance: the published package carries a signed attestation
+      # linking it to this repository, this workflow and this commit.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      # A tag that disagrees with package.json publishes something nobody asked for, and it
+      # cannot be taken back. Checked before anything is built.
+      - name: Tag matches package versions
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          for pkg in packages/core packages/cli; do
+            version=$(node -p "require('./$pkg/package.json').version")
+            if [ "$version" != "$tag" ]; then
+              echo "::error::$pkg is $version but the tag says $tag — run scripts/version.mjs"
+              exit 1
+            fi
+          done
+          echo "all packages at $tag"
+
+      - run: npm run build
+      - run: npm test
+      - run: npm run lint -w tokenstats-site
+
+      # Core first: the CLI depends on an exact core version, so publishing them the other
+      # way round leaves a CLI on the registry that installs nothing.
+      - name: Publish @tokenstats/core
+        run: npm publish -w @tokenstats/core --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @tokenstats/cli
+        run: npm publish -w @tokenstats/cli --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Release notes
+        run: |
+          {
+            echo "## Published"
+            echo
+            echo '```'
+            echo "npx @tokenstats/cli@${GITHUB_REF_NAME#v} init"
+            echo '```'
+            echo
+            echo "- [@tokenstats/cli](https://www.npmjs.com/package/@tokenstats/cli)"
+            echo "- [@tokenstats/core](https://www.npmjs.com/package/@tokenstats/core)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -221,6 +221,30 @@ Profile pages are shareable, so they carry a PNG `og:image` rendered from the sa
 file-based `opengraph-image` convention and the page would then advertise the SVG card, which
 Twitter, Slack and Facebook all decline to render.
 
+## Releasing
+
+CI runs on every pull request: build and tests on Node 22 **and** 24 (the OpenCode adapter
+uses `node:sqlite`, experimental on 22 and stable on 24 — the place they are most likely to
+disagree), plus lint, the standalone site build Vercel performs, and an install of the packed
+tarballs, because the tarball is a different artifact from the working tree.
+
+Publishing is tag-driven, never merge-driven — an unpublished npm name can never be reused by
+anyone, so it should take a deliberate act:
+
+```bash
+npm run version:set 0.2.0   # both packages, and the dependency between them
+npm install
+git commit -am "Release v0.2.0"
+git tag v0.2.0
+git push --follow-tags
+```
+
+The workflow refuses to publish if the tag disagrees with `package.json`, publishes core
+before the CLI (which depends on an exact core version), and attaches npm provenance so the
+package carries a signed link back to the commit that produced it.
+
+Requires an `NPM_TOKEN` repository secret with publish rights.
+
 ## Repo layout
 
 ```

--- a/apps/site/app/u/[handle]/opengraph-image.tsx
+++ b/apps/site/app/u/[handle]/opengraph-image.tsx
@@ -26,8 +26,6 @@ export const alt = "tokenstats profile";
 const INK = "#101010";
 const PAPER = "#FFFDF9";
 const LIME = "#C6FF3D";
-const CORAL = "#FF5C3D";
-const YELLOW = "#FFD23D";
 const DIM = "#8A8A82";
 
 const SEGMENT_COLOURS = [LIME, INK, "#8A8A82", "#D8D6CE"];

--- a/apps/site/components/leaderboard.tsx
+++ b/apps/site/components/leaderboard.tsx
@@ -34,30 +34,35 @@ export function Leaderboard({ initialRows, initialWindow }: {
   const { handle } = useSiteState();
   const [activeWindow, setActiveWindow] = useState<BoardWindow>(initialWindow);
   const [rows, setRows] = useState<BoardRow[]>(initialRows);
-  const [stale, setStale] = useState(false);
+  // Which window the rows on screen actually belong to. `stale` is derived from it rather
+  // than kept as its own state: setting state synchronously inside an effect triggers a
+  // second render pass before the browser paints.
+  const [loadedWindow, setLoadedWindow] = useState<BoardWindow>(initialWindow);
+  const stale = loadedWindow !== activeWindow;
 
   useEffect(() => {
-    if (activeWindow === initialWindow) return;
+    if (activeWindow === loadedWindow) return;
 
     let cancelled = false;
-    setStale(true);
 
     fetch(`/api/submissions?window=${activeWindow}`)
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(String(res.status)))))
       .then((data: { rows: BoardRow[] }) => {
-        if (!cancelled) setRows(data.rows);
+        if (cancelled) return;
+        setRows(data.rows);
+        setLoadedWindow(activeWindow);
       })
       // A board that fails to load should leave the previous window on screen rather than
-      // replace real figures with an error. The dimming stops, so it stops looking pending.
-      .catch(() => {})
-      .finally(() => {
-        if (!cancelled) setStale(false);
+      // replace real figures with an error. Marking it loaded stops the dimming, so it stops
+      // looking pending.
+      .catch(() => {
+        if (!cancelled) setLoadedWindow(activeWindow);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [activeWindow, initialWindow]);
+  }, [activeWindow, loadedWindow]);
 
   return (
     <section id="board" className={styles.section}>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev": "npm run dev -w tokenstats-site",
     "test": "npm run build:core && npm run build -w @tokenstats/cli && npm run test -w @tokenstats/core && npm run test -w @tokenstats/cli",
     "cli": "node packages/cli/dist/index.js",
-    "db:migrate": "node apps/site/db/migrate.mjs"
+    "db:migrate": "node apps/site/db/migrate.mjs",
+    "version:set": "node scripts/version.mjs"
   }
 }

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Set both package versions, and the dependency between them, in one step.
+ *
+ *   node scripts/version.mjs 0.2.0
+ *
+ * The CLI depends on an exact core version, so bumping them separately is how you publish a
+ * CLI that resolves a core which does not exist yet. Doing both here means they cannot
+ * disagree, and the release workflow refuses to publish when the tag does not match.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version)) {
+  console.error("usage: node scripts/version.mjs <major.minor.patch>");
+  process.exit(1);
+}
+
+for (const file of ["packages/core/package.json", "packages/cli/package.json"]) {
+  const pkg = JSON.parse(await readFile(file, "utf8"));
+  pkg.version = version;
+  if (pkg.dependencies?.["@tokenstats/core"]) {
+    pkg.dependencies["@tokenstats/core"] = version;
+  }
+  await writeFile(file, `${JSON.stringify(pkg, null, 2)}\n`);
+  console.log(`${pkg.name} -> ${version}`);
+}
+
+console.log(`\nnext:\n  npm install\n  git commit -am "Release v${version}"\n  git tag v${version}\n  git push --follow-tags`);


### PR DESCRIPTION
CD already existed via Vercel; CI ran build and tests. This adds the missing half —
npm releases — and widens CI to cover things it was blind to.

## Releases are tag-driven, not merge-driven

An unpublished npm name can never be reused by anyone. That is what killed `tokencard`, so
publishing should take a deliberate act rather than following from a merge.

```bash
npm run version:set 0.2.0   # both packages, and the dependency between them
npm install
git commit -am "Release v0.2.0" && git tag v0.2.0 && git push --follow-tags
```

The workflow:

- **refuses to publish if the tag disagrees with `package.json`** — a mismatch ships
  something nobody asked for, and it cannot be taken back
- **publishes core before the CLI**, which depends on an exact core version; the other order
  leaves a CLI on the registry that installs nothing
- attaches **npm provenance**, so the package carries a signed link to the commit that made it

`scripts/version.mjs` sets both versions *and* the dependency between them at once — bumping
them separately is exactly how you publish a CLI pointing at a core that does not exist yet.

## CI now covers two blind spots

**Node 22 and 24.** The OpenCode adapter uses `node:sqlite`, experimental on 22 and stable on
24 — the one place the two are most likely to differ, and a difference would have stayed
silent until a user hit it.

**The packed tarballs get installed and run.** The tarball is a different artifact from the
working tree; a wrong `files`, `exports` or `bin` shows up nowhere else.

Writing that step turned up its own bug: `npm pack <dir> --workspace <name>` packs the **root**
package rather than the workspace, so my first version produced `tokenstats-0.0.0.tgz`, tested
nothing, and would have reported success. Caught by running it locally instead of trusting it.

## Lint joins CI, which meant fixing what it found

Gating on a failing check is worse than no check, so:

- **The board called `setState` synchronously inside an effect**, triggering a cascading
  render before paint. The staleness flag is now derived from which window the visible rows
  belong to, which is both correct React and simpler.
- Two unused colour constants in the OG image.

## Dependabot

Monthly and grouped. A solo project does not want a PR per patch bump, and an unreviewed
dependency PR sitting open is worse than a slightly older dependency.

## One thing you must add

The release workflow needs an **`NPM_TOKEN` repository secret** with publish rights. Until
then, tagging runs everything and fails at the publish step — nothing is half-published,
because the version guard, build, tests and lint all run first.
