### PR TITLE
Put each agent's mark in the card legend

### DIFF
--- a/packages/core/src/agent-icons.ts
+++ b/packages/core/src/agent-icons.ts
@@ -1,0 +1,32 @@
+/**
+ * Agent marks for the card legend.
+ *
+ * Inlined as path data, never referenced as images: the card is a file committed into
+ * someone's repository and rendered by GitHub, where an external <image> is either stripped
+ * or proxied. A self-contained SVG is the only kind that survives.
+ *
+ * Claude and OpenCode marks are from Simple Icons (https://simpleicons.org), CC0-1.0. They
+ * are used to identify the tools whose logs produced these numbers, which is what the legend
+ * is for.
+ *
+ * There is deliberately no OpenAI mark. Simple Icons does not carry one, and drawing a
+ * trademarked logo from memory would produce something both inaccurate and presumptuous —
+ * agents without an available mark get GENERIC below, which claims nothing.
+ *
+ * Every path is authored against a 24x24 viewBox and scaled at render time.
+ */
+
+/** A neutral terminal chevron, for any agent with no mark of its own. */
+const GENERIC = "M4 6l6 6-6 6V6zm8 10h8v2h-8z";
+
+export const AGENT_ICONS: Record<string, string> = {
+  "claude-code":
+    "m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z",
+  opencode: "M22 24H2V0h20zM17 4.8H7v14.4h10z",
+};
+
+/** The mark for an agent, falling back to the neutral one. */
+export const agentIcon = (agent: string): string => AGENT_ICONS[agent] ?? GENERIC;
+
+/** Icons are drawn against this box; the caller scales to the size it needs. */
+export const ICON_VIEWBOX = 24;

--- a/packages/core/src/card-svg.ts
+++ b/packages/core/src/card-svg.ts
@@ -18,12 +18,16 @@
  */
 
 import { DARK, esc, FONT, LIGHT, render, type Palette } from "./svg.js";
+import { agentIcon, ICON_VIEWBOX } from "./agent-icons.js";
 
 export type Layout = "default" | "compact";
 export type Theme = "light" | "dark" | "auto";
 export type HideKey = "spend" | "streak" | "mix";
 
 export type MixEntry = { agent: string; pct: number };
+
+/** Legend mark size. Bigger than the 6px square it replaced, because a mark needs the room. */
+const ICON_SIZE = 8;
 
 export type CardOptions = {
   handle: string;
@@ -333,15 +337,23 @@ export function buildCardSvg(opts: CardOptions): string {
     const dg = GEO.default;
     mix.slice(0, dg.legend.pairs.length).forEach((m, i) => {
       const [sx, tx] = dg.legend.pairs[i];
+      /* The agent's own mark, in the colour of its bar segment. Tinted rather than drawn in
+         each brand's own colour: the mark says which tool, the colour says which piece of
+         the bar above it, and the two would fight if both carried meaning.
+
+         The class stays on this element so theme=auto still recolours it in dark mode,
+         exactly as it did when this was a plain square. */
+      const scale = (ICON_SIZE / ICON_VIEWBOX).toFixed(4);
       parts.push(
         render({
-          tag: "rect",
+          tag: "path",
           attrs: {
             ...cls(`s${i}`),
-            x: sx,
-            y: dg.legend.swatchY,
-            width: 6,
-            height: 6,
+            // Centred on the same point the 6px square used, so the legend's vertical
+            // rhythm is unchanged by the mark being larger: a bigger box drawn from the same
+            // top edge would hang below the text baseline.
+            transform: `translate(${sx} ${dg.legend.swatchY - (ICON_SIZE - 6) / 2}) scale(${scale})`,
+            d: agentIcon(m.agent),
             fill: pal.segments[Math.min(i, pal.segments.length - 1)],
           },
         }),

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -109,6 +109,51 @@ test("the legend rounds percentages so they cannot overrun their slot", () => {
   assert.doesNotMatch(svg, /98\.67/);
 });
 
+test("the legend marks an agent it knows, and claims nothing about one it does not", () => {
+  const known = buildCardSvg({
+    handle: "dev",
+    tokens: "1B",
+    spend: "$1",
+    streak: "1d",
+    mix: [{ agent: "claude-code", pct: 100 }],
+    syncedAt: "SYNCED 0M AGO",
+  });
+  assert.match(known, /<path[^>]*d="m4\.7144/, "claude-code should carry its own mark");
+
+  // No OpenAI mark exists under a licence we can use, and inventing one would be worse than
+  // saying nothing. Anything unrecognised gets the neutral chevron.
+  const unknown = buildCardSvg({
+    handle: "dev",
+    tokens: "1B",
+    spend: "$1",
+    streak: "1d",
+    mix: [{ agent: "some-new-agent", pct: 100 }],
+    syncedAt: "SYNCED 0M AGO",
+  });
+  assert.match(unknown, /<path[^>]*d="M4 6l6 6-6 6V6z/, "an unknown agent should get the generic mark");
+});
+
+test("a legend mark keeps the vertical centre the old square had", () => {
+  // The square was 6px drawn from y=157, so its centre sat at 160. The mark is 8px; drawn
+  // from the same top edge it would hang 2px below the text baseline. This is the arithmetic
+  // that keeps the row optically level, and it is not visible in any screenshot.
+  const svg = buildCardSvg({
+    handle: "dev",
+    tokens: "1B",
+    spend: "$1",
+    streak: "1d",
+    mix: [{ agent: "claude-code", pct: 100 }],
+    syncedAt: "SYNCED 0M AGO",
+  });
+
+  const move = /translate\(\d+ (\d+(?:\.\d+)?)\) scale\(([\d.]+)\)/.exec(svg);
+  assert.ok(move, "expected a translated, scaled legend mark");
+
+  const top = Number(move[1]);
+  const size = Number(move[2]) * 24;
+  assert.ok(Math.abs(top + size / 2 - 160) < 0.05, `mark centre is ${top + size / 2}, want 160`);
+});
+
 test("token formatting keeps three significant figures", () => {
   assert.equal(formatTokens(4_232_281_798), "4.23B");
   assert.equal(formatTokens(890_000_000), "890M");


### PR DESCRIPTION
The legend identified agents with a coloured square and a name. The square only repeated what the bar above already said — so the row carried one fact twice and the agent's identity not at all.

```
before   ▪ claude-code 58%   ▪ codex 21%   ▪ opencode 21%
after    ✳ claude-code 58%   › codex 21%   ▣ opencode 21%
```

## Three constraints that shaped it

**Inlined path data, never an image.** The card is a file committed into someone's repository and rendered by GitHub, where an external `<image>` is stripped or proxied. A self-contained SVG is the only kind that survives — the same reason established by the camo test.

**Tinted to the bar segment, not each brand's colour.** The mark says which tool; the colour says which piece of the bar above it. If both carried meaning they would fight. The segment class stays on the element, so `theme=auto` still recolours it in dark mode exactly as it did the square.

**There is no OpenAI mark, and I did not invent one.** Simple Icons doesn't carry one — likely a trademark removal — so Codex gets a neutral chevron, as does any agent added later. Drawing a trademarked logo from memory would be both inaccurate and presumptuous. Claude and OpenCode are from Simple Icons under CC0, attributed in the module.

## The bug worth naming

The mark is 8px where the square was 6px. Drawn from the same top edge it hangs 2px below the text baseline, so it is translated to keep the centre the square had:

```
old square: y 157..163, centre 160
new mark:   y 156..164, centre 160
```

That has a test, mutation-checked to confirm it fails when the offset is removed. It matters because it is invisible in a screenshot — and this environment has no SVG rasteriser, so I could not have caught it by looking.

I also verified an earlier check of mine against a **stale build**: `npm run build -w @tokenchit/cli` does not rebuild core, so the first geometry check reported the old value. The numbers above are from a full `npm run build`.

## Cost

2836 → 4746 bytes, almost all of it Claude's mark (1811 bytes, 30 path commands). For a file that lives in a README that is a fair trade; for anything larger it would not be.

The site's preview card picks this up automatically — same builder — verified in the built output.

34 core + 11 CLI tests, lint and site build pass.