### PR TITLE
Add generate, and lead with it everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,23 @@ a network request.
 
 ## Commands
 
-Three steps, in order. `sync` shows you everything before anything leaves the machine.
+One command does the lot:
+
+```bash
+npx @tokenchit/cli@latest generate
+```
+
+It detects your agents, shows your stats, writes the card, and puts you on the board — each
+step announced before it happens. `--no-publish` stops after the card.
+
+The steps are also commands in their own right, and `generate` is a composition of exactly
+those, so running them separately does identical work. `sync` shows you everything before
+anything leaves the machine.
 
 ```
+tokenchit generate       the whole flow, below, in order
+  --no-publish           stop after writing the card
+
 tokenchit init           say who you are
   --handle <name>        GitHub handle (default: guessed from your origin remote)
 

--- a/apps/site/app/board/page.tsx
+++ b/apps/site/app/board/page.tsx
@@ -9,7 +9,7 @@ import { readBoard } from "@/lib/board-query";
 import { readBoardTotals } from "@/lib/board-totals";
 
 import styles from "./board.module.css";
-import { cmd, npx } from "@/lib/cli";
+import { cmd, PRIMARY_COMMAND } from "@/lib/cli";
 
 export const revalidate = 300;
 
@@ -83,7 +83,7 @@ export default async function BoardPage({
       {rows.length === 0 ? (
         <p className={styles.empty}>
           Nobody has published in this window yet.{" "}
-          <span className={styles.strong}>{npx("publish")}</span> and the board is
+          <span className={styles.strong}>{PRIMARY_COMMAND}</span> and the board is
           yours.
         </p>
       ) : (

--- a/apps/site/app/globals.css
+++ b/apps/site/app/globals.css
@@ -63,10 +63,18 @@ select {
   border-radius: 0;
 }
 
-/* The one animation on the entire site: the install-command cursor. */
-@keyframes blk {
-  0%, 49%   { opacity: 1; }
-  50%, 100% { opacity: 0; }
+/* The hero's two keyframes live in hero.module.css, not here. CSS Modules rewrites an
+   animation-name inside a module to a scoped identifier, so a module referencing a keyframe
+   declared in this file resolves to a name nothing defines and the animation silently never
+   runs — which is what had quietly disabled the cursor blink. */
+
+@media (prefers-reduced-motion: reduce) {
+  /* A cursor that blinks forever is exactly the kind of motion this setting is asking about. */
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
 }
 
 ::selection { background: var(--lime); }

--- a/apps/site/app/not-found.tsx
+++ b/apps/site/app/not-found.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { PageShell } from "@/components/page-shell";
 
 import styles from "./not-found.module.css";
-import { cmd, npx } from "@/lib/cli";
+import { cmd, PRIMARY_COMMAND } from "@/lib/cli";
 
 /**
  * Profile URLs get shared, mistyped and outlive the handle they name, so this page is
@@ -32,7 +32,7 @@ export default function NotFound() {
           </Link>
         </div>
 
-        <code className={styles.install}>{npx("init")}</code>
+        <code className={styles.install}>{PRIMARY_COMMAND}</code>
       </div>
     </PageShell>
   );

--- a/apps/site/components/hero.module.css
+++ b/apps/site/components/hero.module.css
@@ -106,10 +106,36 @@
   color: var(--text-faint);
 }
 
-/* The site's only animation; the blk keyframes live in globals.css. */
+/* Declared here rather than in globals.css: CSS Modules scopes both the @keyframes name and
+   the animation-name that references it, and the two only agree when they live in the same
+   file. Split across files, the reference is rewritten and the animation never runs. */
+@keyframes blk {
+  0%, 49%   { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes type {
+  from { max-width: 0; }
+  to   { max-width: 100%; }
+}
+
+/* Typed once on load, at a speed that reads as typing rather than as a loading bar. Inline
+   so the cursor sits against the last character; the keyframes live in globals.css. */
+.typed {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  vertical-align: bottom;
+  animation: type 1.15s steps(34, end) both;
+}
+
 .cursor {
   display: inline-block;
-  margin-left: 2px;
+  width: 0.58em;
+  height: 1.05em;
+  margin-left: 3px;
+  background: var(--ink);
+  vertical-align: text-bottom;
   animation: blk 1.06s step-end infinite;
 }
 

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -4,11 +4,11 @@ import { CopyButton } from "./copy-button";
 import { StatCard } from "./stat-card";
 import { useSiteState } from "./site-state";
 import styles from "./hero.module.css";
-import { npx } from "@/lib/cli";
+import { PRIMARY_COMMAND } from "@/lib/cli";
 
 // Scoped, because the bare `tokenchit` name on npm is a 2018 tombstone: it was published
 // and unpublished within a fortnight, and npm never lets an unpublished name be reused.
-const INSTALL = npx("init");
+const INSTALL = PRIMARY_COMMAND;
 
 export function Hero() {
   const { handle, setHandle } = useSiteState();
@@ -37,8 +37,8 @@ export function Hero() {
         <div className={styles.install}>
           <code className={styles.command}>
             <span className={styles.prompt}>$ </span>
-            {INSTALL}
-            <span className={styles.cursor}>▌</span>
+            <span className={styles.typed}>{INSTALL}</span>
+            <span className={styles.cursor} aria-hidden="true" />
           </code>
           <CopyButton
             value={INSTALL}

--- a/apps/site/components/leaderboard.tsx
+++ b/apps/site/components/leaderboard.tsx
@@ -9,7 +9,7 @@ import { formatTokens, formatUsd } from "@tokenchit/core";
 import type { BoardRow } from "@/lib/board";
 import { WINDOWS, type BoardWindow } from "@/lib/board";
 import styles from "./leaderboard.module.css";
-import { cmd, npx } from "@/lib/cli";
+import { cmd, PRIMARY_COMMAND } from "@/lib/cli";
 
 /** Gold, silver, bronze. Only the top three; everyone else takes the default fill. */
 const MEDALS = ["#FFD23D", "#E4E2D8", "#F0B37E"] as const;
@@ -93,7 +93,7 @@ export function Leaderboard({ initialRows, initialWindow }: {
       {rows.length === 0 ? (
         <p className={styles.empty}>
           Nobody has published in this window yet.{" "}
-          <span className={styles.strong}>{npx("publish")}</span> and the board is
+          <span className={styles.strong}>{PRIMARY_COMMAND}</span> and the board is
           yours.
         </p>
       ) : (

--- a/apps/site/components/site-header.module.css
+++ b/apps/site/components/site-header.module.css
@@ -15,12 +15,12 @@
 
 .wordmark {
   display: inline-block;
-  padding: 7px 11px;
+  padding: 10px 16px;
   background: var(--lime);
   border: 2px solid var(--ink);
-  box-shadow: 3px 3px 0 var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
   font-family: var(--font-display), sans-serif;
-  font-size: 16px;
+  font-size: 22px;
   font-weight: 800;
   letter-spacing: -0.02em;
 }

--- a/apps/site/components/site-header.tsx
+++ b/apps/site/components/site-header.tsx
@@ -4,9 +4,9 @@ import { useEffect, useRef, useState } from "react";
 
 import { GithubMark } from "./github-mark";
 import styles from "./site-header.module.css";
-import { npx, VERSION_LABEL } from "@/lib/cli";
+import { PRIMARY_COMMAND, VERSION_LABEL } from "@/lib/cli";
 
-const LOGIN = npx("login");
+const LOGIN = PRIMARY_COMMAND;
 
 // Root-relative, not bare fragments: these render on /u/<handle> and /board too, where a
 // bare "#card" points at an anchor that does not exist on the page.

--- a/apps/site/lib/cli.ts
+++ b/apps/site/lib/cli.ts
@@ -25,8 +25,17 @@ export const VERSION_LABEL = `v${CLI_VERSION} · ${cli.license}`;
 
 export const NPM_URL = `https://npmjs.com/package/${CLI_PACKAGE}`;
 
-/** `npx @tokenchit/cli init` — the form for someone who has not installed anything. */
-export const npx = (...args: string[]) => `npx ${CLI_PACKAGE} ${args.join(" ")}`;
+/**
+ * `npx @tokenchit/cli@latest generate` — the one command the site leads with.
+ *
+ * Pinned to @latest deliberately: npx will reuse a cached copy indefinitely, and someone
+ * following a page that describes three steps should not be handed the build that did one.
+ *
+ * Defined once because it appears in the hero, the header button, the board, the leaderboard
+ * and the 404 — five places that were five separate string literals until the rename proved
+ * how well that goes.
+ */
+export const PRIMARY_COMMAND = `npx ${CLI_PACKAGE}@latest generate`;
 
 /** `tokenchit sync` — the form for someone who has. */
 export const cmd = (...args: string[]) => `${CLI_BIN} ${args.join(" ")}`;

--- a/apps/site/lib/sample-data.ts
+++ b/apps/site/lib/sample-data.ts
@@ -7,7 +7,7 @@
  * signed-in user's own totals, mix, sync timestamp and verification tier.
  */
 
-export const DEFAULT_HANDLE = "dlacey";
+export const DEFAULT_HANDLE = "iyashjayesh";
 
 /** Heatmap ramp, low to high. */
 export const RAMP = ["#F5F4EE", "#E7F5BE", "#C6FF3D", "#FFD23D", "#FF5C3D"] as const;

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,0 +1,78 @@
+import { has } from "../args.js";
+import { CONFIG_FILE, readConfig } from "../config.js";
+import { bold, dim, grey, rule, say, step, wordmark } from "../ui.js";
+import { init } from "./init.js";
+import { publish } from "./publish.js";
+import { sync } from "./sync.js";
+
+/**
+ * The whole flow, in one command.
+ *
+ * Three commands in the right order is not hard, but it is three things to know before
+ * anything happens, and the middle one is easy to skip. `generate` is what someone runs
+ * having read one line on a website: it finds the agents, writes the card, and puts the row
+ * on the board, narrating each step so nothing happens that was not announced.
+ *
+ * It is a composition, not a fourth implementation — each step is the command it is named
+ * after. Anyone who wants a step on its own can still run it on its own, and `generate`
+ * cannot drift away from what those commands do because it *is* them.
+ */
+export async function generate(argv: string[], version: string): Promise<number> {
+  const skipPublish = has(argv, "--no-publish");
+  const total = skipPublish ? 2 : 3;
+
+  say();
+  say(`  ${wordmark()}  ${dim(`v${version}`)}`);
+  say();
+  say(`  ${grey("reads your local agent logs, writes a card, puts you on the board")}`);
+  say(rule());
+
+  /*
+   * init only runs when there is nothing to read. Re-running it on an existing repo would
+   * overwrite a committed file that somebody may have edited by hand — a command that
+   * "just does everything" has to be more careful about what it overwrites, not less.
+   */
+  const existing = await readConfig();
+
+  say();
+  say(step(1, total, existing ? `config ${grey(`(${CONFIG_FILE} already here)`)}` : "detect agents"));
+
+  if (!existing) {
+    const code = await init(argv);
+    if (code !== 0) return code;
+  } else {
+    say(`  ${grey(`  ${existing.agents.join(", ")}`)}`);
+  }
+
+  say(rule());
+  say();
+  say(step(2, total, "your stats, and the card"));
+
+  const synced = await sync(argv, true);
+  if (synced !== 0) return synced;
+
+  if (skipPublish) {
+    say(rule());
+    say();
+    say(`  ${grey("stopped before publishing")} ${dim("— drop --no-publish to join the board")}`);
+    say();
+    return 0;
+  }
+
+  say(rule());
+  say();
+  say(step(3, total, "the board"));
+
+  const published = await publish(argv, version);
+  if (published !== 0) {
+    // A card on disk is most of the value, and it is already written. Saying so stops a
+    // failed upload reading as a failed run.
+    say();
+    say(`  ${bold("The card was written.")} ${grey("Only publishing failed — retry with")}`);
+    say(`  ${bold("tokenchit publish")}${grey(".")}`);
+    say();
+    return published;
+  }
+
+  return 0;
+}

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -20,7 +20,12 @@ import { bold, dim, green, grey, say, spin, warn } from "../ui.js";
 const LAYOUTS = ["default", "compact"] as const satisfies readonly Layout[];
 const THEMES = ["auto", "light", "dark"] as const satisfies readonly Theme[];
 
-export async function sync(argv: string[]): Promise<number> {
+/**
+ * `chained` is set when `generate` is driving. The closing hints assume the reader is done
+ * and choosing what to do next; inside the flow the next thing is about to happen on its
+ * own, and telling someone to run the command already running is noise.
+ */
+export async function sync(argv: string[], chained = false): Promise<number> {
   const config = (await readConfig()) ?? DEFAULT_CONFIG;
 
   // Checked before sanitising: `sanitizeHandle` falls back to "dev" on empty input, which
@@ -109,7 +114,9 @@ export async function sync(argv: string[]): Promise<number> {
   // Committing on the user's behalf is not ours to decide — a tool that reads your logs
   // should not also decide what lands in your history on its first run.
   say(`  ${grey("commit")}    git add ${rel} && git commit -m "chore: update tokenchit"`);
-  say(`  ${grey("share")}     ${bold("tokenchit publish")} ${dim("— put this on the board")}`);
+  if (!chained) {
+    say(`  ${grey("share")}     ${bold("tokenchit publish")} ${dim("— put this on the board")}`);
+  }
   say();
 
   return 0;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,13 +2,14 @@
 import { createRequire } from "node:module";
 
 import { DEFAULT_API } from "./api.js";
+import { generate } from "./commands/generate.js";
 import { init } from "./commands/init.js";
 import { login, logout, whoami } from "./commands/login.js";
 import { publish } from "./commands/publish.js";
 import { recap } from "./commands/recap.js";
 import { schedule } from "./commands/schedule.js";
 import { sync } from "./commands/sync.js";
-import { bold, cyan, dim, fail, grey, muteSqliteWarning, pad, say } from "./ui.js";
+import { bold, cyan, dim, fail, grey, muteSqliteWarning, pad, say, wordmark } from "./ui.js";
 
 type Command = {
   summary: string;
@@ -24,6 +25,21 @@ type Command = {
  * retyped — it was typed out once and drifted to a hostname that 404s.
  */
 const COMMANDS: Record<string, Command> = {
+  generate: {
+    summary: "the whole flow: detect, render the card, join the board",
+    flags: [
+      ["--no-publish", "stop after writing the card"],
+      ["--handle <name>", "GitHub handle (default: guessed from origin remote)"],
+      ["--out <path>", "where to write the card (default: tokenchit.svg)"],
+      ["--theme auto|light|dark", ""],
+    ],
+    detail:
+      "One command for the three steps most people want in order. It runs `init` only when\n" +
+      "there is no .tokenchit.json — re-running it would overwrite a committed file somebody\n" +
+      "may have edited — then `sync`, then `publish`.\n\n" +
+      "It is a composition, not a fourth implementation: each step is the command it is named\n" +
+      "after, so running them separately does exactly the same work.",
+  },
   init: {
     summary: "detect agents, write .tokenchit.json",
     flags: [["--handle <name>", "GitHub handle (default: guessed from origin remote)"]],
@@ -88,7 +104,8 @@ const COMMANDS: Record<string, Command> = {
 };
 
 const GROUPS: Array<[string, string[]]> = [
-  ["start here", ["init", "sync", "publish"]],
+  ["start here", ["generate"]],
+  ["or step by step", ["init", "sync", "publish"]],
   ["more", ["recap", "schedule"]],
   ["account", ["login", "logout", "whoami"]],
 ];
@@ -99,11 +116,10 @@ function usage(): string {
 
   const out: string[] = [
     "",
-    `${bold("tokenchit")} — turn your local AI coding agent logs into a stat card`,
+    `  ${wordmark()}  ${grey("receipts for your robots")}`,
     "",
-    `  ${grey("1")} ${bold("tokenchit init")}      ${grey("say who you are")}`,
-    `  ${grey("2")} ${bold("tokenchit sync")}      ${grey("see your stats, write the card")}`,
-    `  ${grey("3")} ${bold("tokenchit publish")}   ${grey("sign in and join the board")}`,
+    `  ${bold("npx @tokenchit/cli@latest generate")}`,
+    `  ${grey("finds your agents, writes the card, puts you on the board")}`,
     "",
   ];
 
@@ -172,6 +188,8 @@ async function main(): Promise<number> {
   }
 
   switch (command) {
+    case "generate":
+      return generate(argv, cliVersion());
     case "init":
       return init(argv);
     case "sync":

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -51,6 +51,28 @@ export function link(url: string): string {
   return `${ESC}]8;;${url}${ESC}\\${cyan(url)}${ESC}]8;;${ESC}\\`;
 }
 
+/* The site's wordmark, in a terminal. Lime block, black text, the same mark someone saw on
+   the page they installed this from — a CLI and its site looking like two products is a
+   surprisingly cheap thing to get wrong.
+
+   256-colour rather than truecolor: it is what the widest set of terminals actually render,
+   and the brand lime is close enough at index 154 that nobody could pick the difference. */
+export function wordmark(): string {
+  if (!colour) return "tokenchit";
+  return `${ESC}[48;5;154m${ESC}[38;5;16m${ESC}[1m tokenchit ${ESC}[0m`;
+}
+
+/** `[1/3] label` — the spine of a multi-step command, so progress is legible at a glance. */
+export function step(n: number, total: number, label: string): string {
+  return `  ${grey(`[${n}/${total}]`)} ${bold(label)}`;
+}
+
+/** A full-width rule, clamped like the stats panel so the two agree. */
+export function rule(): string {
+  const w = Math.max(64, Math.min(84, (process.stdout.columns ?? 80) - 4));
+  return `  ${dim("─".repeat(w - 2))}`;
+}
+
 const BLOCKS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] as const;
 
 /** A sparkline scaled to its own maximum. A zero day stays a dot, so gaps read as gaps. */

--- a/packages/cli/test/auth.test.js
+++ b/packages/cli/test/auth.test.js
@@ -119,6 +119,7 @@ test("every command in the help table can actually be run", async () => {
   const { stdout: usage } = await cli(["help"], box);
 
   for (const name of [
+    "generate",
     "init",
     "sync",
     "publish",


### PR DESCRIPTION
## One command

```bash
npx @tokenchit/cli@latest generate
```

Detects the agents, shows the stats, writes the card, joins the board — each step announced before it happens:

```
  ▐ tokenchit ▌  v0.2.0

  reads your local agent logs, writes a card, puts you on the board
  ──────────────────────────────────────────────────────────────────

  [1/3] detect agents
    ● Claude Code   ~/.claude*/projects/**/*.jsonl
  ──────────────────────────────────────────────────────────────────

  [2/3] your stats, and the card
    <panel>
  ──────────────────────────────────────────────────────────────────

  [3/3] the board
  ✓ published as @iyashjayesh
```

It **composes** the existing commands rather than reimplementing them, so running the steps separately does identical work and the flow cannot drift from what they do. `init` runs only when there's no `.tokenchit.json` — a command that does everything has to be *more* careful about what it overwrites. `--no-publish` stops after the card, and a failed upload says the card was still written, since that's most of the value and it's already on disk.

## The bug behind the blinking-cursor request

**It never blinked.** The keyframes were declared in `globals.css` while the `animation-name` sat in `hero.module.css`, and CSS Modules rewrites that reference to a scoped identifier. The built CSS said so plainly:

```
defined:     @keyframes blk
referenced:  hero-module__qoEqpW__blk     <- nothing defines this
```

Both now live in the module, where the names agree — verified in the built output:

```
defined:     @keyframes hero-module__qoEqpW__blk
referenced:  hero-module__qoEqpW__blk
```

## The rest

- **CLI** opens with the site's wordmark as a lime 256-colour block — the mark someone saw on the page they installed from. Numbered steps against rules.
- **Site** leads with `npx @tokenchit/cli@latest generate` in all five places that named a command, from one constant. `@latest` is deliberate: npx reuses a cached copy indefinitely, and a page describing three steps shouldn't hand someone the build that did one.
- **Hero** command types itself in on load; the cursor is a drawn block rather than a `▌` glyph.
- **Wordmark** 16px → 22px, heavier shadow.
- **Live preview** opens on `@iyashjayesh` rather than `dlacey`.
- All motion is dropped under `prefers-reduced-motion`.

Lint, typecheck, site build and 42 tests pass. I could not verify visually — the extension isn't connected here and the homepage needs the database — so the rendering claims above are checked against built CSS and markup rather than a screenshot.