### PR TITLE
Release v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7194,7 +7194,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -7245,7 +7245,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
First release under the version-driven workflow (#27): merging this bump is the release. CI will build, test, lint, tag `v0.2.0` and publish with provenance.

Everything below has been sitting on `main` unreleased — `npx @tokenchit/cli` still serves 0.1.1.

**The CLI experience** (`9583d07`)
- `sync` prints a stats panel: headline figures, a 30-day sparkline that keeps empty days as gaps, agent bars, model table. A spinner covers the log walk, so several seconds of silence stops reading as a hang.
- `publish` signs you in on the way through and ends with the profile and leaderboard links. TTY-gated, so CI and cron publish unverified rather than hanging. `--anonymous` makes that choice deliberately.
- `help` is generated from one table; `tokenchit help <command>` explains one command. The API host is interpolated, not retyped.
- New `tokenchit schedule` prints a launchd or cron entry and installs nothing.
- Decoration goes to stderr, so `sync --json | jq` and the exact bytes of `publish --dry-run` are untouched.

**Fixes**
- `--help` advertised `tokenchit-site.vercel.app`, which 404s (#22).

**Also on main since 0.1.1** (no CLI effect): the card endpoint now serves real data instead of hardcoded samples (#23), the Stats-panel discrepancy is documented accurately (#24), and the site takes its version and install commands from the package (#25, #26).

Verified locally with the exact gate CI runs: build, 42 tests, lint. `--version` reports 0.2.0 and the site badge renders `v0.2.0 · MIT`.