### PR TITLE
Release v0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,7 +8199,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -8250,7 +8250,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Ships #34 — agent marks in the card legend.

Each agent now carries its own mark instead of a coloured square that only repeated what the bar above already said. Marks are inlined as path data (an external `<image>` is stripped or proxied by GitHub) and tinted to their bar segment, so `theme=auto` still recolours them in dark mode.

No OpenAI mark exists under a usable licence, so Codex and any future unknown agent get a neutral chevron rather than an invented logo. Claude and OpenCode are from Simple Icons under CC0.

The mark is 8px where the square was 6px and is centred on the square's old centre — drawn from the same top edge it would hang 2px below the text baseline. That has a mutation-checked test, since it is invisible in a screenshot.

Card grows 2836 → 4746 bytes, almost all of it Claude's mark.

Verified locally with the exact gate CI runs: build, 45 tests, lint. `--version` reports 0.4.1 and the site badge renders `v0.4.1 · MIT`.