### PR TITLE
Point --help at the API the CLI actually uses

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -27,7 +27,7 @@ ${bold("tokenchit")} — turn your local AI coding agent logs into a stat card
 
   ${bold("tokenchit publish")}           the only command that uploads anything
     --dry-run                  print the exact bytes and send nothing
-    --api <url>                default https://tokenchit-site.vercel.app
+    --api <url>                default https://tokenchit.vercel.app
     --handle <name>
 
   ${bold("tokenchit recap")}             year in review: heatmap, models, totals

--- a/packages/cli/test/auth.test.js
+++ b/packages/cli/test/auth.test.js
@@ -94,3 +94,14 @@ async function walk(dir) {
   }
   return out;
 }
+
+test("the help text names the same API the CLI actually posts to", async () => {
+  // These drifted once: the default moved to tokenchit.vercel.app while --help still
+  // advertised tokenchit-site.vercel.app, a host that 404s. Anyone who copied the URL out
+  // of --help would have pointed publish at nothing.
+  const { DEFAULT_API } = await import(join(HERE, "..", ".build", "api.js"));
+  const help = await readFile(join(SRC, "index.ts"), "utf8");
+
+  const advertised = help.match(/--api <url>\s+default (\S+)/)?.[1];
+  assert.equal(advertised, DEFAULT_API, "--help advertises a different API than DEFAULT_API");
+});


### PR DESCRIPTION
`tokenchit --help` advertised a host that does not exist:

```
--api <url>    default https://tokenchit-site.vercel.app
```

```
tokenchit.vercel.app       -> HTTP 200
tokenchit-site.vercel.app  -> HTTP 404
```

`DEFAULT_API` moved to `tokenchit.vercel.app` during the rename and the help string was left behind. It shipped that way in v0.1.1.

`publish` was never affected — it reads the constant, and a dry run confirms it targets `https://tokenchit.vercel.app/api/submissions`. The blast radius is limited to someone copying the URL out of `--help` and passing it back through `--api`, who would then post to a dead host.

Also adds a test tying the advertised host to `DEFAULT_API`. They live in different files and nothing connected them, which is how they drifted; the test fails if the old string is restored.