### PR TITLE
Release v0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,7 +8199,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -8250,7 +8250,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Ships #36.

Legend marks now wear their own brand colours instead of being tinted to their bar segment — Claude's orange, OpenCode's black, inverted to white on a dark card so it does not vanish. `theme=auto` emits a rule only for a mark that actually changes.

The hero preview shows them too. It is a hand-written HTML copy rather than the SVG card, so adding marks to the builder had left it behind silently — it now reads the same mark table.

Verified locally with the exact gate CI runs: build, 47 tests, lint. `--version` reports 0.4.2 and the site badge renders `v0.4.2 · MIT`.