### PR TITLE
Release when the version changes, not when a tag is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,36 @@
 name: release
 
-# Tag-driven rather than push-driven: publishing is irreversible on npm — an unpublished
-# name can never be reused by anyone — so it should take a deliberate act, not a merge.
+# Version-driven. The workflow runs on every push to main but publishes only when
+# packages/cli/package.json carries a version npm does not already have — so bumping the
+# version *is* the release, and a docs or site merge publishes nothing.
+#
+# Publishing stays a deliberate act, which is what the previous tag-only trigger was
+# protecting: it now takes an explicit edit to a version field rather than an explicit tag.
+# Merging anything else cannot reach npm, and the guard below is what enforces that.
+#
+# Tags are still honoured so a release can be forced by hand, and the same check makes that
+# safe: a tag for a version already on npm publishes nothing rather than failing.
 on:
   push:
+    branches: [main]
     tags: ["v*"]
+  workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # write, because this workflow creates the release tag itself now.
+      contents: write
       # Required for npm provenance: the published package carries a signed attestation
       # linking it to this repository, this workflow and this commit.
       id-token: write
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Tags are needed to know whether this version was already released.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v7
         with:
@@ -26,22 +40,28 @@ jobs:
 
       - run: npm ci
 
-      # A tag that disagrees with package.json publishes something nobody asked for, and it
-      # cannot be taken back. Checked before anything is built.
-      - name: Tag matches the package version
+      # The whole gate. `npm view` answers for the registry rather than for this checkout,
+      # so a re-run, a revert or a second trigger for the same version all stop here instead
+      # of failing loudly over work that is already done.
+      - name: Is this version unpublished?
+        id: check
         run: |
-          tag="${GITHUB_REF_NAME#v}"
           version=$(node -p "require('./packages/cli/package.json').version")
-          if [ "$version" != "$tag" ]; then
-            echo "::error::@tokenchit/cli is $version but the tag says $tag — run npm run version:set"
-            exit 1
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          if npm view "@tokenchit/cli@$version" version >/dev/null 2>&1; then
+            echo "@tokenchit/cli@$version is already on npm — nothing to release."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "@tokenchit/cli@$version is not on npm — releasing."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
-          echo "@tokenchit/cli at $tag"
 
       # npm provenance attaches a signed attestation pointing at the source commit, which
       # requires a public repository. Publishing --provenance from a private repo fails with
       # a message that does not obviously say so, and by then the tag already exists.
       - name: Repository is public (required for provenance)
+        if: steps.check.outputs.publish == 'true'
         run: |
           private=$(gh api "repos/$GITHUB_REPOSITORY" -q .private)
           if [ "$private" = "true" ]; then
@@ -52,25 +72,54 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - run: npm run build
-      - run: npm test
-      - run: npm run lint -w tokenchit-site
+      # Everything below only runs for a real release, but the checks run before the tag is
+      # created: a tag pointing at a commit that does not build is worse than no tag.
+      - name: Build, test and lint
+        if: steps.check.outputs.publish == 'true'
+        run: |
+          npm run build
+          npm test
+          npm run lint -w tokenchit-site
+
+      - name: Tag the release
+        if: steps.check.outputs.publish == 'true'
+        run: |
+          tag="v${{ steps.check.outputs.version }}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "$tag already exists — leaving it alone."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "$tag"
+          git push origin "$tag"
 
       # One package. @tokenchit/core is private and bundled into this tarball by esbuild,
       # so there is nothing to publish first and no ordering to get wrong.
       - name: Publish @tokenchit/cli
+        if: steps.check.outputs.publish == 'true'
         run: npm publish -w @tokenchit/cli --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Release notes
+        if: steps.check.outputs.publish == 'true'
         run: |
           {
             echo "## Published"
             echo
             echo '```'
-            echo "npx @tokenchit/cli@${GITHUB_REF_NAME#v} init"
+            echo "npx @tokenchit/cli@${{ steps.check.outputs.version }} init"
             echo '```'
             echo
             echo "- [@tokenchit/cli](https://www.npmjs.com/package/@tokenchit/cli)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Nothing to release
+        if: steps.check.outputs.publish == 'false'
+        run: |
+          {
+            echo "No release: @tokenchit/cli@${{ steps.check.outputs.version }} is already on npm."
+            echo
+            echo "Bump the version to publish — \`node scripts/version.mjs <x.y.z>\`."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -291,19 +291,33 @@ into the CLI's single bundled file. Publishing a second package would mean maint
 public API surface nobody has asked for, and every rename inside it would become a
 compatibility decision for strangers. Publishing core later is easy; unpublishing is not.
 
-Publishing is tag-driven, never merge-driven — an unpublished npm name can never be reused by
-anyone, so it should take a deliberate act:
+**Publishing is version-driven.** The release workflow runs on every push to `main` but
+publishes only when `packages/cli/package.json` names a version npm does not already have.
+Bumping the version is the release:
 
 ```bash
 npm run version:set 0.2.0   # both packages, and the dependency between them
 npm install
 git commit -am "Release v0.2.0"
-git tag -a v0.2.0 -m v0.2.0
-git push origin main v0.2.0
+git push
 ```
 
-The workflow refuses to publish if the tag disagrees with `package.json`, and attaches npm
-provenance so the package carries a signed link back to the commit that produced it. CI
+CI then builds, tests, lints, creates the `v0.2.0` tag and publishes. Merging anything that
+leaves the version field alone publishes nothing, which is most merges — docs, the site, a
+dependency bump.
+
+This keeps what a tag-only trigger was protecting. An unpublished npm name can never be
+reused by anyone, so releasing has to be deliberate; it is now an explicit edit to a version
+field rather than an explicit tag. What it removes is the failure mode where the bump lands
+and the tag never gets pushed, so a fix sits on `main` for a week believing it shipped.
+
+The registry, not the tag, is the source of truth: the workflow asks npm whether that exact
+version exists, so a re-run, a revert, or a manually pushed tag all stop quietly instead of
+failing over work already done. Tests run before the tag is created, because a tag pointing
+at a commit that does not build is worse than no tag.
+
+It attaches npm provenance so the package carries a signed link back to the commit that
+produced it. CI
 installs the packed tarball into an empty project on every pull request and asserts nothing
 but `@tokenchit/cli` lands, which is what stops the bundle silently regressing into a broken
 dependency on the private package.

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -29,6 +29,11 @@ for (const file of ["packages/core/package.json", "packages/cli/package.json"]) 
 }
 
 // The site reads this version straight from packages/cli/package.json, so nothing here
-// writes to apps/site. Push the tag in the same command as the branch: the site deploys from
-// main and would otherwise advertise a version npm does not have yet.
-console.log(`\nnext:\n  npm install\n  git commit -am "Release v${version}"\n  git tag -a v${version} -m v${version}\n  git push origin main v${version}\n\nThe site picks up ${version} from that deploy; no separate edit.`);
+// writes to apps/site. Nothing here tags either: the release workflow watches main and
+// publishes whenever this field names a version npm does not have, so the bump is the
+// release. Merging anything that leaves this field alone publishes nothing.
+console.log(
+  `\nnext:\n  npm install\n  git commit -am "Release v${version}"\n  git push` +
+    `\n\nCI tags v${version} and publishes once the checks pass.` +
+    `\nThe site badge follows from the same push.`,
+);


### PR DESCRIPTION
Releasing took two acts: bump the version, then remember to tag and push it. The second is easy to skip, and skipping it is **silent** — the `--help` fix sat on `main` for a day looking released while `npx @tokenchit/cli` still served the version without it.

**The gate.** The workflow now runs on every push to `main` and asks the registry one question:

```bash
version=$(node -p "require('./packages/cli/package.json').version")
npm view "@tokenchit/cli@$version" version   # exists -> nothing to do
```

If npm already has that version — which is most merges, docs and site and dependency bumps — it publishes nothing and says so in the job summary. If npm does not have it, it builds, tests, lints, tags `v<version>` and publishes with provenance.

So bumping the version *is* the release:

```bash
npm run version:set 0.2.0 && npm install
git commit -am "Release v0.2.0"
git push
```

**This keeps what the tag-only trigger was protecting.** An unpublished npm name can never be reused by anyone, so releasing has to be deliberate — it is now a deliberate edit to a version field rather than a deliberate tag. What it removes is the gap between the two, where the bump lands and the tag never follows.

Three details worth naming:

- **The registry is the source of truth, not the tag.** A re-run, a revert, or a manually pushed tag all stop quietly rather than failing loudly over work already done.
- **Tests run before the tag is created.** A tag pointing at a commit that does not build is worse than no tag.
- **Tag pushes still work** as a manual escape hatch; the same check makes that safe.

`permissions: contents` moves to `write`, because the workflow now creates the tag itself.

**Verified both branches of the gate against the live registry**: `0.1.1` resolves, so merging this PR publishes nothing; `9.9.9` does not resolve, so it would. Structural check of the workflow passes — 5 steps correctly gated, no tabs.