### PR TITLE
Take the site's version badge from the package

### DIFF
--- a/apps/site/components/site-header.tsx
+++ b/apps/site/components/site-header.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { GithubMark } from "./github-mark";
+import { VERSION_LABEL } from "@/lib/version";
 import styles from "./site-header.module.css";
 
 const LOGIN = "npx @tokenchit/cli login";
@@ -49,7 +50,7 @@ export function SiteHeader() {
     <header className={styles.header}>
       <div className={styles.brand}>
         <span className={styles.wordmark}>tokenchit</span>
-        <span className={styles.version}>v0.4.1 · MIT</span>
+        <span className={styles.version}>{VERSION_LABEL}</span>
       </div>
 
       <div className={styles.right}>

--- a/apps/site/lib/version.ts
+++ b/apps/site/lib/version.ts
@@ -1,0 +1,17 @@
+/*
+ * The site's version badge, taken from the package it describes rather than typed out again.
+ *
+ * It read "v0.4.1" from a hand-written string while the CLI was at 0.1.1 — a number that had
+ * never been published, advertised on the page telling people what to install. A literal here
+ * is only ever correct until the next release, so there is no literal.
+ *
+ * This is a build-time import: the bundler inlines the value, nothing reads a file at runtime,
+ * and Vercel rebuilds on every push, so a version bump reaches the site with the deploy that
+ * carries it.
+ */
+import cli from "../../../packages/cli/package.json";
+
+export const CLI_VERSION: string = cli.version;
+
+/** "v0.1.1 · MIT" — the badge in the header. */
+export const VERSION_LABEL = `v${CLI_VERSION} · ${cli.license}`;

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -28,4 +28,7 @@ for (const file of ["packages/core/package.json", "packages/cli/package.json"]) 
   console.log(`${pkg.name} -> ${version}`);
 }
 
-console.log(`\nnext:\n  npm install\n  git commit -am "Release v${version}"\n  git tag -a v${version} -m v${version}\n  git push origin main v${version}`);
+// The site reads this version straight from packages/cli/package.json, so nothing here
+// writes to apps/site. Push the tag in the same command as the branch: the site deploys from
+// main and would otherwise advertise a version npm does not have yet.
+console.log(`\nnext:\n  npm install\n  git commit -am "Release v${version}"\n  git tag -a v${version} -m v${version}\n  git push origin main v${version}\n\nThe site picks up ${version} from that deploy; no separate edit.`);


### PR DESCRIPTION
The site header read `v0.4.1 · MIT` from a hand-written string:

```tsx
<span className={styles.version}>v0.4.1 · MIT</span>
```

The CLI is at **0.1.1**, and **0.4.1 has never been published** — so the page whose job is telling people what to install was advertising a version that does not exist. A literal is only correct until the next release, so there is now no literal.

**Single source.** `apps/site/lib/version.ts` imports `packages/cli/package.json` and exports `VERSION_LABEL`. It is a build-time import: the bundler inlines the value, nothing touches the filesystem at runtime, and no generated file or extra build step is involved (`resolveJsonModule` is already on, and `noEmit` means no `rootDir` constraint).

**Verified it actually propagates**, rather than assuming:

```
node scripts/version.mjs 9.9.9 && npm run build -w tokenchit-site
  badge -> v9.9.9 · MIT

(restored)
  badge -> v0.1.1 · MIT
```

No edit under `apps/site` was needed for that. Since Vercel rebuilds on every push to main, a version bump reaches the site with the deploy that carries it.

**One ordering caveat, now documented in `version.mjs`:** the site deploys from `main` while npm publishes from the tag. Pushing the branch without the tag would briefly advertise a version npm does not have, so its printed instructions push both in one command — which they already did; the reason is now written down.

Lint, typecheck and build pass.