### PR TITLE
Give the CLI a front page

### DIFF
--- a/packages/cli/src/banner.ts
+++ b/packages/cli/src/banner.ts
@@ -1,0 +1,56 @@
+/**
+ * The wordmark, big, for the top of a screen someone is actually watching.
+ *
+ * A 5-row block font carrying only the eight letters "tokenchit" needs. A general figlet
+ * font would be a dependency and a megabyte to render nine characters that never change.
+ *
+ * Two things were prototyped and rejected. The site's hard drop-shadow fills the letter
+ * counters at this resolution and turns the word to mush — it needs pixels, not cells. A
+ * knockout plate (lime block, letters punched out) loses its inter-letter gaps into the
+ * counters and stops being readable at all.
+ */
+import { grey, lime, width as visibleWidth } from "./ui.js";
+
+const GLYPHS: Record<string, readonly string[]> = {
+  t: ["####", " ## ", " ## ", " ## ", " ## "],
+  o: ["####", "#  #", "#  #", "#  #", "####"],
+  k: ["#  #", "# # ", "##  ", "# # ", "#  #"],
+  e: ["####", "#   ", "### ", "#   ", "####"],
+  n: ["#  #", "## #", "# ##", "#  #", "#  #"],
+  c: ["####", "#   ", "#   ", "#   ", "####"],
+  h: ["#  #", "#  #", "####", "#  #", "#  #"],
+  i: ["####", " ## ", " ## ", " ## ", "####"],
+};
+
+const WORD = "tokenchit";
+const ROWS = 5;
+
+/** 52 columns at a two-space gap. Below this the banner is dropped rather than wrapped. */
+const MIN_COLUMNS = 66;
+
+function lines(): string[] {
+  const out: string[] = [];
+  for (let r = 0; r < ROWS; r++) {
+    const row = [...WORD].map((ch) => GLYPHS[ch]![r]!).join("  ");
+    out.push(row.replaceAll("#", "█"));
+  }
+  return out;
+}
+
+/**
+ * The banner, or nothing.
+ *
+ * Nothing when there is no TTY — a wall of block letters in a CI log or a piped file is
+ * noise, and the caller falls back to the inline wordmark. Nothing in a narrow terminal
+ * either: a wrapped banner is worse than no banner.
+ */
+export function banner(tagline: string, version: string): string[] {
+  const columns = process.stdout.columns ?? 0;
+  if (!process.stdout.isTTY || columns < MIN_COLUMNS) return [];
+
+  const art = lines();
+  const w = visibleWidth(art[0]!);
+  const foot = `${tagline}${" ".repeat(Math.max(2, w - visibleWidth(tagline) - version.length - 1))}${version}`;
+
+  return ["", ...art.map((l) => `  ${lime(l)}`), "", `  ${grey(foot)}`];
+}

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,6 +1,7 @@
 import { has } from "../args.js";
 import { CONFIG_FILE, readConfig } from "../config.js";
-import { bold, dim, grey, rule, say, step, wordmark } from "../ui.js";
+import { banner } from "../banner.js";
+import { bold, chip, dim, grey, rule, say, step, under, wordmark } from "../ui.js";
 import { init } from "./init.js";
 import { publish } from "./publish.js";
 import { sync } from "./sync.js";
@@ -21,10 +22,21 @@ export async function generate(argv: string[], version: string): Promise<number>
   const skipPublish = has(argv, "--no-publish");
   const total = skipPublish ? 2 : 3;
 
+  /* The banner when there is a person and a wide enough window to show it to, and the
+     inline wordmark otherwise — a wall of block letters in a CI log is noise. */
+  const art = banner("receipts for your robots", `v${version}`);
+  if (art.length > 0) {
+    for (const line of art) say(line);
+  } else {
+    say();
+    say(`  ${wordmark()}  ${dim(`v${version}`)}`);
+  }
+
   say();
-  say(`  ${wordmark()}  ${dim(`v${version}`)}`);
-  say();
-  say(`  ${grey("reads your local agent logs, writes a card, puts you on the board")}`);
+  say(
+    `  ${chip("parsed locally", "lime")} ${chip("no prompts sent", "yellow")} ` +
+      `${chip("card is a file you commit")}`,
+  );
   say(rule());
 
   /*
@@ -35,13 +47,17 @@ export async function generate(argv: string[], version: string): Promise<number>
   const existing = await readConfig();
 
   say();
-  say(step(1, total, existing ? `config ${grey(`(${CONFIG_FILE} already here)`)}` : "detect agents"));
+  say(
+    existing
+      ? `${step(1, total, "config")}  ${grey(`${CONFIG_FILE} already here`)}`
+      : step(1, total, "detect agents"),
+  );
 
   if (!existing) {
-    const code = await init(argv);
+    const code = await init(argv, true);
     if (code !== 0) return code;
   } else {
-    say(`  ${grey(`  ${existing.agents.join(", ")}`)}`);
+    say(under(grey(existing.agents.join(", "))));
   }
 
   say(rule());

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,7 +6,7 @@ import { adapters, unsupported } from "@tokenchit/core/adapters";
 
 import { flag } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig, writeConfig, type Config } from "../config.js";
-import { bold, dim, green, say, warn, yellow } from "../ui.js";
+import { bold, dim, green, say, under, warn, yellow } from "../ui.js";
 
 const run = promisify(execFile);
 
@@ -25,11 +25,19 @@ async function guessHandle(): Promise<string | null> {
   }
 }
 
-export async function init(argv: string[]): Promise<number> {
+/**
+ * `chained` is set when `generate` is driving: the step heading has already said what this
+ * is, and the rows belong inside that step's gutter rather than under a second header.
+ */
+export async function init(argv: string[], chained = false): Promise<number> {
   const handleFlag = flag(argv, "--handle");
 
-  say();
-  say(bold("Scanning for local agent logs"));
+  const row = (text: string) => (chained ? under(text) : `  ${text}`);
+
+  if (!chained) {
+    say();
+    say(bold("Scanning for local agent logs"));
+  }
   say();
 
   const found: AgentId[] = [];
@@ -40,11 +48,11 @@ export async function init(argv: string[]): Promise<number> {
 
     if (state === "ready") {
       found.push(adapter.id);
-      say(`  ${green("●")} ${label} ${dim(adapter.source)}`);
+      say(row(`${green("●")} ${label} ${dim(adapter.source)}`));
     } else if (state === "installed-no-data") {
-      say(`  ${yellow("○")} ${label} ${dim("installed, but no usage recorded yet")}`);
+      say(row(`${yellow("○")} ${label} ${dim("installed, but no usage recorded yet")}`));
     } else {
-      say(`  ${dim("○")} ${dim(`${label} not installed`)}`);
+      say(row(`${dim("○")} ${dim(`${label} not installed`)}`));
     }
   }
 
@@ -52,7 +60,7 @@ export async function init(argv: string[]): Promise<number> {
   // contributes nothing, instead of assuming detection is broken.
   for (const probe of unsupported) {
     if (!(await probe.installed())) continue;
-    say(`  ${yellow("○")} ${probe.name.padEnd(13)} ${dim(`unsupported — ${probe.reason}`)}`);
+    say(row(`${yellow("○")} ${probe.name.padEnd(13)} ${dim(`unsupported — ${probe.reason}`)}`));
   }
 
   say();
@@ -81,8 +89,10 @@ export async function init(argv: string[]): Promise<number> {
     warn(`No handle set. Add one to ${CONFIG_FILE}, or run: tokenchit init --handle <you>`);
   }
 
-  say();
-  say(`  Next: ${bold("tokenchit sync")}`);
+  if (!chained) {
+    say();
+    say(`  Next: ${bold("tokenchit sync")}`);
+  }
   say();
 
   return 0;

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -15,7 +15,7 @@ import { readAll } from "@tokenchit/core/adapters";
 import { flag, has, oneOf } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
 import { renderStats } from "../stats-view.js";
-import { bold, dim, green, grey, say, spin, warn } from "../ui.js";
+import { bold, dim, green, grey, say, spin, under, warn } from "../ui.js";
 
 const LAYOUTS = ["default", "compact"] as const satisfies readonly Layout[];
 const THEMES = ["auto", "light", "dark"] as const satisfies readonly Theme[];
@@ -80,7 +80,9 @@ export async function sync(argv: string[], chained = false): Promise<number> {
   const svg = buildCardSvg(toCardOptions(stats, { handle, layout, theme }));
   const target = resolve(process.cwd(), out);
 
-  for (const line of renderStats(stats, handle)) say(line);
+  for (const line of renderStats(stats, handle, !chained)) {
+    say(chained && line !== "" ? under(line.replace(/^ {2}/, "")) : line);
+  }
   say();
 
   // Never let the dollar figure imply more precision than it has. An unpriced model is not

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { createRequire } from "node:module";
 
 import { DEFAULT_API } from "./api.js";
+import { banner } from "./banner.js";
 import { generate } from "./commands/generate.js";
 import { init } from "./commands/init.js";
 import { login, logout, whoami } from "./commands/login.js";
@@ -114,14 +115,18 @@ function usage(): string {
   const names = Object.keys(COMMANDS);
   const w = Math.max(...names.map((n) => n.length)) + 10;
 
-  const out: string[] = [
-    "",
-    `  ${wordmark()}  ${grey("receipts for your robots")}`,
-    "",
+  // The banner where there is a person and room for it; the inline wordmark otherwise.
+  const art = banner("receipts for your robots", `v${cliVersion()}`);
+  const out: string[] =
+    art.length > 0
+      ? [...art, ""]
+      : ["", `  ${wordmark()}  ${grey("receipts for your robots")}`, ""];
+
+  out.push(
     `  ${bold("npx @tokenchit/cli@latest generate")}`,
     `  ${grey("finds your agents, writes the card, puts you on the board")}`,
     "",
-  ];
+  );
 
   for (const [group, members] of GROUPS) {
     out.push(`${grey(group)}`);

--- a/packages/cli/src/stats-view.ts
+++ b/packages/cli/src/stats-view.ts
@@ -29,9 +29,11 @@ function headline(stats: Stats): string[] {
   ];
 
   const w = cells.map(([v, l]) => Math.max(width(v), width(l)) + 3);
+
+  // Uppercase, matching the labels on the card and the profile page.
   return [
     "  " + cells.map(([v], i) => pad(bold(v), w[i]!)).join(""),
-    "  " + cells.map(([, l], i) => pad(grey(l), w[i]!)).join(""),
+    "  " + cells.map(([, l], i) => pad(grey(l.toUpperCase()), w[i]!)).join(""),
   ];
 }
 
@@ -62,7 +64,7 @@ function agents(stats: Stats): string[] {
   const nameW = Math.max(...stats.mix.map((m) => m.agent.length));
   const cells = Math.max(12, Math.min(28, term() - nameW - 24));
 
-  const out = ["", "  " + grey("agents")];
+  const out = ["", "  " + grey("AGENTS")];
   for (const m of stats.mix) {
     const tokens = stats.byAgent.get(m.agent) ?? 0;
     out.push(
@@ -88,7 +90,7 @@ function models(stats: Stats, limit = 5): string[] {
   const top = stats.models.slice(0, limit);
   const nameW = Math.max(...top.map((m) => m.model.length));
 
-  const out = ["", "  " + grey("models")];
+  const out = ["", "  " + grey("MODELS")];
   for (const m of top) {
     out.push(
       "    " +
@@ -103,8 +105,13 @@ function models(stats: Stats, limit = 5): string[] {
   return out;
 }
 
-/** The full panel, as lines. Returned rather than printed so callers control placement. */
-export function renderStats(stats: Stats, handle: string): string[] {
+/**
+ * The full panel, as lines. Returned rather than printed so callers control placement.
+ *
+ * `framed` draws the panel's own bracket. Inside `generate` it is off: the step's gutter is
+ * already grouping these lines, and a frame within a frame reads as a mistake.
+ */
+export function renderStats(stats: Stats, handle: string, framed = true): string[] {
   const w = term();
   const title = ` @${handle} `;
   const rule = "─".repeat(Math.max(0, w - width(title) - 3));
@@ -112,9 +119,7 @@ export function renderStats(stats: Stats, handle: string): string[] {
   const range =
     stats.firstDay && stats.lastDay ? grey(`  ${stats.firstDay} → ${stats.lastDay}`) : "";
 
-  const lines = [
-    "",
-    `  ${dim("╭─")}${bold(title)}${dim(rule)}`,
+  const body = [
     "",
     ...headline(stats),
     "",
@@ -122,9 +127,11 @@ export function renderStats(stats: Stats, handle: string): string[] {
     ...agents(stats),
     ...models(stats),
     "",
-    `  ${dim("╰" + "─".repeat(Math.max(0, w - 2)))}`,
-    range,
   ];
+
+  const lines = framed
+    ? ["", `  ${dim("╭─")}${bold(title)}${dim(rule)}`, ...body, `  ${dim("╰" + "─".repeat(Math.max(0, w - 2)))}`, range]
+    : [...body, range];
 
   // Padding is how the columns line up; it has no business surviving to the end of a line,
   // where it only shows up as trailing whitespace in a copied terminal buffer.

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -28,6 +28,10 @@ export const cyan = wrap("36");
 export const magenta = wrap("35");
 export const grey = wrap("90");
 
+/* The brand lime, as foreground. 256-colour index 154 rather than truecolor: it is what the
+   widest set of terminals actually render, and nobody could pick it from #C6FF3D. */
+export const lime = (s: string) => (colour ? `${ESC}[38;5;154m${s}${ESC}[0m` : s);
+
 export const say = (s = "") => process.stdout.write(`${s}\n`);
 export const note = (s = "") => process.stderr.write(`${s}\n`);
 export const warn = (s: string) => process.stderr.write(`${yellow("!")} ${s}\n`);
@@ -62,10 +66,45 @@ export function wordmark(): string {
   return `${ESC}[48;5;154m${ESC}[38;5;16m${ESC}[1m tokenchit ${ESC}[0m`;
 }
 
+/*
+ * The site's hero chips, in a terminal. They answer "what is this about to read, and does it
+ * leave my machine" before anyone has to ask, which is the same job they do on the page.
+ *
+ * Reverse video rather than a drawn border: it survives every terminal, needs no box-drawing
+ * characters, and keeps the row one line tall.
+ */
+const CHIP_STYLES = {
+  ink: "48;5;16;38;5;231",
+  lime: "48;5;154;38;5;16",
+  yellow: "48;5;220;38;5;16",
+} as const;
+
+export function chip(text: string, style: keyof typeof CHIP_STYLES = "ink"): string {
+  const label = text.toUpperCase();
+  if (!colour) return `[${label}]`;
+  return `${ESC}[${CHIP_STYLES[style]}m ${label} ${ESC}[0m`;
+}
+
+/**
+ * The left rule that groups a step's output under its heading.
+ *
+ * Lime while the step is running, grey once it is done, so a glance down the left edge says
+ * how far along the command is without reading a word of it.
+ */
+export const gutter = (done = false) => (done ? grey("┃") : lime("┃"));
+
 /** `[1/3] label` — the spine of a multi-step command, so progress is legible at a glance. */
 export function step(n: number, total: number, label: string): string {
-  return `  ${grey(`[${n}/${total}]`)} ${bold(label)}`;
+  // Uppercase, like the micro-labels on the card and the profile page. A CLI and its site
+  // sharing a typographic voice is most of what makes them feel like one product.
+  return `  ${gutter()} ${grey(`[${n}/${total}]`)}  ${bold(label.toUpperCase())}`;
 }
+
+/** Indent a line into a step's gutter. */
+export const under = (text: string, done = false) => `  ${gutter(done)}   ${text}`;
+
+/** The line that closes a step: a tick in the gutter, then what happened. */
+export const done = (text: string) => `  ${green("✓")} ${text}`;
 
 /** A full-width rule, clamped like the stats panel so the two agree. */
 export function rule(): string {

--- a/packages/cli/test/auth.test.js
+++ b/packages/cli/test/auth.test.js
@@ -137,3 +137,33 @@ test("every command in the help table can actually be run", async () => {
     );
   }
 });
+
+test("the banner degrades rather than wrapping or leaking into pipes", async () => {
+  // A wall of block letters is right in a terminal someone is watching and wrong in a CI
+  // log, a piped file, or a 60-column pane. All three fall back to the inline wordmark.
+  const { banner } = await import(join(HERE, "..", ".build", "banner.js"));
+
+  const withStdout = (isTTY, columns) => {
+    const tty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    const cols = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+    Object.defineProperty(process.stdout, "isTTY", { value: isTTY, configurable: true });
+    Object.defineProperty(process.stdout, "columns", { value: columns, configurable: true });
+    try {
+      return banner("receipts for your robots", "v0.0.0");
+    } finally {
+      if (tty) Object.defineProperty(process.stdout, "isTTY", tty);
+      if (cols) Object.defineProperty(process.stdout, "columns", cols);
+    }
+  };
+
+  assert.equal(withStdout(false, 200).length, 0, "a pipe must not get the banner");
+  assert.equal(withStdout(true, 60).length, 0, "a narrow terminal must not get a wrapped banner");
+
+  const wide = withStdout(true, 100);
+  assert.ok(wide.length > 0, "a wide terminal should get the banner");
+  const ANSI = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+  for (const line of wide) {
+    const printable = line.replace(ANSI, "");
+    assert.ok(printable.length <= 100, `banner line exceeds the terminal: ${printable.length}`);
+  }
+});


### PR DESCRIPTION
Builds the design discussed from the Kiro reference, in our own vocabulary.

## What it looks like

```
  ████  ████  █  █  ████  █  █  ████  █  █  ████  ████
   ██   █  █  █ █   █     ██ █  █     █  █   ██    ██
   ██   █  █  ██    ███   █ ██  █     ████   ██    ██
   ██   █  █  █ █   █     █  █  █     █  █   ██    ██
   ██   ████  █  █  ████  █  █  ████  █  █  ████   ██

  receipts for your robots                     v0.3.0

   PARSED LOCALLY   NO PROMPTS SENT   CARD IS A FILE YOU COMMIT
  ────────────────────────────────────────────────────────────

  ┃ [1/2]  CONFIG  .tokenchit.json already here
  ┃   claude-code, codex, opencode
  ────────────────────────────────────────────────────────────

  ┃ [2/2]  YOUR STATS, AND THE CARD
  ┃   10.4B    $6,984        25d      49
  ┃   TOKENS   EQUIV. COST   STREAK   ACTIVE DAYS
  ┃
  ┃   30d  ▅▁▁··▄▆▆▆▅▁▃▅█▃▂▄▂▁▅█▆▂█▇█▅▄█▇  3.46B in 7d
  ┃
  ┃   AGENTS
  ┃     claude-code  ███████████████████████████▇  99.5%   10.3B
```

Banner in lime, chips in lime/yellow/ink, gutter lime while running.

## What was adopted, and what wasn't

Taken from the reference: a banner owning the top of the screen, a gutter grouping nested work, status glyphs carrying meaning in colour, dim hints, rules between phases.

**Not taken: the menus and keyboard navigation.** Those exist because Kiro is a persistent REPL with a session to move around in. This is a one-shot command that exits. Bolting menus on would copy the look while breaking the thing that makes it useful — that you can pipe it, cron it, and run it in CI.

## Two brand devices that didn't survive prototyping

- **The hard drop-shadow.** At 5-row resolution it fills the letter counters and the word turns to mush. It needs pixels, not cells.
- **The knockout plate** (lime block, letters punched out). The inter-letter gaps merge into the counters and it stops being readable.

Both were built and looked at before being dropped.

## Details

- The font is a 5-row table carrying only the eight letters `tokenchit` needs — a figlet dependency to render nine characters that never change isn't a trade worth making.
- The chips row is **the site's**, not Kiro's. It answers what this is about to read and whether anything leaves the machine.
- Micro-labels are uppercase, matching the card and profile page.
- Inside a step, the stats panel drops its own bracket rather than framing a frame.
- `init` renders into the gutter when `generate` drives it, and keeps its own header when run alone.

## Degradation, with a test

No banner without a TTY, none below 66 columns, chips become `[BRACKETS]` without colour. A new test pins all three and asserts no banner line exceeds the terminal width.

Verified `sync --json` still parses and `publish --dry-run` still leads with the payload — decoration stays on stderr.

43 tests, lint and site build pass.