### PR TITLE
Rename to tokenchit, and fix two bugs that halved the reported tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,13 @@ jobs:
         run: |
           mkdir -p /tmp/packtest
           # Packed from the repo, installed somewhere else, with nothing else available.
-          # @tokenstats/core is private and bundled in, so this proves the tarball is
+          # @tokenchit/core is private and bundled in, so this proves the tarball is
           # genuinely self-contained rather than quietly resolving the workspace copy.
-          npm pack -w @tokenstats/cli --pack-destination /tmp/packtest
+          npm pack -w @tokenchit/cli --pack-destination /tmp/packtest
           cd /tmp/packtest && npm init -y >/dev/null
-          npm install ./tokenstats-cli-*.tgz
-          ./node_modules/.bin/tokenstats --version
-          test "$(ls node_modules/@tokenstats)" = "cli" \
+          npm install ./tokenchit-cli-*.tgz
+          ./node_modules/.bin/tokenchit --version
+          test "$(ls node_modules/@tokenchit)" = "cli" \
             || { echo "::error::tarball is not self-contained"; exit 1; }
 
   site:
@@ -93,7 +93,7 @@ jobs:
 
       - run: npm run build
 
-      - run: npm run lint -w tokenstats-site
+      - run: npm run lint -w tokenchit-site
 
       # Vercel builds apps/site on its own, with no root build to create
       # packages/core/dist first. That is exactly how the first deploy failed, so the site
@@ -101,4 +101,4 @@ jobs:
       - name: Site builds standalone, as Vercel builds it
         run: |
           rm -rf packages/core/dist
-          npm run build --workspace=tokenstats-site
+          npm run build --workspace=tokenchit-site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,19 +33,33 @@ jobs:
           tag="${GITHUB_REF_NAME#v}"
           version=$(node -p "require('./packages/cli/package.json').version")
           if [ "$version" != "$tag" ]; then
-            echo "::error::@tokenstats/cli is $version but the tag says $tag — run npm run version:set"
+            echo "::error::@tokenchit/cli is $version but the tag says $tag — run npm run version:set"
             exit 1
           fi
-          echo "@tokenstats/cli at $tag"
+          echo "@tokenchit/cli at $tag"
+
+      # npm provenance attaches a signed attestation pointing at the source commit, which
+      # requires a public repository. Publishing --provenance from a private repo fails with
+      # a message that does not obviously say so, and by then the tag already exists.
+      - name: Repository is public (required for provenance)
+        run: |
+          private=$(gh api "repos/$GITHUB_REPOSITORY" -q .private)
+          if [ "$private" = "true" ]; then
+            echo "::error::$GITHUB_REPOSITORY is private; npm provenance requires a public repo."
+            echo "::error::Make it public, or drop --provenance from this workflow."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - run: npm run build
       - run: npm test
-      - run: npm run lint -w tokenstats-site
+      - run: npm run lint -w tokenchit-site
 
-      # One package. @tokenstats/core is private and bundled into this tarball by esbuild,
+      # One package. @tokenchit/core is private and bundled into this tarball by esbuild,
       # so there is nothing to publish first and no ordering to get wrong.
-      - name: Publish @tokenstats/cli
-        run: npm publish -w @tokenstats/cli --provenance
+      - name: Publish @tokenchit/cli
+        run: npm publish -w @tokenchit/cli --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -55,8 +69,8 @@ jobs:
             echo "## Published"
             echo
             echo '```'
-            echo "npx @tokenstats/cli@${GITHUB_REF_NAME#v} init"
+            echo "npx @tokenchit/cli@${GITHUB_REF_NAME#v} init"
             echo '```'
             echo
-            echo "- [@tokenstats/cli](https://www.npmjs.com/package/@tokenstats/cli)"
+            echo "- [@tokenchit/cli](https://www.npmjs.com/package/@tokenchit/cli)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.tokenchit.json
+++ b/.tokenchit.json
@@ -5,7 +5,7 @@
     "codex",
     "opencode"
   ],
-  "output": "tokenstats.svg",
+  "output": "tokenchit.svg",
   "layout": "default",
   "theme": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# tokenstats
+# tokenchit
 
 Turn your local AI coding agent logs into an embeddable stat card for your GitHub README.
 
-tokenstats reads the transcripts **Claude Code**, **Codex** and **OpenCode** already write to
+tokenchit reads the transcripts **Claude Code**, **Codex** and **OpenCode** already write to
 your disk, totals them, and renders an SVG you commit to your own repo. No account, no
 upload, no server — the card is a file.
 
 ```bash
-npx @tokenstats/cli init     # detect agents, write .tokenstats.json
-npx @tokenstats/cli sync     # render tokenstats.svg
-npx @tokenstats/cli recap    # render tokenstats-recap.svg — the year in review
+npx @tokenchit/cli init     # detect agents, write .tokenchit.json
+npx @tokenchit/cli sync     # render tokenchit.svg
+npx @tokenchit/cli recap    # render tokenchit-recap.svg — the year in review
 ```
 
 ```markdown
-![tokenstats](./tokenstats.svg)
-![tokenstats recap](./tokenstats-recap.svg)
+![tokenchit](./tokenchit.svg)
+![tokenchit recap](./tokenchit-recap.svg)
 ```
 
 ## What it reads
@@ -24,6 +24,24 @@ npx @tokenstats/cli recap    # render tokenstats-recap.svg — the year in revie
 | Claude Code | `~/.claude/projects/**/*.jsonl` |
 | Codex | `~/.codex/sessions/**/rollout-*.jsonl` |
 | OpenCode | `~/.local/share/opencode/opencode.db` |
+
+All Claude Code configuration directories are read, not just `~/.claude`. Anyone with more
+than one account has several — `~/.claude-work`, `~/.claude-personal` and so on — and reading
+only the first silently omitted most of the usage. `CLAUDE_CONFIG_DIR` is added to that scan
+rather than replacing it: it names the directory the *current* session uses, which is a
+different question from where all your usage lives.
+
+### Why the total differs from Claude Code's Stats panel
+
+**Claude Code deletes old transcripts.** Its own Stats panel reads a cumulative
+`stats-cache.json` that survives the cleanup, so it reports a lifetime figure. tokenchit
+parses the transcripts themselves, so it can only report the retention window — on the
+machine this was measured on, the caches went back to June while the oldest surviving
+transcript was late July.
+
+That is a real limitation, not a bug: a number derived from logs cannot include logs that no
+longer exist. It also means the figure only ever shrinks toward the truth as history ages out,
+never inflates.
 
 **Copilot CLI and Gemini CLI are detected but cannot be counted.** Copilot records only a
 live context-window gauge, never a cumulative total; Gemini's chat transcripts carry no token
@@ -51,27 +69,27 @@ a network request.
 ## Commands
 
 ```
-tokenstats init
+tokenchit init
   --handle <name>        GitHub handle (default: guessed from your origin remote)
 
-tokenstats sync
-  --out <path>           where to write it (default: tokenstats.svg)
+tokenchit sync
+  --out <path>           where to write it (default: tokenchit.svg)
   --layout default|compact
   --theme auto|light|dark
   --json                 print the aggregate instead of writing an SVG
   --dry-run              report what would be written, write nothing
 
-tokenstats login          prove your GitHub handle (device flow, no password)
-tokenstats logout         forget this machine
-tokenstats whoami         who this machine is signed in as
+tokenchit login          prove your GitHub handle (device flow, no password)
+tokenchit logout         forget this machine
+tokenchit whoami         who this machine is signed in as
 
-tokenstats publish        the only command that uploads anything
+tokenchit publish        the only command that uploads anything
   --dry-run              print the exact bytes and send nothing
-  --api <url>            default https://tokenstats-site.vercel.app
+  --api <url>            default https://tokenchit-site.vercel.app
   --handle <name>
 
-tokenstats recap
-  --out <path>           default: tokenstats-recap.svg
+tokenchit recap
+  --out <path>           default: tokenchit-recap.svg
   --year <yyyy>          label the recap with a different year
   --theme auto|light|dark
   --json                 print the recap model instead of writing an SVG
@@ -106,7 +124,7 @@ turn. Claude Code and OpenCode are exact to the message.
 ## Publishing to the board
 
 `publish` is the **only** command that sends anything anywhere. `sync` and `recap` are local
-forever, and there is deliberately no config switch to change that: `.tokenstats.json` is a
+forever, and there is deliberately no config switch to change that: `.tokenchit.json` is a
 committed file, and a committed file must never be able to cause a network call on somebody
 else's machine.
 
@@ -118,7 +136,7 @@ and model ids. No prompts, no replies, no branch names, no paths.
 ## Signing in
 
 ```
-$ tokenstats login
+$ tokenchit login
   Open https://github.com/login/device
   and enter  WDJB-MJHT
 ✓ signed in as @octocat
@@ -134,8 +152,8 @@ and numeric id are all we need.
 The GitHub token is handed to the server **once**, so that the server — not the client — is
 what asks GitHub who you are; a client that simply asserted `{"handle": "octocat"}` would be
 forgeable. It is then discarded, never written to disk on either side. What you keep is a
-tokenstats API key in `~/.config/tokenstats/auth.json`, mode `0600`, stored server-side only as
-a SHA-256 hash. Never in `.tokenstats.json`, which is committed.
+tokenchit API key in `~/.config/tokenchit/auth.json`, mode `0600`, stored server-side only as
+a SHA-256 hash. Never in `.tokenchit.json`, which is committed.
 
 Without signing in, submissions land as the unverified `cli` tier. Those rows appear on the
 board with a badge rather than being hidden — a transparency signal, not a gate. Signing in
@@ -151,8 +169,8 @@ cp apps/site/.env.example apps/site/.env.local   # then fill in the password
 npm run db:migrate                               # idempotent; safe to re-run
 npm run dev
 
-npx @tokenstats/cli login   --api http://localhost:3000
-npx @tokenstats/cli publish --api http://localhost:3000
+npx @tokenchit/cli login   --api http://localhost:3000
+npx @tokenchit/cli publish --api http://localhost:3000
 ```
 
 `.env.local` is gitignored; `apps/site/.env.example` documents the shape. Next reads
@@ -228,7 +246,7 @@ uses `node:sqlite`, experimental on 22 and stable on 24 — the place they are m
 disagree), plus lint, the standalone site build Vercel performs, and an install of the packed
 tarballs, because the tarball is a different artifact from the working tree.
 
-**One published package.** `@tokenstats/core` stays a workspace package — it is what keeps
+**One published package.** `@tokenchit/core` stays a workspace package — it is what keeps
 the site and the CLI rendering the same card — but it is `private` and esbuild inlines it
 into the CLI's single bundled file. Publishing a second package would mean maintaining a
 public API surface nobody has asked for, and every rename inside it would become a
@@ -248,7 +266,7 @@ git push --follow-tags
 The workflow refuses to publish if the tag disagrees with `package.json`, and attaches npm
 provenance so the package carries a signed link back to the commit that produced it. CI
 installs the packed tarball into an empty project on every pull request and asserts nothing
-but `@tokenstats/cli` lands, which is what stops the bundle silently regressing into a broken
+but `@tokenchit/cli` lands, which is what stops the bundle silently regressing into a broken
 dependency on the private package.
 
 Requires an `NPM_TOKEN` repository secret with publish rights.
@@ -258,7 +276,7 @@ Requires an `NPM_TOKEN` repository secret with publish rights.
 ```
 apps/site/          Next.js marketing site + the board API
 packages/core/      adapters, aggregation, price table, SVG builder
-packages/cli/       the tokenstats binary
+packages/cli/       the tokenchit binary
 docs/research.md    positioning, competitive landscape, infrastructure decisions
 ```
 

--- a/apps/site/app/api/auth/github/route.ts
+++ b/apps/site/app/api/auth/github/route.ts
@@ -8,7 +8,7 @@ import { clientIp, hit, limitHeaders, LIMITS } from "@/lib/rate-limit";
 export const dynamic = "force-dynamic";
 
 /**
- * Exchange a GitHub access token for a tokenstats API key.
+ * Exchange a GitHub access token for a tokenchit API key.
  *
  * The identity check happens **here**, not in the CLI. A client that simply posted
  * `{ handle: "octocat" }` would be trivially forgeable, so the server takes the GitHub token
@@ -45,7 +45,7 @@ export async function POST(req: Request) {
       headers: {
         authorization: `Bearer ${githubToken}`,
         accept: "application/vnd.github+json",
-        "user-agent": "tokenstats",
+        "user-agent": "tokenchit",
       },
       cache: "no-store",
     });

--- a/apps/site/app/api/card/[handle]/route.ts
+++ b/apps/site/app/api/card/[handle]/route.ts
@@ -5,7 +5,7 @@ import {
   type HideKey,
   type Layout,
   type Theme,
-} from "@tokenstats/core";
+} from "@tokenchit/core";
 import { OWN_STATS } from "@/lib/sample-data";
 
 /** Cache window printed on the card. Clamped 4h–24h, same as the rest of the genre. */

--- a/apps/site/app/api/submissions/route.ts
+++ b/apps/site/app/api/submissions/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { validatePayload, type Payload } from "@tokenstats/core";
+import { validatePayload, type Payload } from "@tokenchit/core";
 
 import { userFromRequest } from "@/lib/auth";
 import { DEFAULT_WINDOW, isWindow } from "@/lib/board";

--- a/apps/site/app/board/page.tsx
+++ b/apps/site/app/board/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
-import { formatTokens, formatUsd } from "@tokenstats/core";
+import { formatTokens, formatUsd } from "@tokenchit/core";
 
 import { PageShell } from "@/components/page-shell";
 import { isWindow, WINDOWS, type BoardWindow } from "@/lib/board";
@@ -13,7 +13,7 @@ import styles from "./board.module.css";
 export const revalidate = 300;
 
 export const metadata: Metadata = {
-  title: "The board · tokenstats",
+  title: "The board · tokenchit",
   description: "Public ranking of developers who chose to publish their AI coding agent usage.",
 };
 
@@ -51,7 +51,7 @@ export default async function BoardPage({
       </header>
 
       <p className={styles.intro}>
-        Everyone who ran <span className={styles.strong}>tokenstats publish</span>. Rank is
+        Everyone who ran <span className={styles.strong}>tokenchit publish</span>. Rank is
         total tokens over the selected window, and every column — cost, agent mix — covers
         that same window. It is a usage count, not a skill score.
       </p>
@@ -82,7 +82,7 @@ export default async function BoardPage({
       {rows.length === 0 ? (
         <p className={styles.empty}>
           Nobody has published in this window yet.{" "}
-          <span className={styles.strong}>npx @tokenstats/cli publish</span> and the board is
+          <span className={styles.strong}>npx @tokenchit/cli publish</span> and the board is
           yours.
         </p>
       ) : (

--- a/apps/site/app/globals.css
+++ b/apps/site/app/globals.css
@@ -1,5 +1,5 @@
 /* ── Design tokens ──────────────────────────────────────────────────────────
-   Source: design_handoff_tokenstats_site/README.md § Design tokens.
+   Source: design_handoff_tokenchit_site/README.md § Design tokens.
    Border radius is 0 everywhere. Shadows are hard offsets only (Npx Npx 0 c). */
 :root {
   --ink: #101010;

--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -25,9 +25,9 @@ export const metadata: Metadata = {
   // shared from production would advertise a localhost preview image whenever the page was
   // rendered anywhere but the live host.
   metadataBase: new URL(SITE_URL),
-  title: "tokenstats — receipts for your robots",
+  title: "tokenchit — receipts for your robots",
   description:
-    "tokenstats reads your local Claude Code, Codex and OpenCode logs and renders one embeddable card straight into your repo.",
+    "tokenchit reads your local Claude Code, Codex and OpenCode logs and renders one embeddable card straight into your repo.",
 };
 
 export default function RootLayout({

--- a/apps/site/app/not-found.tsx
+++ b/apps/site/app/not-found.tsx
@@ -18,7 +18,7 @@ export default function NotFound() {
         <h1 className={styles.h1}>Nothing here.</h1>
         <p className={styles.body}>
           If you were looking for someone&apos;s stats, they may not have published yet — a
-          profile only exists once <span className={styles.strong}>tokenstats publish</span>{" "}
+          profile only exists once <span className={styles.strong}>tokenchit publish</span>{" "}
           has run at least once. Handles are case-insensitive, so that is not it.
         </p>
 
@@ -27,11 +27,11 @@ export default function NotFound() {
             see the board
           </Link>
           <Link href="/" className={styles.secondary}>
-            what is tokenstats?
+            what is tokenchit?
           </Link>
         </div>
 
-        <code className={styles.install}>npx @tokenstats/cli init</code>
+        <code className={styles.install}>npx @tokenchit/cli init</code>
       </div>
     </PageShell>
   );

--- a/apps/site/app/u/[handle]/opengraph-image.tsx
+++ b/apps/site/app/u/[handle]/opengraph-image.tsx
@@ -3,14 +3,14 @@ import { join } from "node:path";
 
 import { ImageResponse } from "next/og";
 
-import { formatTokens, formatUsd, sanitizeHandle } from "@tokenstats/core";
+import { formatTokens, formatUsd, sanitizeHandle } from "@tokenchit/core";
 
 import { readProfile } from "@/lib/profile";
 
 export const runtime = "nodejs";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
-export const alt = "tokenstats profile";
+export const alt = "tokenchit profile";
 
 /**
  * The link preview for a shared profile.
@@ -127,7 +127,7 @@ export default async function Image({ params }: { params: Promise<{ handle: stri
 
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
           <div style={{ display: "flex", fontSize: 26, color: INK, fontWeight: 700 }}>
-            tokenstats
+            tokenchit
           </div>
           <div style={{ display: "flex", fontSize: 22, color: DIM }}>
             {profile

--- a/apps/site/app/u/[handle]/page.tsx
+++ b/apps/site/app/u/[handle]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { buildCardSvg, formatTokens, formatUsd, sanitizeHandle } from "@tokenstats/core";
+import { buildCardSvg, formatTokens, formatUsd, sanitizeHandle } from "@tokenchit/core";
 
 import { ContributionGraph } from "@/components/contribution-graph";
 import { CopyButton } from "@/components/copy-button";
@@ -24,14 +24,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const handle = sanitizeHandle(decodeURIComponent((await params).handle));
   const profile = await readProfile(handle).catch(() => null);
 
-  if (!profile) return { title: "Not found · tokenstats" };
+  if (!profile) return { title: "Not found · tokenchit" };
 
   const summary = `${formatTokens(profile.tokens)} tokens across ${profile.activeDays} active days`;
   return {
-    title: `@${profile.handle} · tokenstats`,
+    title: `@${profile.handle} · tokenchit`,
     description: summary,
     openGraph: {
-      title: `@${profile.handle} · tokenstats`,
+      title: `@${profile.handle} · tokenchit`,
       description: summary,
       url: `${SITE_URL}/u/${profile.handle}`,
       // No `images` here on purpose: setting it overrides the file-based opengraph-image
@@ -68,7 +68,7 @@ export default async function ProfilePage({ params, searchParams }: Props) {
   });
 
   const embed =
-    `[![tokenstats](${SITE_URL}/api/card/${profile.handle}.svg)]` +
+    `[![tokenchit](${SITE_URL}/api/card/${profile.handle}.svg)]` +
     `(${SITE_URL}/u/${profile.handle})`;
 
   const tiles: [string, string][] = [
@@ -105,7 +105,7 @@ export default async function ProfilePage({ params, searchParams }: Props) {
         {profile.lastPublished
           ? `Last published ${profile.lastPublished.slice(0, 10)}.`
           : "Never published."}{" "}
-        Figures are self-reported by the tokenstats CLI from local agent logs.
+        Figures are self-reported by the tokenchit CLI from local agent logs.
       </p>
 
       <nav className={styles.windows} aria-label="Time window">
@@ -219,7 +219,7 @@ export default async function ProfilePage({ params, searchParams }: Props) {
             <code className={styles.embedCode}>{embed}</code>
             <p className={styles.embedNote}>
               This renders live from the endpoint. To commit the file instead — no request to
-              us at all — run <span className={styles.strong}>tokenstats sync</span> and add the
+              us at all — run <span className={styles.strong}>tokenchit sync</span> and add the
               SVG to your repo.
             </p>
           </div>

--- a/apps/site/components/card-section.tsx
+++ b/apps/site/components/card-section.tsx
@@ -3,7 +3,7 @@
 import { CopyButton } from "@/components/copy-button";
 import { SectionHeading } from "@/components/section-heading";
 import { useSiteState } from "@/components/site-state";
-import { buildCardSvg } from "@tokenstats/core";
+import { buildCardSvg } from "@tokenchit/core";
 import { DEFAULT_HANDLE, OWN_STATS, QUERY_OPTIONS } from "@/lib/sample-data";
 import { SITE_URL } from "@/lib/site";
 import styles from "./card-section.module.css";
@@ -19,10 +19,10 @@ export function CardSection() {
   const { handle } = useSiteState();
 
   // Linked to the profile: every embedded card is a door back to the site, which is the
-  // whole growth loop. The plain-image form is still what `tokenstats sync` prints, because
+  // whole growth loop. The plain-image form is still what `tokenchit sync` prints, because
   // a committed SVG has no hosted page to guarantee.
   const markdown =
-    `[![tokenstats](${SITE_URL}/api/card/${handle}.svg)](${SITE_URL}/u/${handle})`;
+    `[![tokenchit](${SITE_URL}/api/card/${handle}.svg)](${SITE_URL}/u/${handle})`;
 
   /* The panel shows the origin elided so the two tags fit without scrolling; the
      clipboard gets the full URLs, which is what a README actually needs. */

--- a/apps/site/components/contribution-graph.tsx
+++ b/apps/site/components/contribution-graph.tsx
@@ -1,4 +1,4 @@
-import { formatTokens, quantise, RAMP, scaleOf } from "@tokenstats/core";
+import { formatTokens, quantise, RAMP, scaleOf } from "@tokenchit/core";
 
 import styles from "./contribution-graph.module.css";
 

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -5,9 +5,9 @@ import { StatCard } from "./stat-card";
 import { useSiteState } from "./site-state";
 import styles from "./hero.module.css";
 
-// Scoped, because the bare `tokenstats` name on npm is a 2018 tombstone: it was published
+// Scoped, because the bare `tokenchit` name on npm is a 2018 tombstone: it was published
 // and unpublished within a fortnight, and npm never lets an unpublished name be reused.
-const INSTALL = "npx @tokenstats/cli init";
+const INSTALL = "npx @tokenchit/cli init";
 
 export function Hero() {
   const { handle, setHandle } = useSiteState();
@@ -28,7 +28,7 @@ export function Hero() {
         </h1>
 
         <p className={styles.lede}>
-          tokenstats reads your local Claude Code, Codex and OpenCode logs and renders one
+          tokenchit reads your local Claude Code, Codex and OpenCode logs and renders one
           embeddable card straight into your repo. Nothing is uploaded — the card is a file
           you commit.
         </p>

--- a/apps/site/components/leaderboard.tsx
+++ b/apps/site/components/leaderboard.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 
 import { SectionHeading } from "@/components/section-heading";
 import { useSiteState } from "@/components/site-state";
-import { formatTokens, formatUsd } from "@tokenstats/core";
+import { formatTokens, formatUsd } from "@tokenchit/core";
 import type { BoardRow } from "@/lib/board";
 import { WINDOWS, type BoardWindow } from "@/lib/board";
 import styles from "./leaderboard.module.css";
@@ -72,7 +72,7 @@ export function Leaderboard({ initialRows, initialWindow }: {
 
       <p className={styles.intro}>
         Public ranking of developers who chose to publish. Run{" "}
-        <span className={styles.strong}>tokenstats publish</span> and you are on it. Stop
+        <span className={styles.strong}>tokenchit publish</span> and you are on it. Stop
         publishing and your row goes stale, then falls out of the window on its own.
       </p>
 
@@ -92,7 +92,7 @@ export function Leaderboard({ initialRows, initialWindow }: {
       {rows.length === 0 ? (
         <p className={styles.empty}>
           Nobody has published in this window yet.{" "}
-          <span className={styles.strong}>npx @tokenstats/cli publish</span> and the board is
+          <span className={styles.strong}>npx @tokenchit/cli publish</span> and the board is
           yours.
         </p>
       ) : (

--- a/apps/site/components/recap.tsx
+++ b/apps/site/components/recap.tsx
@@ -21,7 +21,7 @@ export function Recap() {
     <section id="recap" className={styles.section}>
       <SectionHeading n={5} title="Year in review" tone="coral" />
       <p className={styles.intro}>
-        <code>tokenstats recap</code> renders this as a second committable SVG. Same
+        <code>tokenchit recap</code> renders this as a second committable SVG. Same
         data, no card constraints.
       </p>
 

--- a/apps/site/components/site-footer.tsx
+++ b/apps/site/components/site-footer.tsx
@@ -1,8 +1,8 @@
 import styles from "./site-footer.module.css";
 
 const LINKS = [
-  { label: "github.com/iyashjayesh/tokenstats", href: "https://github.com/iyashjayesh/tokenstats" },
-  { label: "npm / @tokenstats/cli", href: "https://npmjs.com/package/@tokenstats/cli" },
+  { label: "github.com/iyashjayesh/tokenchit", href: "https://github.com/iyashjayesh/tokenchit" },
+  { label: "npm / @tokenchit/cli", href: "https://npmjs.com/package/@tokenchit/cli" },
   { label: "the board", href: "/board" },
 ];
 
@@ -17,7 +17,7 @@ export function SiteFooter() {
             </a>
           ))}
         </div>
-        <div className={styles.legal}>MIT License · © 2026 tokenstats contributors</div>
+        <div className={styles.legal}>MIT License · © 2026 tokenchit contributors</div>
       </div>
     </footer>
   );

--- a/apps/site/components/site-header.tsx
+++ b/apps/site/components/site-header.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { GithubMark } from "./github-mark";
 import styles from "./site-header.module.css";
 
-const LOGIN = "npx @tokenstats/cli login";
+const LOGIN = "npx @tokenchit/cli login";
 
 // Root-relative, not bare fragments: these render on /u/<handle> and /board too, where a
 // bare "#card" points at an anchor that does not exist on the page.
@@ -48,7 +48,7 @@ export function SiteHeader() {
   return (
     <header className={styles.header}>
       <div className={styles.brand}>
-        <span className={styles.wordmark}>tokenstats</span>
+        <span className={styles.wordmark}>tokenchit</span>
         <span className={styles.version}>v0.4.1 · MIT</span>
       </div>
 

--- a/apps/site/components/site-state.tsx
+++ b/apps/site/components/site-state.tsx
@@ -18,7 +18,7 @@ import { DEFAULT_HANDLE, sanitizeHandle } from "@/lib/sample-data";
  * local to their own components and deliberately not in here.
  *
  * Handle only. There was a `signedIn` flag here driving a header pill, but nothing ever
- * set it from a real session — identity is established by `tokenstats login` in the terminal,
+ * set it from a real session — identity is established by `tokenchit login` in the terminal,
  * and the site has no per-user surface for a browser session to unlock.
  *
  * hosted endpoint and opts into the public board — wire this seam to a real GitHub

--- a/apps/site/components/stat-card.tsx
+++ b/apps/site/components/stat-card.tsx
@@ -52,7 +52,7 @@ export function StatCard() {
       </div>
 
       <div className={styles.footer}>
-        <span>TOKENSTATS.APP</span>
+        <span>TOKENCHIT.APP</span>
         <span>{OWN_STATS.syncedAt}</span>
       </div>
     </div>

--- a/apps/site/db/migrations/002_auth.sql
+++ b/apps/site/db/migrations/002_auth.sql
@@ -7,7 +7,7 @@ CREATE TABLE api_tokens (
   user_id      bigint      NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   -- SHA-256 of the token. A database leak must not hand out working credentials.
   token_hash   text        NOT NULL UNIQUE,
-  -- Shown in `tokenstats whoami` so a user can tell two machines apart before revoking one.
+  -- Shown in `tokenchit whoami` so a user can tell two machines apart before revoking one.
   label        text        NOT NULL DEFAULT 'cli',
   created_at   timestamptz NOT NULL DEFAULT now(),
   last_used_at timestamptz

--- a/apps/site/lib/db.ts
+++ b/apps/site/lib/db.ts
@@ -6,20 +6,20 @@ import pg from "pg";
  * Next's dev server re-evaluates modules on every edit; without the global, each reload
  * would leak a pool and Postgres would run out of connections within a few saves.
  */
-const globalForDb = globalThis as unknown as { tokenstatsPool?: pg.Pool };
+const globalForDb = globalThis as unknown as { tokenchitPool?: pg.Pool };
 
 export const pool: pg.Pool =
-  globalForDb.tokenstatsPool ??
+  globalForDb.tokenchitPool ??
   new pg.Pool({
     connectionString:
-      process.env["DATABASE_URL"] ?? "postgres://tokenstats:tokenstats@localhost:5432/tokenstats",
+      process.env["DATABASE_URL"] ?? "postgres://tokenchit:tokenchit@localhost:5432/tokenchit",
     // A leaderboard write is short; a connection held open longer than this is a bug.
     connectionTimeoutMillis: 5_000,
     idleTimeoutMillis: 30_000,
     max: 5,
   });
 
-if (process.env.NODE_ENV !== "production") globalForDb.tokenstatsPool = pool;
+if (process.env.NODE_ENV !== "production") globalForDb.tokenchitPool = pool;
 
 /** Run `fn` inside a transaction, rolling back on any throw. */
 export async function transaction<T>(fn: (client: pg.PoolClient) => Promise<T>): Promise<T> {

--- a/apps/site/lib/sample-data.ts
+++ b/apps/site/lib/sample-data.ts
@@ -121,7 +121,7 @@ export const PEAK_MASK = Array.from({ length: 24 }, (_, i) =>
 );
 
 /** Re-exported so components have one import for placeholder data and handle rules alike. */
-export { sanitizeHandle } from "@tokenstats/core";
+export { sanitizeHandle } from "@tokenchit/core";
 
 /**
  * Year-in-review tiles. Kept separate from OWN_STATS because the recap page has no

--- a/apps/site/lib/site.ts
+++ b/apps/site/lib/site.ts
@@ -2,12 +2,12 @@
  * The site's own public origin, used wherever the page hands someone a URL to copy.
  *
  * One constant because these strings end up in other people's READMEs: a stale one there is
- * a broken image on a repo we do not control and cannot fix. When tokenstats.dev is attached,
+ * a broken image on a repo we do not control and cannot fix. When tokenchit.dev is attached,
  * change it here and in packages/cli/src/api.ts — those two are the only places that must be
  * true rather than aspirational.
  *
- * The `TOKENSTATS.APP` wordmark printed on the card itself is deliberately not driven by this.
+ * The `TOKENCHIT.APP` wordmark printed on the card itself is deliberately not driven by this.
  * It is a signature at 8px, not a link, and a vercel.app subdomain would neither fit the
  * design nor read as a brand.
  */
-export const SITE_URL = "https://tokenstats-site.vercel.app";
+export const SITE_URL = "https://tokenchit.vercel.app";

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tokenstats-site",
+  "name": "tokenchit-site",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -11,7 +11,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@tokenstats/core": "0.1.0",
+    "@tokenchit/core": "0.1.0",
     "next": "16.3.4",
     "pg": "^8.23.0",
     "react": "19.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tokenstats",
+  "name": "tokenchit",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tokenstats",
+      "name": "tokenchit",
       "version": "0.0.0",
       "license": "MIT",
       "workspaces": [
@@ -17,10 +17,10 @@
       }
     },
     "apps/site": {
-      "name": "tokenstats-site",
+      "name": "tokenchit-site",
       "version": "0.1.0",
       "dependencies": {
-        "@tokenstats/core": "0.1.0",
+        "@tokenchit/core": "0.1.0",
         "next": "16.3.4",
         "pg": "^8.23.0",
         "react": "19.2.8",
@@ -1776,11 +1776,11 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@tokenstats/cli": {
+    "node_modules/@tokenchit/cli": {
       "resolved": "packages/cli",
       "link": true
     },
-    "node_modules/@tokenstats/core": {
+    "node_modules/@tokenchit/core": {
       "resolved": "packages/core",
       "link": true
     },
@@ -6366,7 +6366,7 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tokenstats-site": {
+    "node_modules/tokenchit-site": {
       "resolved": "apps/site",
       "link": true
     },
@@ -6817,17 +6817,11 @@
       }
     },
     "packages/cli": {
-      "name": "@tokenstats/cli",
+      "name": "@tokenchit/cli",
       "version": "0.1.0",
-      "bundleDependencies": [
-        "@tokenstats/core"
-      ],
       "license": "MIT",
-      "dependencies": {
-        "@tokenstats/core": "0.1.0"
-      },
       "bin": {
-        "tokenstats": "dist/index.js"
+        "tokenchit": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -6849,7 +6843,7 @@
       }
     },
     "packages/core": {
-      "name": "@tokenstats/core",
+      "name": "@tokenchit/core",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tokenstats",
+  "name": "tokenchit",
   "version": "0.0.0",
   "private": true,
   "description": "Turn your local AI coding agent logs into an embeddable stat card.",
@@ -12,10 +12,10 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "npm run build -w @tokenstats/core && npm run build -w @tokenstats/cli && npm run build -w tokenstats-site",
-    "build:core": "npm run build -w @tokenstats/core",
-    "dev": "npm run dev -w tokenstats-site",
-    "test": "npm run build:core && npm run build -w @tokenstats/cli && npm run test -w @tokenstats/core && npm run test -w @tokenstats/cli",
+    "build": "npm run build -w @tokenchit/core && npm run build -w @tokenchit/cli && npm run build -w tokenchit-site",
+    "build:core": "npm run build -w @tokenchit/core",
+    "dev": "npm run dev -w tokenchit-site",
+    "test": "npm run build:core && npm run build -w @tokenchit/cli && npm run test -w @tokenchit/core && npm run test -w @tokenchit/cli",
     "cli": "node packages/cli/dist/index.js",
     "db:migrate": "node apps/site/db/migrate.mjs",
     "version:set": "node scripts/version.mjs"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,4 +1,4 @@
-# @tokenstats/cli
+# @tokenchit/cli
 
 Turn your local AI coding agent logs into an embeddable stat card for your GitHub README.
 
@@ -7,12 +7,12 @@ totals them, and renders an SVG you commit to your own repo. No account, no uplo
 — the card is a file.
 
 ```bash
-npx @tokenstats/cli init     # detect agents, write .tokenstats.json
-npx @tokenstats/cli sync     # render tokenstats.svg
+npx @tokenchit/cli init     # detect agents, write .tokenchit.json
+npx @tokenchit/cli sync     # render tokenchit.svg
 ```
 
 ```markdown
-![tokenstats](./tokenstats.svg)
+![tokenchit](./tokenchit.svg)
 ```
 
 ## What it reads
@@ -33,25 +33,25 @@ file contents, and no paths — not hashed, not truncated, absent.
 ## Commands
 
 ```
-tokenstats init            detect agents, write .tokenstats.json
+tokenchit init            detect agents, write .tokenchit.json
   --handle <name>          GitHub handle (default: guessed from your origin remote)
 
-tokenstats sync            render the card
-  --out <path>             default: tokenstats.svg
+tokenchit sync            render the card
+  --out <path>             default: tokenchit.svg
   --layout default|compact
   --theme auto|light|dark
   --json                   print the aggregate instead of writing an SVG
   --dry-run
 
-tokenstats recap           year in review: heatmap, models, totals
-  --out <path>             default: tokenstats-recap.svg
+tokenchit recap           year in review: heatmap, models, totals
+  --out <path>             default: tokenchit-recap.svg
   --year <yyyy>
 
-tokenstats login           prove your GitHub handle (device flow, no password)
-tokenstats logout
-tokenstats whoami
+tokenchit login           prove your GitHub handle (device flow, no password)
+tokenchit logout
+tokenchit whoami
 
-tokenstats publish         the only command that uploads anything
+tokenchit publish         the only command that uploads anything
   --dry-run                print the exact bytes and send nothing
   --api <url>
 ```
@@ -66,7 +66,7 @@ tells you what share of tokens the figure covers.
 ## Publishing is opt-in
 
 `sync` and `recap` are local forever. `publish` is the only command that sends anything, and
-there is deliberately no config switch to change that: `.tokenstats.json` is a committed
+there is deliberately no config switch to change that: `.tokenchit.json` is a committed
 file, and a committed file must never be able to cause a network call on someone else's
 machine.
 
@@ -75,4 +75,4 @@ of it, which a test in this package enforces by comparing against what a real pu
 the wire.
 
 Requires Node 22 or newer. MIT licensed. Source, issues and the full documentation:
-[github.com/iyashjayesh/tokenstats](https://github.com/iyashjayesh/tokenstats).
+[github.com/iyashjayesh/tokenchit](https://github.com/iyashjayesh/tokenchit).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tokenstats/cli",
+  "name": "@tokenchit/cli",
   "version": "0.1.0",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
@@ -15,18 +15,18 @@
   ],
   "license": "MIT",
   "author": "Yash Chauhan (https://github.com/iyashjayesh)",
-  "homepage": "https://github.com/iyashjayesh/tokenstats#readme",
+  "homepage": "https://github.com/iyashjayesh/tokenchit#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iyashjayesh/tokenstats.git",
+    "url": "git+https://github.com/iyashjayesh/tokenchit.git",
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/iyashjayesh/tokenstats/issues"
+    "url": "https://github.com/iyashjayesh/tokenchit/issues"
   },
   "type": "module",
   "bin": {
-    "tokenstats": "./dist/index.js"
+    "tokenchit": "./dist/index.js"
   },
   "files": [
     "dist"

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,16 +1,16 @@
 /**
  * Where the CLI talks to, unless told otherwise.
  *
- * Points at the Vercel URL rather than tokenstats.dev because the domain is not attached yet
+ * Points at the Vercel URL rather than tokenchit.dev because the domain is not attached yet
  * and a default that does not resolve makes `publish` fail for everyone who does not pass
  * `--api`. Swap this the day the domain is live; the site's own copy already says
- * tokenstats.dev, and this is the one place that has to be true rather than aspirational.
+ * tokenchit.dev, and this is the one place that has to be true rather than aspirational.
  *
  * Defined once because it was previously duplicated across login and publish, which is how
  * two defaults end up disagreeing.
  */
-export const DEFAULT_API = "https://tokenstats-site.vercel.app";
+export const DEFAULT_API = "https://tokenchit.vercel.app";
 
 /** Resolve the API base: explicit flag, then environment, then the default. */
 export const resolveApi = (flagValue: string | undefined): string =>
-  (flagValue ?? process.env["TOKENSTATS_API"] ?? DEFAULT_API).replace(/\/$/, "");
+  (flagValue ?? process.env["TOKENCHIT_API"] ?? DEFAULT_API).replace(/\/$/, "");

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -3,15 +3,15 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 /**
- * Where the tokenstats API key lives.
+ * Where the tokenchit API key lives.
  *
- * Deliberately not `.tokenstats.json` — that file is committed. Credentials belong in the
+ * Deliberately not `.tokenchit.json` — that file is committed. Credentials belong in the
  * user's config directory, on their machine, and nowhere a `git add -A` can reach.
  */
 const authPath = (): string =>
   join(
     process.env["XDG_CONFIG_HOME"] ?? join(homedir(), ".config"),
-    "tokenstats",
+    "tokenchit",
     "auth.json",
   );
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,8 +1,8 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-import { type AgentId } from "@tokenstats/core";
-import { adapters, unsupported } from "@tokenstats/core/adapters";
+import { type AgentId } from "@tokenchit/core";
+import { adapters, unsupported } from "@tokenchit/core/adapters";
 
 import { flag } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig, writeConfig, type Config } from "../config.js";
@@ -78,11 +78,11 @@ export async function init(argv: string[]): Promise<number> {
 
   if (!handle) {
     say();
-    warn(`No handle set. Add one to ${CONFIG_FILE}, or run: tokenstats init --handle <you>`);
+    warn(`No handle set. Add one to ${CONFIG_FILE}, or run: tokenchit init --handle <you>`);
   }
 
   say();
-  say(`  Next: ${bold("tokenstats sync")}`);
+  say(`  Next: ${bold("tokenchit sync")}`);
   say();
 
   return 0;

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -9,7 +9,7 @@ import { bold, dim, fail, green, say, warn } from "../ui.js";
  * to ship an OAuth client inside a CLI that anybody can read. Overridable so the flow can be
  * pointed at a throwaway app during development.
  */
-const CLIENT_ID = process.env["TOKENSTATS_CLIENT_ID"] ?? "Ov23liSMxVycJS63ZqN5";
+const CLIENT_ID = process.env["TOKENCHIT_CLIENT_ID"] ?? "Ov23liSMxVycJS63ZqN5";
 
 const DEVICE_CODE_URL = "https://github.com/login/device/code";
 const TOKEN_URL = "https://github.com/login/oauth/access_token";
@@ -33,8 +33,8 @@ export async function login(argv: string[]): Promise<number> {
   if (existing && !argv.includes("--force")) {
     say();
     say(`Already signed in as ${bold(`@${existing.handle}`)} ${dim(`(${existing.api})`)}`);
-    say(dim("  tokenstats login --force   sign in again"));
-    say(dim("  tokenstats logout          forget this machine"));
+    say(dim("  tokenchit login --force   sign in again"));
+    say(dim("  tokenchit logout          forget this machine"));
     say();
     return 0;
   }
@@ -84,7 +84,7 @@ export async function login(argv: string[]): Promise<number> {
       continue;
     }
     if (error === "expired_token") {
-      fail("The code expired. Run `tokenstats login` again.");
+      fail("The code expired. Run `tokenchit login` again.");
       return 1;
     }
     if (error === "access_denied") {
@@ -141,7 +141,7 @@ export async function login(argv: string[]): Promise<number> {
   }
 
   say();
-  say(`  Next: ${bold("tokenstats publish")} ${dim("— your rows will be marked verified")}`);
+  say(`  Next: ${bold("tokenchit publish")} ${dim("— your rows will be marked verified")}`);
   say();
 
   return 0;
@@ -156,7 +156,7 @@ export async function logout(): Promise<number> {
 export async function whoami(): Promise<number> {
   const auth = await readAuth();
   if (!auth) {
-    say("Not signed in. Run `tokenstats login`.");
+    say("Not signed in. Run `tokenchit login`.");
     return 1;
   }
   say(`@${auth.handle} ${dim(`· ${auth.api} · since ${auth.createdAt.slice(0, 10)}`)}`);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -4,8 +4,8 @@ import {
   sanitizeHandle,
   serializePayload,
   validatePayload,
-} from "@tokenstats/core";
-import { readAll } from "@tokenstats/core/adapters";
+} from "@tokenchit/core";
+import { readAll } from "@tokenchit/core/adapters";
 
 import { resolveApi } from "../api.js";
 import { flag, has } from "../args.js";
@@ -19,7 +19,7 @@ import { post } from "../net.js";
  * The only command that sends anything anywhere.
  *
  * Kept separate from `sync` on purpose, and with no config switch to make `sync` do it:
- * `.tokenstats.json` is a committed file, and a committed file must never be able to cause a
+ * `.tokenchit.json` is a committed file, and a committed file must never be able to cause a
  * network call on somebody else's machine.
  */
 export async function publish(argv: string[], version: string): Promise<number> {
@@ -40,7 +40,7 @@ export async function publish(argv: string[], version: string): Promise<number> 
 
   const stats = await aggregate(readAll(config.agents));
   if (stats.tokens === 0) {
-    warn("No usage found. Run `tokenstats init` to see which agents were detected.");
+    warn("No usage found. Run `tokenchit init` to see which agents were detected.");
     return 1;
   }
 
@@ -88,7 +88,7 @@ export async function publish(argv: string[], version: string): Promise<number> 
   if ((res.body?.tier ?? "cli") === "cli" && !auth) {
     say();
     say(dim("  This row is marked unverified on the board — nothing has proved the handle"));
-    say(dim("  is yours. Run `tokenstats login` to upgrade it."));
+    say(dim("  is yours. Run `tokenchit login` to upgrade it."));
   }
   say();
 

--- a/packages/cli/src/commands/recap.ts
+++ b/packages/cli/src/commands/recap.ts
@@ -7,8 +7,8 @@ import {
   buildRecapSvg,
   sanitizeHandle,
   type Theme,
-} from "@tokenstats/core";
-import { readAll } from "@tokenstats/core/adapters";
+} from "@tokenchit/core";
+import { readAll } from "@tokenchit/core/adapters";
 
 import { flag, has, oneOf } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
@@ -25,7 +25,7 @@ export async function recap(argv: string[]): Promise<number> {
   const rawHandle = flag(argv, "--handle") ?? config.handle;
   const handle = sanitizeHandle(rawHandle);
   const theme = oneOf(flag(argv, "--theme"), THEMES, "theme") ?? config.theme;
-  const out = flag(argv, "--out") ?? "tokenstats-recap.svg";
+  const out = flag(argv, "--out") ?? "tokenchit-recap.svg";
   const json = has(argv, "--json");
   const dryRun = has(argv, "--dry-run");
   const yearFlag = flag(argv, "--year");
@@ -37,7 +37,7 @@ export async function recap(argv: string[]): Promise<number> {
 
   const stats = await aggregate(readAll(config.agents));
   if (stats.tokens === 0) {
-    warn("No usage found. Run `tokenstats init` to see which agents were detected.");
+    warn("No usage found. Run `tokenchit init` to see which agents were detected.");
     return 1;
   }
 
@@ -108,7 +108,7 @@ export async function recap(argv: string[]): Promise<number> {
   await writeFile(target, svg, "utf8");
   say(`${green("✓")} wrote ${bold(rel)} ${dim(`(${svg.length} bytes)`)}`);
   say();
-  say(`  ![tokenstats recap](./${rel})`);
+  say(`  ![tokenchit recap](./${rel})`);
   say();
 
   return 0;

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -11,8 +11,8 @@ import {
   toCardOptions,
   type Layout,
   type Theme,
-} from "@tokenstats/core";
-import { readAll } from "@tokenstats/core/adapters";
+} from "@tokenchit/core";
+import { readAll } from "@tokenchit/core/adapters";
 
 import { flag, has, oneOf } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
@@ -38,7 +38,7 @@ export async function sync(argv: string[]): Promise<number> {
   const stats = await aggregate(readAll(config.agents));
 
   if (stats.tokens === 0) {
-    warn("No usage found. Run `tokenstats init` to see which agents were detected.");
+    warn("No usage found. Run `tokenchit init` to see which agents were detected.");
     return 1;
   }
 
@@ -112,11 +112,11 @@ export async function sync(argv: string[]): Promise<number> {
 
   say();
   say(dim("  Embed it:"));
-  say(`  ![tokenstats](./${rel})`);
+  say(`  ![tokenchit](./${rel})`);
   say();
   // Committing on the user's behalf is not ours to decide — a tool that reads your logs
   // should not also decide what lands in your history on its first run.
-  say(dim(`  Then: git add ${rel} && git commit -m "chore: update tokenstats"`));
+  say(dim(`  Then: git add ${rel} && git commit -m "chore: update tokenchit"`));
   say();
 
   return 0;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,9 +1,9 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
-import type { AgentId, Layout, Theme } from "@tokenstats/core";
+import type { AgentId, Layout, Theme } from "@tokenchit/core";
 
-export const CONFIG_FILE = ".tokenstats.json";
+export const CONFIG_FILE = ".tokenchit.json";
 
 export type Config = {
   /** GitHub handle shown on the card. */
@@ -19,7 +19,7 @@ export type Config = {
 export const DEFAULT_CONFIG: Config = {
   handle: "",
   agents: [],
-  output: "tokenstats.svg",
+  output: "tokenchit.svg",
   layout: "default",
   theme: "auto",
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,29 +9,29 @@ import { sync } from "./commands/sync.js";
 import { bold, dim, fail, muteSqliteWarning, say } from "./ui.js";
 
 const USAGE = `
-${bold("tokenstats")} — turn your local AI coding agent logs into a stat card
+${bold("tokenchit")} — turn your local AI coding agent logs into a stat card
 
-  ${bold("tokenstats init")}              detect agents, write .tokenstats.json
+  ${bold("tokenchit init")}              detect agents, write .tokenchit.json
     --handle <name>            GitHub handle (default: guessed from origin remote)
 
-  ${bold("tokenstats sync")}              render the card into your repo
-    --out <path>               where to write it (default: tokenstats.svg)
+  ${bold("tokenchit sync")}              render the card into your repo
+    --out <path>               where to write it (default: tokenchit.svg)
     --layout default|compact
     --theme auto|light|dark
     --json                     print the aggregate instead of writing an SVG
     --dry-run                  report what would be written, write nothing
 
-  ${bold("tokenstats login")}             prove your GitHub handle (device flow, no password)
-  ${bold("tokenstats logout")}            forget this machine
-  ${bold("tokenstats whoami")}            who this machine is signed in as
+  ${bold("tokenchit login")}             prove your GitHub handle (device flow, no password)
+  ${bold("tokenchit logout")}            forget this machine
+  ${bold("tokenchit whoami")}            who this machine is signed in as
 
-  ${bold("tokenstats publish")}           the only command that uploads anything
+  ${bold("tokenchit publish")}           the only command that uploads anything
     --dry-run                  print the exact bytes and send nothing
-    --api <url>                default https://tokenstats-site.vercel.app
+    --api <url>                default https://tokenchit-site.vercel.app
     --handle <name>
 
-  ${bold("tokenstats recap")}             year in review: heatmap, models, totals
-    --out <path>               default: tokenstats-recap.svg
+  ${bold("tokenchit recap")}             year in review: heatmap, models, totals
+    --out <path>               default: tokenchit-recap.svg
     --year <yyyy>              label the recap with a different year
     --theme auto|light|dark
     --json                     print the recap model instead of writing an SVG

--- a/packages/cli/src/net.ts
+++ b/packages/cli/src/net.ts
@@ -6,7 +6,7 @@
  * scanning the source for network calls outside this file. Keeping the surface to one small
  * module is what makes that claim checkable rather than aspirational.
  *
- * Nothing here is imported unless `tokenstats publish` runs.
+ * Nothing here is imported unless `tokenchit publish` runs.
  */
 
 export type PostResult = {
@@ -84,7 +84,7 @@ export async function postForm(
       headers: {
         "content-type": "application/x-www-form-urlencoded",
         accept: "application/json",
-        "user-agent": "tokenstats-cli",
+        "user-agent": "tokenchit-cli",
       },
       body: new URLSearchParams(fields).toString(),
       signal: controller.signal,

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -21,7 +21,7 @@ export const fail = (s: string) => process.stderr.write(`${red("✗")} ${s}\n`);
 
 /**
  * Node 22 prints an ExperimentalWarning the first time `node:sqlite` loads. It is true but
- * not actionable by the person running `tokenstats sync`, and it lands in the middle of the
+ * not actionable by the person running `tokenchit sync`, and it lands in the middle of the
  * output. Every other warning is re-emitted so nothing real is swallowed.
  */
 export function muteSqliteWarning(): void {

--- a/packages/cli/test/auth.test.js
+++ b/packages/cli/test/auth.test.js
@@ -16,8 +16,8 @@ const SRC = join(HERE, "..", "src");
 const FIXTURE_HOME = join(HERE, "fixtures", "home");
 
 async function sandbox() {
-  const home = await mkdtemp(join(tmpdir(), "tokenstats-home-"));
-  const cwd = await mkdtemp(join(tmpdir(), "tokenstats-cwd-"));
+  const home = await mkdtemp(join(tmpdir(), "tokenchit-home-"));
+  const cwd = await mkdtemp(join(tmpdir(), "tokenchit-cwd-"));
   return { home, cwd };
 }
 
@@ -32,7 +32,7 @@ test("credentials live outside the repo, never in the committed config", async (
 
   // init writes the file that gets committed. It must never gain a credential field.
   await cli(["init", "--handle", "octocat"], { ...box, home: FIXTURE_HOME });
-  const config = JSON.parse(await readFile(join(box.cwd, ".tokenstats.json"), "utf8"));
+  const config = JSON.parse(await readFile(join(box.cwd, ".tokenchit.json"), "utf8"));
 
   assert.deepEqual(
     Object.keys(config).sort(),
@@ -57,7 +57,7 @@ test("the auth file is owner-only and lives under the config directory", async (
   });
 
   assert.equal(path, authFile());
-  assert.ok(path.includes(join(".config", "tokenstats")), `unexpected location: ${path}`);
+  assert.ok(path.includes(join(".config", "tokenchit")), `unexpected location: ${path}`);
 
   // 0600. A world-readable credential on a shared machine is the same as no credential.
   const mode = (await stat(path)).mode & 0o777;

--- a/packages/cli/test/privacy.test.js
+++ b/packages/cli/test/privacy.test.js
@@ -24,9 +24,9 @@ const CORE_SRC = join(HERE, "..", "..", "core", "src");
 
 /** Run the CLI in a sandbox whose HOME contains only the fixture transcripts. */
 async function cli(args, extraEnv = {}) {
-  const cwd = await mkdtemp(join(tmpdir(), "tokenstats-test-"));
+  const cwd = await mkdtemp(join(tmpdir(), "tokenchit-test-"));
   await writeFile(
-    join(cwd, ".tokenstats.json"),
+    join(cwd, ".tokenchit.json"),
     JSON.stringify({ handle: "canary", agents: ["claude-code"], output: "c.svg", layout: "default", theme: "auto" }),
   );
 
@@ -35,6 +35,9 @@ async function cli(args, extraEnv = {}) {
     env: {
       ...process.env,
       HOME: FIXTURE_HOME,
+      // This machine sets CLAUDE_CONFIG_DIR, and the adapter honours it by design, so it
+      // has to be cleared or the fixture home is ignored and the test reads real logs.
+      CLAUDE_CONFIG_DIR: '',
       USERPROFILE: FIXTURE_HOME,
       NO_COLOR: "1",
       ...extraEnv,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@tokenstats/core",
+  "name": "@tokenchit/core",
   "version": "0.1.0",
   "private": true,
-  "description": "Internal engine for @tokenstats/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
+  "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",
   "author": "Yash Chauhan (https://github.com/iyashjayesh)",
-  "homepage": "https://github.com/iyashjayesh/tokenstats#readme",
+  "homepage": "https://github.com/iyashjayesh/tokenchit#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iyashjayesh/tokenstats.git",
+    "url": "git+https://github.com/iyashjayesh/tokenchit.git",
     "directory": "packages/core"
   },
   "bugs": {
-    "url": "https://github.com/iyashjayesh/tokenstats/issues"
+    "url": "https://github.com/iyashjayesh/tokenchit/issues"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/scripts/refresh-prices.mjs
+++ b/packages/core/scripts/refresh-prices.mjs
@@ -2,7 +2,7 @@
 /**
  * Regenerate `src/prices.json` from LiteLLM's public price map.
  *
- * Run by a maintainer, never by the CLI. tokenstats's whole claim is that it reads local
+ * Run by a maintainer, never by the CLI. tokenchit's whole claim is that it reads local
  * files and talks to nobody, so the price table ships vendored — a card must render the
  * same on a plane as it does online, and a pricing lookup at sync time would be a network
  * call users did not ask for.

--- a/packages/core/src/adapters/claude-code.ts
+++ b/packages/core/src/adapters/claude-code.ts
@@ -1,5 +1,5 @@
 import { createReadStream } from "node:fs";
-import { stat } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -7,7 +7,46 @@ import { createInterface } from "node:readline";
 import type { Adapter, Detection, UsageEvent } from "../types.js";
 import { walkFiles } from "./walk.js";
 
-const defaultRoot = () => join(homedir(), ".claude", "projects");
+/**
+ * Every Claude Code configuration directory on this machine.
+ *
+ * Reading only `~/.claude` was wrong: anyone with more than one account has several. On the
+ * machine this was fixed on there were four — `.claude`, `.claude-personal`, `.claude-spark`
+ * and `.claude-work` — and three of them were invisible to the card, which is most of why the
+ * reported total looked nothing like the figure Claude Code shows.
+ *
+ * `CLAUDE_CONFIG_DIR` is added to the scan rather than replacing it. It names the directory
+ * the *current* session uses, which is not the same question as "where is all my usage" —
+ * on a machine with several accounts the other three still hold real tokens, and a card
+ * claiming to total your usage should not omit them because of one environment variable.
+ */
+async function defaultRoots(): Promise<string[]> {
+  const roots = new Set<string>();
+
+  const configured = process.env["CLAUDE_CONFIG_DIR"];
+  if (configured) roots.add(join(configured, "projects"));
+
+  const home = homedir();
+  let entries: string[];
+  try {
+    entries = await readdir(home);
+  } catch {
+    roots.add(join(home, ".claude", "projects"));
+    return [...roots];
+  }
+
+  for (const name of entries.sort()) {
+    // `.claude` and `.claude-<profile>`, but never `.claude.json` or a `.bak` beside it.
+    if (name !== ".claude" && !name.startsWith(".claude-")) continue;
+    roots.add(join(home, name, "projects"));
+  }
+
+  const usable: string[] = [];
+  for (const root of roots) {
+    if ((await stat(root).catch(() => null))?.isDirectory()) usable.push(root);
+  }
+  return usable;
+}
 
 /**
  * Models that appear in the logs but never correspond to a billable request. `<synthetic>`
@@ -16,6 +55,8 @@ const defaultRoot = () => join(homedir(), ".claude", "projects");
  * would pollute the model breakdown with rows that can never be priced.
  */
 const NON_MODELS = new Set(["<synthetic>", "default", "unknown"]);
+
+const total = (e: UsageEvent): number => e.input + e.output + e.cacheWrite + e.cacheRead;
 
 type ClaudeLine = {
   timestamp?: string;
@@ -43,66 +84,90 @@ type ClaudeLine = {
  * Sidechain entries are *kept*. Subagent tokens are tokens the user really spent; the
  * `(message.id, requestId)` key already removes the duplication that sidechains introduce.
  */
-export function createClaudeCode(root = defaultRoot()): Adapter {
+export function createClaudeCode(roots?: string[] | string): Adapter {
+  const resolve = async (): Promise<string[]> =>
+    roots === undefined ? defaultRoots() : Array.isArray(roots) ? roots : [roots];
+
   return {
     id: "claude-code",
     name: "Claude Code",
-    source: "~/.claude/projects/**/*.jsonl",
+    source: "~/.claude*/projects/**/*.jsonl",
 
     async detect(): Promise<Detection> {
-      const dir = await stat(root).catch(() => null);
-      if (!dir?.isDirectory()) return "absent";
-      for await (const _ of walkFiles(root, ".jsonl")) return "ready";
-      return "installed-no-data";
+      const found = await resolve();
+      if (found.length === 0) return "absent";
+
+      let anyDir = false;
+      for (const root of found) {
+        if (!(await stat(root).catch(() => null))?.isDirectory()) continue;
+        anyDir = true;
+        for await (const _ of walkFiles(root, ".jsonl")) return "ready";
+      }
+      return anyDir ? "installed-no-data" : "absent";
     },
 
     async *read(): AsyncIterable<UsageEvent> {
-      const seen = new Set<string>();
+      // Keyed rather than a Set, because a duplicate is not always a replay. Claude Code
+      // writes an assistant message repeatedly as it streams, with output_tokens growing
+      // each time and the other three buckets already final:
+      //
+      //   2/1/13364/4780   then   2/305/13364/4780
+      //
+      // Keeping the first occurrence therefore kept a partial output count and discarded the
+      // finished one — 2,826 messages were undercounted this way in a single directory. The
+      // largest total per key is the completed write.
+      const best = new Map<string, UsageEvent>();
 
-      for await (const file of walkFiles(root, ".jsonl")) {
-        const lines = createInterface({
-          input: createReadStream(file, { encoding: "utf8" }),
-          crlfDelay: Infinity,
-        });
+      for (const root of await resolve()) {
+        for await (const file of walkFiles(root, ".jsonl")) {
+          const lines = createInterface({
+            input: createReadStream(file, { encoding: "utf8" }),
+            crlfDelay: Infinity,
+          });
 
-        for await (const line of lines) {
-          // Cheap prefilter. Most lines in a transcript are prompts, tool calls and tool
-          // results; only assistant replies carry usage, and parsing the rest of a 298 MB
-          // corpus to discover that costs seconds.
-          if (!line.includes('"usage"')) continue;
+          for await (const line of lines) {
+            // Cheap prefilter. Most lines in a transcript are prompts, tool calls and tool
+            // results; only assistant replies carry usage, and parsing the rest of a corpus
+            // this size to discover that costs seconds.
+            if (!line.includes('"usage"')) continue;
 
-          let row: ClaudeLine;
-          try {
-            row = JSON.parse(line) as ClaudeLine;
-          } catch {
-            continue; // A partially flushed final line is normal in a live session.
+            let row: ClaudeLine;
+            try {
+              row = JSON.parse(line) as ClaudeLine;
+            } catch {
+              continue; // A partially flushed final line is normal in a live session.
+            }
+
+            const msg = row.message;
+            const usage = msg?.usage;
+            if (!usage || msg?.role !== "assistant") continue;
+
+            const key = `${msg.id ?? ""}:${row.requestId ?? ""}`;
+            if (key === ":") continue;
+
+            const model = msg.model ?? "unknown";
+            if (NON_MODELS.has(model)) continue;
+
+            const ts = row.timestamp ? new Date(row.timestamp) : null;
+            if (!ts || Number.isNaN(ts.getTime())) continue;
+
+            const event: UsageEvent = {
+              agent: "claude-code",
+              ts,
+              model,
+              input: usage.input_tokens ?? 0,
+              output: usage.output_tokens ?? 0,
+              cacheWrite: usage.cache_creation_input_tokens ?? 0,
+              cacheRead: usage.cache_read_input_tokens ?? 0,
+            };
+
+            const previous = best.get(key);
+            if (!previous || total(event) > total(previous)) best.set(key, event);
           }
-
-          const msg = row.message;
-          const usage = msg?.usage;
-          if (!usage || msg?.role !== "assistant") continue;
-
-          const key = `${msg.id ?? ""}:${row.requestId ?? ""}`;
-          if (key === ":" || seen.has(key)) continue;
-          seen.add(key);
-
-          const model = msg.model ?? "unknown";
-          if (NON_MODELS.has(model)) continue;
-
-          const ts = row.timestamp ? new Date(row.timestamp) : null;
-          if (!ts || Number.isNaN(ts.getTime())) continue;
-
-          yield {
-            agent: "claude-code",
-            ts,
-            model,
-            input: usage.input_tokens ?? 0,
-            output: usage.output_tokens ?? 0,
-            cacheWrite: usage.cache_creation_input_tokens ?? 0,
-            cacheRead: usage.cache_read_input_tokens ?? 0,
-          };
         }
       }
+
+      yield* best.values();
     },
   };
 }

--- a/packages/core/src/adapters/unsupported.ts
+++ b/packages/core/src/adapters/unsupported.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 /**
  * Agents we can detect but cannot total.
  *
- * These are reported by `tokenstats init` rather than quietly omitted. A user with Copilot
+ * These are reported by `tokenchit init` rather than quietly omitted. A user with Copilot
  * CLI installed will otherwise assume detection is broken, and the honest answer — the data
  * simply is not written to disk — is more useful than silence. If either tool starts
  * recording cumulative usage, these become real adapters.

--- a/packages/core/src/card-svg.ts
+++ b/packages/core/src/card-svg.ts
@@ -376,7 +376,7 @@ export function buildCardSvg(opts: CardOptions): string {
     render({
       tag: "text",
       attrs: { ...cls("ft"), x: g.footer.left, y: g.footer.y, ...footAttrs },
-      text: "TOKENSTATS.APP",
+      text: "TOKENCHIT.APP",
     }),
   );
   parts.push(
@@ -398,7 +398,7 @@ export function buildCardSvg(opts: CardOptions): string {
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${g.w} ${g.h}" ` +
     `width="${g.w}" height="${g.h}" role="img" ` +
-    `aria-label="tokenstats stats for @${esc(handle)}">` +
+    `aria-label="tokenchit stats for @${esc(handle)}">` +
     style +
     parts.join("") +
     `</svg>`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@
  * Isomorphic entry point: the card builder, the price table and the aggregation, none of
  * which touch the filesystem.
  *
- * The adapters live behind `@tokenstats/core/adapters` precisely because they import
+ * The adapters live behind `@tokenchit/core/adapters` precisely because they import
  * `node:fs` and `node:sqlite`. Re-exporting them here would drag Node built-ins into the
  * site's client bundle the moment a component imports `buildCardSvg`, which is exactly what
  * happened the first time this was one barrel.

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -12,7 +12,7 @@ export type Price = {
 
 const PRICES = table.prices as Record<string, Price>;
 
-/** The day the vendored table was generated, for `tokenstats sync --json` and the docs. */
+/** The day the vendored table was generated, for `tokenchit sync --json` and the docs. */
 export const PRICES_GENERATED: string = table.$generated;
 
 /**

--- a/packages/core/src/recap-svg.ts
+++ b/packages/core/src/recap-svg.ts
@@ -274,7 +274,7 @@ export function buildRecapSvg(opts: RecapCardOptions): string {
     render({
       tag: "text",
       attrs: { ...cls("ft"), x: PAD, y: H - 14, "font-family": FONT, "font-size": 8, "letter-spacing": 1, fill: pal.footer },
-      text: "TOKENSTATS.APP",
+      text: "TOKENCHIT.APP",
     }),
   );
   parts.push(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,7 +26,7 @@ export type Detection = "ready" | "installed-no-data" | "absent";
 
 export type Adapter = {
   id: AgentId;
-  /** Display name, as it appears on the card and in `tokenstats init`. */
+  /** Display name, as it appears on the card and in `tokenchit init`. */
   name: string;
   /** Where this adapter reads from, shown by `init` so nothing is hidden. */
   source: string;

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -4,7 +4,7 @@
  *
  *   node scripts/version.mjs 0.2.0
  *
- * Only @tokenstats/cli is published; core is private and bundled into it. Both are bumped
+ * Only @tokenchit/cli is published; core is private and bundled into it. Both are bumped
  * anyway so the repo does not carry two versions that quietly diverge, and the release
  * workflow refuses to publish when the tag disagrees with the CLI.
  */
@@ -19,8 +19,8 @@ if (!version || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version)) {
 for (const file of ["packages/core/package.json", "packages/cli/package.json"]) {
   const pkg = JSON.parse(await readFile(file, "utf8"));
   pkg.version = version;
-  if (pkg.dependencies?.["@tokenstats/core"]) {
-    pkg.dependencies["@tokenstats/core"] = version;
+  if (pkg.dependencies?.["@tokenchit/core"]) {
+    pkg.dependencies["@tokenchit/core"] = version;
   }
   await writeFile(file, `${JSON.stringify(pkg, null, 2)}\n`);
   console.log(`${pkg.name} -> ${version}`);


### PR DESCRIPTION
Two things: the name, and a correctness bug that made every card understate usage
by more than half.

## The card was wrong

Reported **4.36B** where Claude Code's own Stats panel reported far more. Two causes.

**It read one config directory out of four.** The adapter hardcoded
`~/.claude/projects`. Anyone with more than one account has several — this machine
has `.claude`, `.claude-personal`, `.claude-spark` and `.claude-work`, and three were
invisible to the card. `.claude-personal` alone held 482 MB across 1,295 files.

All are scanned now. `CLAUDE_CONFIG_DIR` is *added* to that scan rather than
replacing it: it names where the current session writes, which is a different
question from where all the usage lives.

**Deduplication kept the wrong copy.** A duplicate `(message.id, requestId)` is not
always a replay — Claude Code rewrites an assistant message as it streams, with
`output_tokens` growing while the other three buckets are already final:

```
2/1/13364/4780    then   2/305/13364/4780
2/17/4466/18144   then   2/210/4466/18144
```

Keeping the first occurrence banked the partial write and discarded the finished
one. **2,826 messages** undercounted in a single directory. The largest total per key
is now kept.

Together: **4.36B → 10.2B.**

## The remaining difference is not a bug

```
Claude Code lifetime (its stats caches)   27.79b   since 2026-06-02
tokenchit (parsing transcripts)           10.2b
oldest transcript still on disk                    2026-07-29
```

Claude Code deletes transcripts past its retention window but keeps lifetime totals
in `stats-cache.json`. A figure derived from logs cannot include logs that no longer
exist. Documented in the README rather than quietly reading an undocumented internal
cache that would not generalise to Codex or OpenCode.

## The rename

`tokenstats` had to go, and the evidence was Google's own AI Overview:

> *"Tokenstats usually refers to tools or APIs that track cryptocurrency metrics,
> token data, or AI model token usages."*

That is worse than a crowded results page — Google **defines** the word as crypto,
above every organic result.

Candidates that looked clean and were not, each caught by **reading** the results
rather than counting them:

| rejected | why |
| --- | --- |
| `tokenprint` | `sburl/TokenPrint — "Track your token use."` |
| `tokenslate` | `TokenSlate — live AI coding token display` |
| `tokenember` | `carlossansl/TokenEmber` exists |
| `tokenflex` | Autodesk ship a product called TokenFlex |
| `tokenstamp` | 58 repos for "bitcoin stamps" |
| `tokenking` | `dreamiurg/tokenking — "Analyze Claude Code token usage"` |

A chit is a short note or voucher — the closest single word to *"receipts for your
robots"*.

## Also

`SITE_URL` and `DEFAULT_API` point at `tokenchit.vercel.app`, the host that answers —
verified serving the real board, not assumed. The bulk rename had aimed them at a
host that 404s.

The release workflow now **refuses to publish when the repository is private**,
because npm provenance requires a public repo and otherwise fails with a message that
does not say so, by which point the tag already exists.

## Verified

40 tests pass, build clean, lint clean. Packed tarball installs standalone as
`@tokenchit/cli` and renders a real card. Local state moved with the rename, so an
existing session keeps working without re-running `init` or `login`.
