### PR TITLE
Replace the camo assumption with a measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,20 @@ Requires Node 22 or newer — OpenCode support uses the built-in `node:sqlite`.
 `apps/site` also serves `GET /api/card/<handle>.svg` with `layout`, `theme`, `agents`, `hide`
 and `cache` parameters. It renders sample data and exists to demonstrate the builder. The
 supported path is the committed SVG: it costs nothing to run, cannot be abused, and — unlike
-an external image — GitHub serves it straight from `raw.githubusercontent.com` rather than
-through its camo proxy.
+an external image — GitHub serves it directly rather than through its camo proxy.
+
+Measured on a live public repository rather than assumed:
+
+| in a README | rendered as | proxied |
+| --- | --- | --- |
+| committed SVG, relative `./card.svg` | `/owner/repo/raw/main/card.svg` | no |
+| committed SVG, absolute `raw.githubusercontent.com` | unchanged | no |
+| any external image | `camo.githubusercontent.com/…` | yes |
+| this project's own `/api/card/…` endpoint | `camo.githubusercontent.com/…` | yes |
+
+Both committed forms work, so `sync` printing a relative path costs nothing. The `<style>`
+block survives too — a committed `theme=auto` card really does follow GitHub's dark mode,
+which the original design brief assumed was impossible.
 
 ## Design and research
 

--- a/packages/core/src/card-svg.ts
+++ b/packages/core/src/card-svg.ts
@@ -409,10 +409,14 @@ export function buildCardSvg(opts: CardOptions): string {
  * theme=auto. Light values are already on the elements as presentation attributes;
  * CSS outranks those, so this block flips them under a dark colour scheme.
  *
- * The handoff both asks for media-query theming and warns that GitHub strips
- * <style> from README SVGs. Attributes-first satisfies both: where the CSS
- * survives, auto works; where it is stripped, the card degrades to light rather
- * than to nothing.
+ * The handoff warned that GitHub strips <style> from README SVGs. Measured against a live
+ * public repository, it does not: a committed card is served byte-identical from
+ * raw.githubusercontent.com, <style> and prefers-color-scheme intact, and the README renders
+ * it in dark mode under a dark colour scheme.
+ *
+ * Attributes-first is kept anyway. It costs nothing, and it is what makes the card degrade to
+ * light rather than to nothing anywhere CSS is dropped — an email client, a Markdown viewer,
+ * a sanitiser stricter than GitHub's.
  */
 function autoThemeStyle(segmentCount: number): string {
   const segRules = Array.from({ length: segmentCount }, (_, i) =>


### PR DESCRIPTION
The design brief warned that GitHub strips `<style>` from README SVGs, and `card-svg.ts` carried that warning forward as a hedge — *"where the CSS survives, auto works; where it is stripped, the card degrades to light."* Nobody had checked which half was true.

Tested against a live public repository with a real generated card:

| in a README | rendered as | proxied |
| --- | --- | --- |
| committed SVG, relative `./card.svg` | `/owner/repo/raw/main/card.svg` | no |
| committed SVG, absolute `raw.githubusercontent.com` | unchanged | no |
| shields.io badge (control) | `camo.githubusercontent.com/…` | yes |
| our own `/api/card/…` endpoint | `camo.githubusercontent.com/…` | yes |

Two results:

**The brief was wrong about `<style>`.** The committed SVG is served byte-identical from both raw paths, `Content-Type: image/svg+xml`, `<style>` and `prefers-color-scheme` intact — and the README renders it in dark mode under GitHub's dark theme. A committed `theme=auto` card really does follow the reader's theme, which the brief assumed was impossible.

**Both committed forms bypass camo.** This was the open question. `sync` prints the relative form, so no code changes — but the choice is now a measurement rather than a guess, and the CLI could safely print either.

Attributes-first theming stays. It costs nothing, and it is what makes the card degrade to light rather than to nothing in an email client or a stricter sanitiser than GitHub's.

No behaviour change — comment and README only. Build and both test suites pass (32 + 8).