### PR TITLE
Serve real data from the card endpoint

### DIFF
--- a/apps/site/app/api/card/[handle]/route.ts
+++ b/apps/site/app/api/card/[handle]/route.ts
@@ -6,11 +6,19 @@ import {
   type Layout,
   type Theme,
 } from "@tokenchit/core";
-import { OWN_STATS } from "@/lib/sample-data";
+import { DEFAULT_WINDOW } from "@/lib/board";
+import { cardFigures, EMPTY_FIGURES } from "@/lib/card-figures";
+import { readProfile } from "@/lib/profile";
 
 /** Cache window printed on the card. Clamped 4h–24h, same as the rest of the genre. */
 const MIN_CACHE = 4 * 3600;
 const MAX_CACHE = 24 * 3600;
+
+/* A handle with nothing published is not an error, so the card renders rather than 404s —
+   a broken image in someone's README is a worse answer than an honest empty one. It is
+   cached briefly instead of the usual four hours so the real card appears soon after a
+   first publish, rather than after GitHub's copy of an empty card expires. */
+const EMPTY_CACHE = 300;
 
 const HIDEABLE = new Set<HideKey>(["spend", "streak", "mix"]);
 
@@ -57,22 +65,37 @@ export async function GET(
 
   const maxAge = parseCache(searchParams.get("cache"));
 
+  /* null means the handle has never published; undefined means the lookup itself failed.
+     They are cached differently below, so the two cases stay distinct here. */
+  const profile = await readProfile(handle, DEFAULT_WINDOW).catch(() => undefined);
+
+  const figures = profile ? cardFigures(profile) : EMPTY_FIGURES;
+
   const svg = buildCardSvg({
     handle,
-    tokens: OWN_STATS.tokens,
-    spend: OWN_STATS.spend,
-    streak: OWN_STATS.streak,
-    mix: filterAgents(OWN_STATS.mix, allow),
-    syncedAt: OWN_STATS.syncedAt,
+    tokens: figures.tokens,
+    spend: figures.spend,
+    streak: figures.streak,
+    mix: filterAgents(figures.mix, allow),
+    syncedAt: figures.syncedAt,
     layout,
     theme,
     hide,
   });
 
+  /* A failed lookup must not be cached: the next request should try the database again
+     rather than serve an empty card for four hours because of one blip. */
+  const cache =
+    profile === undefined
+      ? "no-store"
+      : profile === null
+        ? `public, max-age=${EMPTY_CACHE}, s-maxage=${EMPTY_CACHE}`
+        : `public, max-age=${maxAge}, s-maxage=${maxAge}`;
+
   return new Response(svg, {
     headers: {
       "Content-Type": "image/svg+xml; charset=utf-8",
-      "Cache-Control": `public, max-age=${maxAge}, s-maxage=${maxAge}`,
+      "Cache-Control": cache,
       "X-Content-Type-Options": "nosniff",
     },
   });

--- a/apps/site/app/u/[handle]/page.tsx
+++ b/apps/site/app/u/[handle]/page.tsx
@@ -8,6 +8,7 @@ import { ContributionGraph } from "@/components/contribution-graph";
 import { CopyButton } from "@/components/copy-button";
 import { PageShell } from "@/components/page-shell";
 import { isWindow, WINDOW_DAYS, WINDOWS, type BoardWindow } from "@/lib/board";
+import { cardFigures } from "@/lib/card-figures";
 import { readProfile } from "@/lib/profile";
 import { SITE_URL } from "@/lib/site";
 
@@ -54,18 +55,7 @@ export default async function ProfilePage({ params, searchParams }: Props) {
   const mix = Object.entries(profile.mix).sort((a, b) => b[1] - a[1]);
   const mixTotal = mix.reduce((a, [, n]) => a + n, 0);
 
-  const card = buildCardSvg({
-    handle: profile.handle,
-    tokens: formatTokens(profile.tokens),
-    spend: profile.equivCostUsd > 0 ? formatUsd(profile.equivCostUsd) : "—",
-    streak: `${profile.streakDays}d`,
-    mix: mix.map(([agent, tokens]) => ({
-      agent,
-      pct: mixTotal > 0 ? (tokens / mixTotal) * 100 : 0,
-    })),
-    syncedAt: profile.lastPublished ? new Date(profile.lastPublished) : new Date(),
-    theme: "light",
-  });
+  const card = buildCardSvg({ handle: profile.handle, ...cardFigures(profile), theme: "light" });
 
   const embed =
     `[![tokenchit](${SITE_URL}/api/card/${profile.handle}.svg)]` +

--- a/apps/site/lib/card-figures.ts
+++ b/apps/site/lib/card-figures.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import { formatTokens, formatUsd, type MixEntry } from "@tokenchit/core";
+import type { Profile } from "@/lib/profile";
+
+export type CardFigures = {
+  tokens: string;
+  spend: string;
+  streak: string;
+  mix: MixEntry[];
+  syncedAt: Date | string;
+};
+
+/** What an unpublished handle shows: zeroes and a line saying so, never sample data. */
+export const EMPTY_FIGURES: CardFigures = {
+  tokens: "0",
+  spend: "—",
+  streak: "0d",
+  mix: [],
+  syncedAt: "NOT PUBLISHED YET",
+};
+
+/**
+ * The card figures for one profile.
+ *
+ * Shared by the embed endpoint and the profile page on purpose. They render the same card for
+ * the same person and used to derive it separately, which is how the endpoint went on serving
+ * sample data long after the page was reading the database.
+ */
+export function cardFigures(profile: Profile): CardFigures {
+  const mix = Object.entries(profile.mix).sort((a, b) => b[1] - a[1]);
+  const total = mix.reduce((a, [, n]) => a + n, 0);
+
+  return {
+    tokens: formatTokens(profile.tokens),
+    spend: profile.equivCostUsd > 0 ? formatUsd(profile.equivCostUsd) : "—",
+    streak: `${profile.streakDays}d`,
+    mix: mix.map(([agent, tokens]) => ({
+      agent,
+      pct: total > 0 ? (tokens / total) * 100 : 0,
+    })),
+    syncedAt: profile.lastPublished ? new Date(profile.lastPublished) : new Date(),
+  };
+}


### PR DESCRIPTION
`/api/card/<handle>.svg` never queried the database. It read the handle, then rendered `OWN_STATS` — the hardcoded sample from the marketing page:

```ts
const svg = buildCardSvg({
  handle,
  tokens: OWN_STATS.tokens,   // "4.24B"
  spend:  OWN_STATS.spend,    // "$1,284"
  streak: OWN_STATS.streak,   // "63d"
  ...
```

So every card the site has ever served showed the same invented figures for every handle. It is the product's central artefact — the thing a README embeds — and it was a stub.

This surfaced because publishing corrected stats appeared to change nothing: `/u/iyashjayesh` moved to 10.3B while the card stayed at 4.24B. The card was never going to move.

**The fix.** The endpoint now reads the same profile the `/u/<handle>` page reads, over the same default window, and both build the card through one shared `cardFigures()`. They previously derived it separately — which is precisely how the page came to read the database while the endpoint kept serving samples.

**Handles with no data** render a zeroed card reading `NOT PUBLISHED YET` rather than returning 404: a broken image in someone's README is a worse answer than an honest empty one. Cached 5 minutes rather than the usual 4 hours, so a first publish appears promptly. A *failed lookup* is not cached at all, so one database blip cannot pin an empty card in front of a real profile for four hours.

Lint, typecheck and the site build pass.