### PR TITLE
Explain the Stats panel gap correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,29 @@ different question from where all your usage lives.
 
 ### Why the total differs from Claude Code's Stats panel
 
-**Claude Code deletes old transcripts.** Its own Stats panel reads a cumulative
-`stats-cache.json` that survives the cleanup, so it reports a lifetime figure. tokenchit
-parses the transcripts themselves, so it can only report the retention window — on the
-machine this was measured on, the caches went back to June while the oldest surviving
-transcript was late July.
+Expect Claude Code's panel to read roughly twice as high. Two separate things cause that,
+and only one of them is a limitation on this side.
 
-That is a real limitation, not a bug: a number derived from logs cannot include logs that no
-longer exist. It also means the figure only ever shrinks toward the truth as history ages out,
-never inflates.
+**The Stats panel counts each API call once per streaming rewrite.** Claude Code rewrites an
+assistant message in the transcript as it streams, so one call leaves several `usage` records
+carrying the same growing figures. `stats-cache.json` sums them as written. On one machine,
+51,373 usage records represented 23,644 real API calls, and the cache matched the naive sum of
+all 51,373 to the exact token on 28 of 57 days — and matched the deduplicated total on none.
+
+tokenchit collapses those to one row per call. That is safe to do: every message id observed
+more than once carried exactly one `requestId`, without exception, and deduplicating by
+`message.id` and by `requestId` independently agreed to within 0.002%. Counting them again
+would invent tokens nobody was billed for.
+
+**Claude Code also deletes old transcripts.** The Stats panel keeps reading the cumulative
+cache after the underlying transcripts are gone, so it covers a longer period than any
+transcript parser can see. On the same machine the cache reached back to June while the
+oldest surviving transcript was early July.
+
+That second one is a real limitation, not a bug: a number derived from logs cannot include
+logs that no longer exist. The cache is not a usable substitute, because it carries the
+inflation described above and the factor varies day to day — between 1.15x and 2.18x on the
+days measured — so there is no constant to divide out.
 
 **Copilot CLI and Gemini CLI are detected but cannot be counted.** Copilot records only a
 live context-window gauge, never a cumulative total; Gemini's chat transcripts carry no token


### PR DESCRIPTION
The README attributed the entire difference from Claude Code's Stats panel to transcript retention, and closed with:

> It also means the figure only ever shrinks toward the truth as history ages out, never inflates.

That treats Claude Code's number as the truth. It isn't, and the claim is falsifiable on a directory with no retention loss.

**Measured.** `~/.claude-personal` has 30 distinct days on disk and Claude Code reports "Active days: 30/33" — nothing rotated away. It still reads 1.8× higher than tokenchit.

The cause is streaming rewrites. Claude Code rewrites an assistant message in the transcript as it streams, so one API call leaves several `usage` records with the same growing figures, and `stats-cache.json` sums them as written:

| | tokens |
| --- | --- |
| naive sum of every usage record | 11,743,554,950 |
| `stats-cache.json` | 9,728,113,509 |
| one row per API call (tokenchit) | 5,694,433,656 |

Across 57 comparable days in two directories, the cache equalled the **naive** sum to the exact token on **28 days**, and the deduplicated total on **zero**.

**Deduplicating is sound.** Every message id seen more than once carried exactly one `requestId` — 16,975 of them, no exceptions — and deduplicating by `message.id` and by `requestId` independently agree to within 0.002%. Those are one billed call written repeatedly, not separate spend.

**So the cache can't rescue rotated history either**, which is worth stating explicitly since it looks like an obvious fix: it carries this inflation, and the factor ranged 1.15×–2.18× across days, so there is no constant to divide out.

Retention is still real and still documented — it is now the second reason rather than the only one.

Docs only.