### PR TITLE
Release v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7194,7 +7194,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -7245,7 +7245,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Ships #29.

**`tokenchit generate`** — one command for the whole flow: detect agents, show stats, write the card, join the board, each step announced before it happens. Composes the existing commands rather than reimplementing them. `--no-publish` stops after the card.

**CLI** opens with the site's wordmark as a lime 256-colour block; numbered steps against rules.

**Site** leads with `npx @tokenchit/cli@latest generate` everywhere it names a command, from one constant.

**Fixed: the hero cursor never blinked.** Keyframes were declared in `globals.css` while the `animation-name` lived in `hero.module.css`; CSS Modules rewrote the reference to a scoped identifier nothing defined, so the animation silently never ran. Both now sit in the module.

Also: the command types itself in on load, the wordmark is 22px, the live preview opens on `@iyashjayesh`, and all motion drops under `prefers-reduced-motion`.

Verified locally with the exact gate CI runs — build, 42 tests, lint. `--version` reports 0.3.0 and the site badge renders `v0.3.0 · MIT`.