### PR TITLE
Release v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7194,7 +7194,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -7245,7 +7245,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Ships #31 — the CLI front page.

- Big lime wordmark banner on `generate` and bare `help`, from a 5-row block font carrying only the eight letters `tokenchit` needs.
- The site's chips row — `PARSED LOCALLY` / `NO PROMPTS SENT` / `CARD IS A FILE YOU COMMIT` — answering what gets read and whether anything leaves the machine.
- Steps group under a lime gutter; inside one the stats panel drops its own bracket rather than framing a frame.
- Micro-labels uppercase, matching the card and profile page.
- `init` renders into the gutter when `generate` drives it, keeps its own header when run alone.

Degradation is pinned by a test: no banner without a TTY, none below 66 columns, chips fall back to `[BRACKETS]`, and no banner line exceeds the terminal width. `sync --json` still parses and `publish --dry-run` still leads with the payload — decoration stays on stderr.

Verified locally with the exact gate CI runs: build, 43 tests, lint. `--version` reports 0.4.0 and the site badge renders `v0.4.0 · MIT`.