### PR TITLE
Give the marks their own colours, and put them in the hero

### DIFF
--- a/apps/site/components/stat-card.module.css
+++ b/apps/site/components/stat-card.module.css
@@ -67,9 +67,13 @@
   gap: 6px;
 }
 
-.swatch {
-  width: 6px;
-  height: 6px;
+/* 8px to match the SVG card's mark, which is 8px where the old square was 6px. `block`
+   because an inline SVG otherwise sits on the text baseline and drags the row down. */
+.mark {
+  width: 8px;
+  height: 8px;
+  display: block;
+  flex: none;
 }
 
 .footer {

--- a/apps/site/components/stat-card.tsx
+++ b/apps/site/components/stat-card.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { agentMark, ICON_VIEWBOX } from "@tokenchit/core";
+
 import { OWN_STATS } from "@/lib/sample-data";
 import { useSiteState } from "./site-state";
 import styles from "./stat-card.module.css";
@@ -10,6 +12,10 @@ import styles from "./stat-card.module.css";
  * not lay out. The static cards in section 01 stay SVG (see lib/card-svg.ts).
  *
  * Geometry mirrors the SVG card exactly. Note the streak is not coloured here.
+ *
+ * The agent marks come from the same table the SVG card uses, so the preview cannot show a
+ * different legend from the thing it is previewing — which it did, silently, when the marks
+ * were added to the builder and this hand-written copy was missed.
  */
 const MIX_FILLS = ["var(--lime)", "var(--ink)", "var(--seg-2)", "var(--seg-3)"];
 
@@ -43,9 +49,16 @@ export function StatCard() {
       </div>
 
       <div className={styles.legend}>
-        {OWN_STATS.mix.map((m, i) => (
+        {OWN_STATS.mix.map((m) => (
           <span key={m.agent} className={styles.legendItem}>
-            <span className={styles.swatch} style={{ background: MIX_FILLS[i] }} />
+            <svg
+              className={styles.mark}
+              viewBox={`0 0 ${ICON_VIEWBOX} ${ICON_VIEWBOX}`}
+              aria-hidden="true"
+            >
+              {/* The card sits on a light ground, so the light colour is always the right one. */}
+              <path d={agentMark(m.agent).path} fill={agentMark(m.agent).light} />
+            </svg>
             {m.agent} {m.pct}%
           </span>
         ))}

--- a/packages/core/src/agent-icons.ts
+++ b/packages/core/src/agent-icons.ts
@@ -5,9 +5,9 @@
  * someone's repository and rendered by GitHub, where an external <image> is either stripped
  * or proxied. A self-contained SVG is the only kind that survives.
  *
- * Claude and OpenCode marks are from Simple Icons (https://simpleicons.org), CC0-1.0. They
- * are used to identify the tools whose logs produced these numbers, which is what the legend
- * is for.
+ * Claude and OpenCode marks are from Simple Icons (https://simpleicons.org), CC0-1.0, in
+ * their own brand colours. A mark recoloured to match a chart is no longer the mark people
+ * recognise, which was the whole point of using it.
  *
  * There is deliberately no OpenAI mark. Simple Icons does not carry one, and drawing a
  * trademarked logo from memory would produce something both inaccurate and presumptuous —
@@ -16,17 +16,45 @@
  * Every path is authored against a 24x24 viewBox and scaled at render time.
  */
 
-/** A neutral terminal chevron, for any agent with no mark of its own. */
-const GENERIC = "M4 6l6 6-6 6V6zm8 10h8v2h-8z";
+export type AgentMark = {
+  path: string;
+  /** Brand colour on a light card. */
+  light: string;
+  /**
+   * The same mark on a dark card. Usually identical — a brand colour is a brand colour — but
+   * a mark whose brand colour is black disappears on black, so those get an inversion rather
+   * than a different colour.
+   */
+  dark: string;
+};
 
-export const AGENT_ICONS: Record<string, string> = {
-  "claude-code":
-    "m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z",
-  opencode: "M22 24H2V0h20zM17 4.8H7v14.4h10z",
+/**
+ * A neutral terminal chevron for any agent with no mark of its own. It follows the legend
+ * text rather than claiming a colour, because it is not standing in for a brand.
+ */
+export const GENERIC: AgentMark = {
+  path: "M4 6l6 6-6 6V6zm8 10h8v2h-8z",
+  light: "#55554E",
+  dark: "#8A8A82",
+};
+
+export const AGENT_MARKS: Record<string, AgentMark> = {
+  "claude-code": {
+    path: "m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z",
+    light: "#D97757",
+    dark: "#D97757",
+  },
+  opencode: {
+    path: "M22 24H2V0h20zM17 4.8H7v14.4h10z",
+    // Black on white, white on black: the mark is a square outline, and either way round it
+    // is the same mark. Leaving it black would make it vanish on a dark card.
+    light: "#000000",
+    dark: "#FFFFFF",
+  },
 };
 
 /** The mark for an agent, falling back to the neutral one. */
-export const agentIcon = (agent: string): string => AGENT_ICONS[agent] ?? GENERIC;
+export const agentMark = (agent: string): AgentMark => AGENT_MARKS[agent] ?? GENERIC;
 
 /** Icons are drawn against this box; the caller scales to the size it needs. */
 export const ICON_VIEWBOX = 24;

--- a/packages/core/src/card-svg.ts
+++ b/packages/core/src/card-svg.ts
@@ -18,7 +18,7 @@
  */
 
 import { DARK, esc, FONT, LIGHT, render, type Palette } from "./svg.js";
-import { agentIcon, ICON_VIEWBOX } from "./agent-icons.js";
+import { agentMark, ICON_VIEWBOX } from "./agent-icons.js";
 
 export type Layout = "default" | "compact";
 export type Theme = "light" | "dark" | "auto";
@@ -337,24 +337,26 @@ export function buildCardSvg(opts: CardOptions): string {
     const dg = GEO.default;
     mix.slice(0, dg.legend.pairs.length).forEach((m, i) => {
       const [sx, tx] = dg.legend.pairs[i];
-      /* The agent's own mark, in the colour of its bar segment. Tinted rather than drawn in
-         each brand's own colour: the mark says which tool, the colour says which piece of
-         the bar above it, and the two would fight if both carried meaning.
+      /* The agent's own mark, in its own brand colour.
+      
+         Tinting these to the bar segment made every mark look like part of the chart rather
+         than like the thing it identifies, which defeated the point of using real marks.
 
-         The class stays on this element so theme=auto still recolours it in dark mode,
-         exactly as it did when this was a plain square. */
+         The class carries a dark-mode colour for theme=auto. Most marks keep their colour in
+         both; one whose brand colour is black would otherwise vanish on a dark card. */
+      const mark = agentMark(m.agent);
       const scale = (ICON_SIZE / ICON_VIEWBOX).toFixed(4);
       parts.push(
         render({
           tag: "path",
           attrs: {
-            ...cls(`s${i}`),
+            ...cls(`ic${i}`),
             // Centred on the same point the 6px square used, so the legend's vertical
             // rhythm is unchanged by the mark being larger: a bigger box drawn from the same
             // top edge would hang below the text baseline.
             transform: `translate(${sx} ${dg.legend.swatchY - (ICON_SIZE - 6) / 2}) scale(${scale})`,
-            d: agentIcon(m.agent),
-            fill: pal.segments[Math.min(i, pal.segments.length - 1)],
+            d: mark.path,
+            fill: theme === "dark" ? mark.dark : mark.light,
           },
         }),
       );
@@ -405,7 +407,7 @@ export function buildCardSvg(opts: CardOptions): string {
     }),
   );
 
-  const style = auto ? autoThemeStyle(widths.length || mix.length) : "";
+  const style = auto ? autoThemeStyle(widths.length || mix.length, mix) : "";
 
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${g.w} ${g.h}" ` +
@@ -430,10 +432,19 @@ export function buildCardSvg(opts: CardOptions): string {
  * light rather than to nothing anywhere CSS is dropped — an email client, a Markdown viewer,
  * a sanitiser stricter than GitHub's.
  */
-function autoThemeStyle(segmentCount: number): string {
+function autoThemeStyle(segmentCount: number, mix: MixEntry[]): string {
   const segRules = Array.from({ length: segmentCount }, (_, i) =>
     i === 0 ? "" : `.s${i}{fill:${DARK.segments[Math.min(i, 3)]}}`,
   ).join("");
+
+  /* Only marks that actually change are emitted. Claude's orange reads on either ground and
+     needs no rule; OpenCode's black would vanish on a dark card and needs one. */
+  const iconRules = mix
+    .map((m, i) => {
+      const mark = agentMark(m.agent);
+      return mark.dark === mark.light ? "" : `.ic${i}{fill:${mark.dark}}`;
+    })
+    .join("");
 
   return (
     `<style>@media (prefers-color-scheme:dark){` +
@@ -444,6 +455,7 @@ function autoThemeStyle(segmentCount: number): string {
     `.lg{fill:${DARK.legend}}` +
     `.ft{fill:${DARK.footer}}` +
     segRules +
+    iconRules +
     `}</style>`
   );
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@
  * site's client bundle the moment a component imports `buildCardSvg`, which is exactly what
  * happened the first time this was one barrel.
  */
+export * from "./agent-icons.js";
 export * from "./card-svg.js";
 export * from "./types.js";
 export * from "./aggregate.js";

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -133,6 +133,51 @@ test("the legend marks an agent it knows, and claims nothing about one it does n
   assert.match(unknown, /<path[^>]*d="M4 6l6 6-6 6V6z/, "an unknown agent should get the generic mark");
 });
 
+test("legend marks wear their own brand colour, not the chart's", () => {
+  const card = (theme) =>
+    buildCardSvg({
+      handle: "dev",
+      tokens: "1B",
+      spend: "$1",
+      streak: "1d",
+      mix: [
+        { agent: "claude-code", pct: 60 },
+        { agent: "opencode", pct: 40 },
+      ],
+      syncedAt: "SYNCED 0M AGO",
+      theme,
+    });
+
+  // Tinting marks to the bar segment made each one look like part of the chart rather than
+  // like the thing it identifies, which is the whole reason for using real marks.
+  assert.match(card("light"), /fill="#D97757"/, "claude-code should be its own orange");
+  assert.match(card("dark"), /fill="#D97757"/, "and the same orange on a dark card");
+
+  // A mark whose brand colour is black would disappear on a black card.
+  assert.match(card("light"), /fill="#000000"/, "opencode is black on a light card");
+  assert.match(card("dark"), /fill="#FFFFFF"/, "and inverted on a dark card");
+});
+
+test("theme=auto emits a dark rule only for marks that actually change", () => {
+  const svg = buildCardSvg({
+    handle: "dev",
+    tokens: "1B",
+    spend: "$1",
+    streak: "1d",
+    mix: [
+      { agent: "claude-code", pct: 60 },
+      { agent: "opencode", pct: 40 },
+    ],
+    syncedAt: "SYNCED 0M AGO",
+    theme: "auto",
+  });
+
+  // opencode flips black to white and needs a rule; claude's orange reads on either ground
+  // and emitting one for it would be bytes that change nothing, in a file people commit.
+  assert.match(svg, /\.ic1\{fill:#FFFFFF\}/, "opencode needs a dark-mode rule");
+  assert.doesNotMatch(svg, /\.ic0\{/, "claude-code should need no rule");
+});
+
 test("a legend mark keeps the vertical centre the old square had", () => {
   // The square was 6px drawn from y=157, so its centre sat at 160. The mark is 8px; drawn
   // from the same top edge it would hang 2px below the text baseline. This is the arithmetic


### PR DESCRIPTION
Two problems with how the marks landed in #34.

## They were the wrong colour

Tinted to their bar segment, every mark looked like part of the chart rather than like the thing it identifies — which was the whole reason for using real marks. They now carry brand colours:

| agent | light | dark |
| --- | --- | --- |
| claude-code | `#D97757` | `#D97757` |
| opencode | `#000000` | `#FFFFFF` |
| anything else | `#55554E` | `#8A8A82` |

A brand colour of black vanishes on a black card, so each mark carries a dark variant. Claude's orange reads on either ground and gets **no** `theme=auto` rule at all — emitting one would be bytes that change nothing in a file people commit.

## The hero had none of them

Because the hero preview **is not the card**. It is a hand-written HTML copy — the handle is live-bound to an input, and text injected into an `<svg><text>` node does not lay out — so adding marks to the builder left the copy behind silently.

That is the same failure as the card endpoint serving `OWN_STATS`: a second implementation of something that already exists, drifting the moment the first one changes. It now reads the same mark table the builder does, so the preview and the thing it previews cannot disagree again.

Verified in the prerendered page: three `mark` elements in the hero legend, and the Claude path appears three times — hero, plus the light and dark cards in section 01.

## Tests

- Marks wear brand colours, not segment colours, in both light and dark.
- `theme=auto` emits `.ic1{fill:#FFFFFF}` for OpenCode and no rule for Claude.

36 core + 11 CLI tests, lint and site build pass.

I still have no SVG rasteriser here, so this is verified by generated output and colour values rather than by looking at it.