### PR TITLE
Rank on verified rows, and say what the card is for

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ tokenchit sync           read your logs, show your stats, write the card
 tokenchit publish        put your row on the public board
   --anonymous            publish without signing in; the row is marked unverified
   --dry-run              print the exact bytes and send nothing
-  --api <url>            default https://tokenchit.vercel.app
+  --api <url>            default https://tokenchit.app
   --handle <name>
 
 tokenchit recap
@@ -324,7 +324,7 @@ Every response carries `x-ratelimit-limit` and `x-ratelimit-remaining`, refusals
 | `/api/submissions` | publish (POST) and read the board (GET) |
 
 **The site is measured; the CLI is not.** Page views and one copy event go to Firebase
-Analytics from tokenchit.vercel.app — not from previews, not from localhost. The privacy
+Analytics from tokenchit.app — not from previews, not from localhost. The privacy
 guarantees in `packages/cli/test/privacy.test.js` are about the CLI, which makes exactly one
 network call, to publish, and carries no analytics of any kind. Saying so here rather than
 leaving someone to find a Google request in devtools and wonder what else is unstated.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,26 @@ of it, which `dryrun.exact` in the test suite enforces by comparing against what
 publish puts on the wire. The payload is aggregates only: totals, per-day token counts, agent
 and model ids. No prompts, no replies, no branch names, no paths.
 
+
+### How the board ranks
+
+Verified rows first, then tokens over the selected window.
+
+Signing in is the only thing that ties a row to a GitHub account, so it is the only thing that
+can carry a position. An unverified row still appears and still shows its figures; it simply
+cannot outrank a verified one. A `tier` that is displayed but never affects the ordering is
+decoration — it told you nothing about the ranking you were reading.
+
+Submissions far outside the range of real usage are **held for review**: stored, returned to
+their owner, and kept off the board until a person looks. The threshold is half the hard
+rejection limit — about 1.6x the busiest day in the corpus these figures were measured
+against — and `publish` says so out loud rather than leaving someone refreshing a board they
+will never appear on.
+
+The `flagged` column has existed since the first migration and, until this was added, nothing
+ever wrote to it. The board query already refused to show flagged rows; there was simply no
+code path that could set one.
+
 ## Signing in
 
 ```

--- a/README.md
+++ b/README.md
@@ -210,14 +210,35 @@ code path that could set one.
 
 ```
 $ tokenchit login
-  Open https://github.com/login/device
-  and enter  WDJB-MJHT
+  Open  https://github.com/login/device
+  Code  WDJB-MJHT
+  opened your browser, copied the code — the code should already be filled in
 ✓ signed in as @octocat
 ```
 
 GitHub's **device flow** — no password, no token to paste, and no localhost callback server,
 which matters because the usual OAuth-in-a-CLI approach breaks over SSH, in containers and on
 remote dev boxes: exactly where people run coding agents.
+
+**Why not the redirect flow.** GitHub requires a `client_secret` at the token exchange even
+with PKCE, which it added in July 2025 — it does not distinguish public from confidential
+clients. Shipping that flow in a public npm package would mean publishing the secret. GitHub's
+own `gh` reaches for a localhost callback only as a fallback for Enterprise hosts without
+device flow, and embeds a secret to do it.
+
+**The code is copied and the page is opened with it pre-filled**, so there is nothing to
+retype. Both are conveniences layered over output that stands on its own: the URL and the code
+are printed first, and stay correct when a container has no clipboard tool or `xdg-open` opens
+a window nobody is looking at. `--no-clipboard` and `--no-browser` turn them off; neither runs
+without a TTY.
+
+The code is always shown, even when the page is pre-filled. RFC 8628 §3.3.1 requires it, and
+§5.4 explains why: confirming the code is how you know the device asking for access is the one
+in front of you.
+
+GitHub does not return `verification_uri_complete`, so the pre-filled URL uses a `user_code`
+query parameter the verification page accepts but does not document. That is why it is used
+for the browser launch only, and never printed in place of the URL GitHub actually sent.
 
 **No scopes are requested.** GitHub answers `GET /user` for an unscoped token, and your login
 and numeric id are all we need.

--- a/apps/site/app/api/submissions/route.ts
+++ b/apps/site/app/api/submissions/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { validatePayload, type Payload } from "@tokenchit/core";
+import { reviewReason, validatePayload, type Payload } from "@tokenchit/core";
 
 import { userFromRequest } from "@/lib/auth";
 import { DEFAULT_WINDOW, isWindow } from "@/lib/board";
@@ -100,11 +100,16 @@ export async function POST(req: Request) {
       );
       const user = userRows[0]!;
 
+      /* Held back from the board, not refused. The column has existed since the first
+         migration and until now nothing ever wrote to it, so the hide path the board query
+         already implements could never fire. */
+      const review = reviewReason(payload);
+
       const { rows: subRows } = await client.query<{ id: string; received_at: Date }>(
         `INSERT INTO submissions
            (user_id, tokens, equiv_cost_usd, priced_share, streak_days, active_days,
-            first_day, last_day, agents, models, client_version)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+            first_day, last_day, agents, models, client_version, flagged)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
          RETURNING id, received_at`,
         [
           user.id,
@@ -118,6 +123,7 @@ export async function POST(req: Request) {
           JSON.stringify(payload.agents),
           JSON.stringify(payload.models),
           payload.clientVersion,
+          review !== null,
         ],
       );
 
@@ -145,7 +151,7 @@ export async function POST(req: Request) {
         );
       }
 
-      return { submissionId: subRows[0]!.id, tier: user.tier };
+      return { submissionId: subRows[0]!.id, tier: user.tier, review };
     });
 
     return NextResponse.json(
@@ -156,6 +162,10 @@ export async function POST(req: Request) {
         submissionId: result.submissionId,
         tokens: payload.tokens,
         days: payload.days.length,
+        // Said out loud rather than hidden. A row quietly missing from the board looks like a
+        // bug to its owner, and someone whose real usage tripped the threshold deserves to
+        // know why and to be able to say so.
+        review: result.review,
       },
       { status: 201, headers: tightest ? limitHeaders(tightest) : undefined },
     );

--- a/apps/site/app/board/page.tsx
+++ b/apps/site/app/board/page.tsx
@@ -57,6 +57,17 @@ export default async function BoardPage({
         that same window. It is a usage count, not a skill score.
       </p>
 
+      {/* Stated rather than left to be inferred from the ordering. A ranking whose rules are
+          not written down is one nobody can check, and the verified-first rule in particular
+          is invisible until it costs someone a place. */}
+      <p className={styles.intro}>
+        <span className={styles.strong}>How this is ranked.</span> Verified rows first, then
+        tokens. Signing in is the only thing that ties a row to a GitHub account, so it is the
+        only thing that can carry a position — an unverified row still appears and still shows
+        its figures, it just cannot outrank a verified one. Submissions far outside the range
+        of real usage are held for review and do not appear until a person has looked at them.
+      </p>
+
       <nav className={styles.windows} aria-label="Time window">
         {WINDOWS.map((w) => (
           <Link

--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: "tokenchit — receipts for your robots",
   description:
-    "tokenchit reads your local Claude Code, Codex and OpenCode logs and renders one embeddable card straight into your repo.",
+    "tokenchit reads your local Claude Code, Codex and OpenCode logs and renders one embeddable card straight into your repo. A file you commit, not a URL you depend on.",
 };
 
 export default function RootLayout({

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -5,6 +5,11 @@ import { CardSection } from "@/components/card-section";
 import { Leaderboard } from "@/components/leaderboard";
 import { DEFAULT_WINDOW } from "@/lib/board";
 import { readBoard } from "@/lib/board-query";
+import { formatSynced } from "@tokenchit/core";
+
+import { cardFigures } from "@/lib/card-figures";
+import { readProfile } from "@/lib/profile";
+import { DEFAULT_HANDLE, OWN_STATS } from "@/lib/sample-data";
 import { Verification } from "@/components/verification";
 import { Privacy } from "@/components/privacy";
 import { Recap } from "@/components/recap";
@@ -27,10 +32,28 @@ export default async function Page() {
   // Failing to read the board should cost the reader the table, not the whole page.
   const rows = await readBoard(DEFAULT_WINDOW).catch(() => []);
 
+  /* The preview shows the default handle's real figures. It used to show invented ones under
+     whatever handle was set, which was harmless while that handle was a made-up persona and
+     wrong the moment it became a real person's — the card then reads as theirs and is false.
+     Sample figures remain the fallback for a database with nobody in it yet. */
+  const profile = await readProfile(DEFAULT_HANDLE, DEFAULT_WINDOW).catch(() => null);
+  const preview = profile
+    ? (({ tokens, spend, streak, mix }) => ({
+        tokens,
+        spend,
+        streak,
+        mix,
+        syncedAt: formatSynced(
+          profile.lastPublished ? new Date(profile.lastPublished) : new Date(),
+        ),
+        real: true,
+      }))(cardFigures(profile))
+    : { ...OWN_STATS, real: false };
+
   return (
     <SiteStateProvider>
       <SiteHeader />
-      <Hero />
+      <Hero preview={preview} />
       <CardSection />
       <Leaderboard initialRows={rows} initialWindow={DEFAULT_WINDOW} />
       <Verification />

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -5,11 +5,7 @@ import { CardSection } from "@/components/card-section";
 import { Leaderboard } from "@/components/leaderboard";
 import { DEFAULT_WINDOW } from "@/lib/board";
 import { readBoard } from "@/lib/board-query";
-import { formatSynced } from "@tokenchit/core";
-
-import { cardFigures } from "@/lib/card-figures";
-import { readProfile } from "@/lib/profile";
-import { DEFAULT_HANDLE, OWN_STATS } from "@/lib/sample-data";
+import { readFeatured } from "@/lib/featured";
 import { Verification } from "@/components/verification";
 import { Privacy } from "@/components/privacy";
 import { Recap } from "@/components/recap";
@@ -32,26 +28,10 @@ export default async function Page() {
   // Failing to read the board should cost the reader the table, not the whole page.
   const rows = await readBoard(DEFAULT_WINDOW).catch(() => []);
 
-  /* The preview shows the default handle's real figures. It used to show invented ones under
-     whatever handle was set, which was harmless while that handle was a made-up persona and
-     wrong the moment it became a real person's — the card then reads as theirs and is false.
-     Sample figures remain the fallback for a database with nobody in it yet. */
-  const profile = await readProfile(DEFAULT_HANDLE, DEFAULT_WINDOW).catch(() => null);
-  const preview = profile
-    ? (({ tokens, spend, streak, mix }) => ({
-        tokens,
-        spend,
-        streak,
-        mix,
-        syncedAt: formatSynced(
-          profile.lastPublished ? new Date(profile.lastPublished) : new Date(),
-        ),
-        real: true,
-      }))(cardFigures(profile))
-    : { ...OWN_STATS, real: false };
+  const preview = await readFeatured(rows);
 
   return (
-    <SiteStateProvider>
+    <SiteStateProvider initialHandle={preview.handle}>
       <SiteHeader />
       <Hero preview={preview} />
       <CardSection />

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -34,7 +34,7 @@ export default async function Page() {
     <SiteStateProvider initialHandle={preview.handle}>
       <SiteHeader />
       <Hero preview={preview} />
-      <CardSection />
+      <CardSection preview={preview} />
       <Leaderboard initialRows={rows} initialWindow={DEFAULT_WINDOW} />
       <Verification />
       <Privacy />

--- a/apps/site/components/card-section.tsx
+++ b/apps/site/components/card-section.tsx
@@ -3,20 +3,18 @@
 import { CopyButton } from "@/components/copy-button";
 import { SectionHeading } from "@/components/section-heading";
 import { useSiteState } from "@/components/site-state";
-import { buildCardSvg } from "@tokenchit/core";
-import { DEFAULT_HANDLE, OWN_STATS, QUERY_OPTIONS } from "@/lib/sample-data";
+import type { Featured } from "@/lib/featured";
+import { QUERY_OPTIONS } from "@/lib/sample-data";
 import { SITE_URL } from "@/lib/site";
 import styles from "./card-section.module.css";
 
-/* The three variant cards are fixed artefacts of the sample handle, not the live one —
-   they illustrate layout/theme, so they are built once at module scope. */
-const SAMPLE = { handle: DEFAULT_HANDLE, ...OWN_STATS };
-const LIGHT_SVG = buildCardSvg({ ...SAMPLE, layout: "default", theme: "light" });
-const DARK_SVG = buildCardSvg({ ...SAMPLE, layout: "default", theme: "dark" });
-const COMPACT_SVG = buildCardSvg({ ...SAMPLE, layout: "compact", theme: "light" });
-
-export function CardSection() {
+export function CardSection({ preview }: { preview: Featured }) {
   const { handle } = useSiteState();
+
+  /* Built on the server from a real board member, not here from a sample. These illustrated
+     the layout with invented figures under whatever handle was set, which was a false claim
+     about a real account the moment that handle belonged to one. */
+  const { light, dark, compact } = preview.cards;
 
   // Linked to the profile: every embedded card is a door back to the site, which is the
   // whole growth loop. The plain-image form is still what `tokenchit sync` prints, because
@@ -50,11 +48,11 @@ export function CardSection() {
           <div className={styles.label}>variant / light</div>
           {/* Builder output, not user content: the handle is sanitised and XML-escaped
               inside buildCardSvg. */}
-          <div className={styles.card} dangerouslySetInnerHTML={{ __html: LIGHT_SVG }} />
+          <div className={styles.card} dangerouslySetInnerHTML={{ __html: light }} />
         </div>
         <div className={styles.cardCol}>
           <div className={styles.label}>variant / dark</div>
-          <div className={styles.card} dangerouslySetInnerHTML={{ __html: DARK_SVG }} />
+          <div className={styles.card} dangerouslySetInnerHTML={{ __html: dark }} />
         </div>
       </div>
 
@@ -63,7 +61,7 @@ export function CardSection() {
           <div className={styles.label}>layout=compact · 340px</div>
           <div
             className={styles.compactCard}
-            dangerouslySetInnerHTML={{ __html: COMPACT_SVG }}
+            dangerouslySetInnerHTML={{ __html: compact }}
           />
         </div>
 

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CopyButton } from "./copy-button";
-import { StatCard } from "./stat-card";
+import { StatCard, type PreviewFigures } from "./stat-card";
 import { useSiteState } from "./site-state";
 import styles from "./hero.module.css";
 import { PRIMARY_COMMAND } from "@/lib/cli";
@@ -10,7 +10,7 @@ import { PRIMARY_COMMAND } from "@/lib/cli";
 // and unpublished within a fortnight, and npm never lets an unpublished name be reused.
 const INSTALL = PRIMARY_COMMAND;
 
-export function Hero() {
+export function Hero({ preview }: { preview: PreviewFigures }) {
   const { handle, setHandle } = useSiteState();
 
   return (
@@ -56,7 +56,7 @@ export function Hero() {
           <span className={styles.label}>live preview</span>
         </div>
 
-        <StatCard />
+        <StatCard preview={preview} />
 
         <div className={styles.handleRow}>
           <span className={styles.label}>handle</span>

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { CopyButton } from "./copy-button";
-import { StatCard, type PreviewFigures } from "./stat-card";
+import type { Featured } from "@/lib/featured";
+import { StatCard } from "./stat-card";
 import { useSiteState } from "./site-state";
 import styles from "./hero.module.css";
 import { PRIMARY_COMMAND } from "@/lib/cli";
@@ -10,7 +11,7 @@ import { PRIMARY_COMMAND } from "@/lib/cli";
 // and unpublished within a fortnight, and npm never lets an unpublished name be reused.
 const INSTALL = PRIMARY_COMMAND;
 
-export function Hero({ preview }: { preview: PreviewFigures }) {
+export function Hero({ preview }: { preview: Featured }) {
   const { handle, setHandle } = useSiteState();
 
   return (

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -17,7 +17,7 @@ export function Hero() {
     <section className={styles.hero}>
       <div className={styles.left}>
         <div className={styles.chips}>
-          <span className={styles.chipInk}>3 agents</span>
+          <span className={styles.chipInk}>no hosted endpoint</span>
           <span className={styles.chipYellow}>parsed locally</span>
           <span className={styles.chipWhite}>no prompts sent</span>
         </div>
@@ -30,8 +30,9 @@ export function Hero() {
 
         <p className={styles.lede}>
           tokenchit reads your local Claude Code, Codex and OpenCode logs and renders one
-          embeddable card straight into your repo. Nothing is uploaded — the card is a file
-          you commit.
+          embeddable card straight into your repo. The card is a file you commit, not a URL
+          you depend on — nothing to rate-limit, nothing to go down, and it keeps working if
+          this site does not.
         </p>
 
         <div className={styles.install}>

--- a/apps/site/components/site-state.tsx
+++ b/apps/site/components/site-state.tsx
@@ -31,8 +31,15 @@ type SiteState = {
 
 const Ctx = createContext<SiteState | null>(null);
 
-export function SiteStateProvider({ children }: { children: ReactNode }) {
-  const [handle, setHandleRaw] = useState(DEFAULT_HANDLE);
+export function SiteStateProvider({
+  children,
+  initialHandle = DEFAULT_HANDLE,
+}: {
+  children: ReactNode;
+  /** Whoever the server picked off the board for the preview. */
+  initialHandle?: string;
+}) {
+  const [handle, setHandleRaw] = useState(initialHandle);
 
   const setHandle = useCallback((raw: string) => {
     setHandleRaw(sanitizeHandle(raw));

--- a/apps/site/components/stat-card.tsx
+++ b/apps/site/components/stat-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { agentMark, ICON_VIEWBOX } from "@tokenchit/core";
+import { agentMark, CARD_HOST, formatShare, ICON_VIEWBOX } from "@tokenchit/core";
 
-import { DEFAULT_HANDLE } from "@/lib/sample-data";
+import type { Featured } from "@/lib/featured";
 import { useSiteState } from "./site-state";
 import styles from "./stat-card.module.css";
 
@@ -19,23 +19,14 @@ import styles from "./stat-card.module.css";
  */
 const MIX_FILLS = ["var(--lime)", "var(--ink)", "var(--seg-2)", "var(--seg-3)"];
 
-export type PreviewFigures = {
-  tokens: string;
-  spend: string;
-  streak: string;
-  mix: { agent: string; pct: number }[];
-  syncedAt: string;
-  /** True when these came from a published profile rather than the sample fallback. */
-  real: boolean;
-};
 
-export function StatCard({ preview }: { preview: PreviewFigures }) {
+export function StatCard({ preview }: { preview: Featured }) {
   const { handle } = useSiteState();
 
-  /* The figures belong to the default handle. Typing another name changes whose card this
-     looks like but not whose numbers these are, and saying so is the difference between a
-     preview and a false claim about somebody. */
-  const borrowed = preview.real && handle !== DEFAULT_HANDLE;
+  /* The figures belong to whoever the server featured. Typing another name changes whose card
+     this looks like but not whose numbers these are, and saying so is the difference between
+     a preview and a false claim about somebody. */
+  const borrowed = preview.real && handle !== preview.handle;
 
   return (
     <div className={styles.card}>
@@ -74,13 +65,13 @@ export function StatCard({ preview }: { preview: PreviewFigures }) {
               {/* The card sits on a light ground, so the light colour is always the right one. */}
               <path d={agentMark(m.agent).path} fill={agentMark(m.agent).light} />
             </svg>
-            {m.agent} {m.pct}%
+            {m.agent} {formatShare(m.pct)}
           </span>
         ))}
       </div>
 
       <div className={styles.footer}>
-        <span>{borrowed ? `@${DEFAULT_HANDLE}'S FIGURES` : "TOKENCHIT.APP"}</span>
+        <span>{borrowed ? `@${preview.handle}'S FIGURES` : CARD_HOST}</span>
         <span>{preview.syncedAt}</span>
       </div>
     </div>

--- a/apps/site/components/stat-card.tsx
+++ b/apps/site/components/stat-card.tsx
@@ -2,7 +2,7 @@
 
 import { agentMark, ICON_VIEWBOX } from "@tokenchit/core";
 
-import { OWN_STATS } from "@/lib/sample-data";
+import { DEFAULT_HANDLE } from "@/lib/sample-data";
 import { useSiteState } from "./site-state";
 import styles from "./stat-card.module.css";
 
@@ -19,8 +19,23 @@ import styles from "./stat-card.module.css";
  */
 const MIX_FILLS = ["var(--lime)", "var(--ink)", "var(--seg-2)", "var(--seg-3)"];
 
-export function StatCard() {
+export type PreviewFigures = {
+  tokens: string;
+  spend: string;
+  streak: string;
+  mix: { agent: string; pct: number }[];
+  syncedAt: string;
+  /** True when these came from a published profile rather than the sample fallback. */
+  real: boolean;
+};
+
+export function StatCard({ preview }: { preview: PreviewFigures }) {
   const { handle } = useSiteState();
+
+  /* The figures belong to the default handle. Typing another name changes whose card this
+     looks like but not whose numbers these are, and saying so is the difference between a
+     preview and a false claim about somebody. */
+  const borrowed = preview.real && handle !== DEFAULT_HANDLE;
 
   return (
     <div className={styles.card}>
@@ -30,26 +45,26 @@ export function StatCard() {
       <div className={styles.stats}>
         <div className={styles.stat}>
           <div className={styles.statLabel}>TOKENS</div>
-          <div className={styles.statValue}>{OWN_STATS.tokens}</div>
+          <div className={styles.statValue}>{preview.tokens}</div>
         </div>
         <div className={styles.stat}>
           <div className={styles.statLabel}>EQUIV. COST</div>
-          <div className={styles.statValue}>{OWN_STATS.spend}</div>
+          <div className={styles.statValue}>{preview.spend}</div>
         </div>
         <div className={styles.stat}>
           <div className={styles.statLabel}>STREAK</div>
-          <div className={styles.statValue}>{OWN_STATS.streak}</div>
+          <div className={styles.statValue}>{preview.streak}</div>
         </div>
       </div>
 
       <div className={styles.mix}>
-        {OWN_STATS.mix.map((m, i) => (
+        {preview.mix.map((m, i) => (
           <span key={m.agent} style={{ flex: m.pct, background: MIX_FILLS[i] }} />
         ))}
       </div>
 
       <div className={styles.legend}>
-        {OWN_STATS.mix.map((m) => (
+        {preview.mix.map((m) => (
           <span key={m.agent} className={styles.legendItem}>
             <svg
               className={styles.mark}
@@ -65,8 +80,8 @@ export function StatCard() {
       </div>
 
       <div className={styles.footer}>
-        <span>TOKENCHIT.APP</span>
-        <span>{OWN_STATS.syncedAt}</span>
+        <span>{borrowed ? `@${DEFAULT_HANDLE}'S FIGURES` : "TOKENCHIT.APP"}</span>
+        <span>{preview.syncedAt}</span>
       </div>
     </div>
   );

--- a/apps/site/lib/board-query.ts
+++ b/apps/site/lib/board-query.ts
@@ -47,7 +47,11 @@ export async function readBoard(window: BoardWindow, limit = 25): Promise<BoardR
      JOIN users u ON u.id = t.user_id
      LEFT JOIN latest l ON l.user_id = t.user_id
      WHERE COALESCE(l.flagged, false) = false
-     ORDER BY t.tokens DESC
+     /* Verified first, then tokens. A tier that is displayed but never affects position is
+        decoration: an unverified row could outrank a signed-in one, so the badge told you
+        nothing about the ranking you were reading. Signing in is the only thing that ties a
+        row to a GitHub account, so it is the only thing that can carry a ranking. */
+     ORDER BY (u.tier = 'verified') DESC, t.tokens DESC
      LIMIT $2`,
     [WINDOW_DAYS[window], limit],
   );

--- a/apps/site/lib/featured.ts
+++ b/apps/site/lib/featured.ts
@@ -1,0 +1,57 @@
+import "server-only";
+
+import { DEFAULT_WINDOW, type BoardRow } from "@/lib/board";
+import { cardFigures } from "@/lib/card-figures";
+import { readProfile } from "@/lib/profile";
+import { DEFAULT_HANDLE, OWN_STATS } from "@/lib/sample-data";
+import { formatSynced } from "@tokenchit/core";
+
+export type Featured = {
+  tokens: string;
+  spend: string;
+  streak: string;
+  mix: { agent: string; pct: number }[];
+  syncedAt: string;
+  /** Whose figures these are. */
+  handle: string;
+  /** False when the board was empty and these are the sample figures. */
+  real: boolean;
+};
+
+/**
+ * Somebody real to put on the front page.
+ *
+ * The hero preview used to be a fixed handle with invented figures underneath. Once that
+ * handle was a real person's, the card stated something false about their account — and no
+ * choice of fixed handle would have fixed it, because the numbers were never going to be
+ * theirs.
+ *
+ * Featuring a published member solves both halves: the figures are true, and they are
+ * attributed to the person they belong to. It also means a visitor sees somebody actually
+ * using this rather than a mock-up, which is worth more than a tidier sample.
+ *
+ * The choice lives here rather than in the page because picking is a data decision, and
+ * because React's rules of purity correctly object to a random call during render.
+ */
+export async function readFeatured(rows: BoardRow[]): Promise<Featured> {
+  const sample: Featured = { ...OWN_STATS, handle: DEFAULT_HANDLE, real: false };
+  if (rows.length === 0) return sample;
+
+  // Rotates on each revalidation, so the front page is not one person's in perpetuity.
+  const pick = rows[Math.floor(Math.random() * rows.length)]!;
+  const profile = await readProfile(pick.handle, DEFAULT_WINDOW).catch(() => null);
+  if (!profile) return sample;
+
+  const figures = cardFigures(profile);
+  return {
+    tokens: figures.tokens,
+    spend: figures.spend,
+    streak: figures.streak,
+    mix: figures.mix,
+    syncedAt: formatSynced(
+      profile.lastPublished ? new Date(profile.lastPublished) : new Date(),
+    ),
+    handle: profile.handle,
+    real: true,
+  };
+}

--- a/apps/site/lib/featured.ts
+++ b/apps/site/lib/featured.ts
@@ -4,7 +4,7 @@ import { DEFAULT_WINDOW, type BoardRow } from "@/lib/board";
 import { cardFigures } from "@/lib/card-figures";
 import { readProfile } from "@/lib/profile";
 import { DEFAULT_HANDLE, OWN_STATS } from "@/lib/sample-data";
-import { formatSynced } from "@tokenchit/core";
+import { buildCardSvg, formatSynced } from "@tokenchit/core";
 
 export type Featured = {
   tokens: string;
@@ -16,7 +16,24 @@ export type Featured = {
   handle: string;
   /** False when the board was empty and these are the sample figures. */
   real: boolean;
+  /**
+   * The three variants section 01 shows, rendered here rather than in the browser.
+   *
+   * They are the same builder the endpoint and the CLI use, so the page cannot illustrate a
+   * card that differs from the one it produces — and building them on the server keeps
+   * buildCardSvg out of the client bundle, since nothing about them is interactive.
+   */
+  cards: { light: string; dark: string; compact: string };
 };
+
+function variants(handle: string, figures: Omit<Featured, "handle" | "real" | "cards">) {
+  const base = { handle, ...figures };
+  return {
+    light: buildCardSvg({ ...base, layout: "default", theme: "light" }),
+    dark: buildCardSvg({ ...base, layout: "default", theme: "dark" }),
+    compact: buildCardSvg({ ...base, layout: "compact", theme: "light" }),
+  };
+}
 
 /**
  * Somebody real to put on the front page.
@@ -34,7 +51,12 @@ export type Featured = {
  * because React's rules of purity correctly object to a random call during render.
  */
 export async function readFeatured(rows: BoardRow[]): Promise<Featured> {
-  const sample: Featured = { ...OWN_STATS, handle: DEFAULT_HANDLE, real: false };
+  const sample: Featured = {
+    ...OWN_STATS,
+    handle: DEFAULT_HANDLE,
+    real: false,
+    cards: variants(DEFAULT_HANDLE, OWN_STATS),
+  };
   if (rows.length === 0) return sample;
 
   // Rotates on each revalidation, so the front page is not one person's in perpetuity.
@@ -42,16 +64,21 @@ export async function readFeatured(rows: BoardRow[]): Promise<Featured> {
   const profile = await readProfile(pick.handle, DEFAULT_WINDOW).catch(() => null);
   if (!profile) return sample;
 
-  const figures = cardFigures(profile);
-  return {
-    tokens: figures.tokens,
-    spend: figures.spend,
-    streak: figures.streak,
-    mix: figures.mix,
+  const derived = cardFigures(profile);
+  const figures = {
+    tokens: derived.tokens,
+    spend: derived.spend,
+    streak: derived.streak,
+    mix: derived.mix,
     syncedAt: formatSynced(
       profile.lastPublished ? new Date(profile.lastPublished) : new Date(),
     ),
+  };
+
+  return {
+    ...figures,
     handle: profile.handle,
     real: true,
+    cards: variants(profile.handle, figures),
   };
 }

--- a/apps/site/lib/sample-data.ts
+++ b/apps/site/lib/sample-data.ts
@@ -41,7 +41,13 @@ export const AGENT_BREAKDOWN = [
   { name: "opencode",    pct: "21%", w: "21%", color: "#8A8A82", tokens: "902M",  cost: "—" },
 ];
 
-/** The signed-in developer's own card figures — what the hero preview and the endpoint show. */
+/**
+ * Illustrative card figures.
+ *
+ * Used only when the default handle has no published profile to read — a fresh database, or
+ * before anyone has run `publish`. When a real profile exists the hero shows that instead,
+ * because a made-up total under a real person's handle reads as their card and is wrong.
+ */
 export const OWN_STATS = {
   tokens: "4.24B",
   spend: "$1,284",

--- a/apps/site/lib/site.ts
+++ b/apps/site/lib/site.ts
@@ -2,12 +2,11 @@
  * The site's own public origin, used wherever the page hands someone a URL to copy.
  *
  * One constant because these strings end up in other people's READMEs: a stale one there is
- * a broken image on a repo we do not control and cannot fix. When tokenchit.dev is attached,
- * change it here and in packages/cli/src/api.ts — those two are the only places that must be
- * true rather than aspirational.
+ * a broken image on a repo we do not control and cannot fix. It must be paired with
+ * packages/cli/src/api.ts, which is where the CLI decides who to publish to.
  *
- * The `TOKENCHIT.APP` wordmark printed on the card itself is deliberately not driven by this.
- * It is a signature at 8px, not a link, and a vercel.app subdomain would neither fit the
- * design nor read as a brand.
+ * The wordmark printed on the card is deliberately separate, in packages/core/src/svg.ts. It
+ * is a signature at 8px rather than a link, it has to be short enough to read at that size,
+ * and core cannot import from the site.
  */
-export const SITE_URL = "https://tokenchit.vercel.app";
+export const SITE_URL = "https://tokenchit.app";

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -9,7 +9,7 @@
  * Defined once because it was previously duplicated across login and publish, which is how
  * two defaults end up disagreeing.
  */
-export const DEFAULT_API = "https://tokenchit.vercel.app";
+export const DEFAULT_API = "https://tokenchit.app";
 
 /** Resolve the API base: explicit flag, then environment, then the default. */
 export const resolveApi = (flagValue: string | undefined): string =>

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,6 +1,7 @@
 import { resolveApi } from "../api.js";
 import { flag } from "../args.js";
 import { readAuth, writeAuth, clearAuth, authFile } from "../auth.js";
+import { copyToClipboard, openBrowser, prefilled } from "../desktop.js";
 import { post, postForm } from "../net.js";
 import { bold, cyan, dim, fail, green, grey, say, spin, warn } from "../ui.js";
 
@@ -15,6 +16,13 @@ const DEVICE_CODE_URL = "https://github.com/login/device/code";
 const TOKEN_URL = "https://github.com/login/oauth/access_token";
 
 export type SignInResult = { ok: boolean; handle?: string };
+
+export type SignInOptions = {
+  /** Put the device code on the clipboard. On by default; --no-clipboard opts out. */
+  clipboard?: boolean;
+  /** Open the verification page. On by default at a TTY; --no-browser opts out. */
+  browser?: boolean;
+};
 
 /**
  * Prove a GitHub handle is yours, using GitHub's device flow.
@@ -31,7 +39,7 @@ export type SignInResult = { ok: boolean; handle?: string };
  * Split out from the `login` command so `publish` can call it mid-flow: signing in is a step
  * on the way to publishing, not a separate errand to be sent away on.
  */
-export async function signIn(api: string): Promise<SignInResult> {
+export async function signIn(api: string, opts: SignInOptions = {}): Promise<SignInResult> {
   const start = await postForm(DEVICE_CODE_URL, { client_id: CLIENT_ID, scope: "" });
   if (!start.ok) {
     fail(`GitHub refused the device request: ${String(start.body["error"] ?? start.status)}`);
@@ -47,11 +55,32 @@ export async function signIn(api: string): Promise<SignInResult> {
   const expiresIn = Number(start.body["expires_in"] ?? 900);
   let interval = Number(start.body["interval"] ?? 5);
 
-  // The code is the one thing the reader has to act on, so it gets its own line and the
-  // only strong colour on screen.
+  /*
+   * Printed before anything is attempted, and printed whatever happens afterwards.
+   *
+   * The clipboard and the browser are conveniences over an instruction that has to stand on
+   * its own: over SSH, in a container, or on a machine with no graphical session, both will
+   * quietly do nothing, and the person is left with exactly what they had before — a URL and
+   * a code. RFC 8628 requires the code be shown in any case, as a phishing mitigation: the
+   * point is to confirm the device asking is the one in front of you.
+   */
   say();
   say(`  Open  ${bold(verifyUrl)}`);
   say(`  Code  ${bold(cyan(userCode))}`);
+
+  const copied = opts.clipboard === false ? false : await copyToClipboard(userCode);
+
+  // Only at a terminal. Launching a browser from a cron entry or a CI job is at best useless
+  // and at worst a window opening on somebody's unattended desktop.
+  const opened =
+    opts.browser === false || !process.stdout.isTTY
+      ? false
+      : await openBrowser(prefilled(verifyUrl, userCode));
+
+  if (copied || opened) {
+    const did = [opened && "opened your browser", copied && "copied the code"].filter(Boolean);
+    say(grey(`  ${did.join(", ")}${opened ? " — the code should already be filled in" : ""}`));
+  }
   say();
 
   const spinner = spin(
@@ -149,6 +178,7 @@ export async function signIn(api: string): Promise<SignInResult> {
 
 export async function login(argv: string[]): Promise<number> {
   const api = resolveApi(flag(argv, "--api"));
+  const opts = signInOptions(argv);
 
   const existing = await readAuth();
   if (existing && !argv.includes("--force")) {
@@ -160,7 +190,7 @@ export async function login(argv: string[]): Promise<number> {
     return 0;
   }
 
-  const result = await signIn(api);
+  const result = await signIn(api, opts);
   if (!result.ok) return 1;
 
   say();
@@ -184,5 +214,11 @@ export async function whoami(): Promise<number> {
   say(`@${auth.handle} ${dim(`· ${auth.api} · since ${auth.createdAt.slice(0, 10)}`)}`);
   return 0;
 }
+
+/** Reads the two opt-outs. Both default on, so absence means enabled. */
+export const signInOptions = (argv: string[]): SignInOptions => ({
+  clipboard: !argv.includes("--no-clipboard"),
+  browser: !argv.includes("--no-browser"),
+});
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -119,6 +119,16 @@ export async function publish(argv: string[], version: string): Promise<number> 
   );
   say();
 
+  /* A row held for review still has a profile, so the links below stand — but saying nothing
+     would leave someone refreshing a board they are never going to appear on. */
+  const review = res.body?.review;
+  if (typeof review === "string" && review) {
+    warn("This submission is held for review and will not appear on the board yet.");
+    say(dim(`  ${review}`));
+    say(dim("  Nothing was rejected — open an issue if this looks wrong."));
+    say();
+  }
+
   // The point of publishing. Printed last, because this is what someone actually wants out
   // of the command, and printed as full URLs so they survive a copy out of scrollback.
   say(`  ${grey("your profile")}   ${link(`${api}/u/${payload.handle}`)}`);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -14,7 +14,7 @@ import { readAuth } from "../auth.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
 import { bold, dim, fail, green, grey, link, say, spin, warn, yellow } from "../ui.js";
 import { post } from "../net.js";
-import { signIn } from "./login.js";
+import { signIn, signInOptions } from "./login.js";
 
 /**
  * The only command that sends anything anywhere.
@@ -45,7 +45,7 @@ export async function publish(argv: string[], version: string): Promise<number> 
     say();
     say(`  ${bold("Sign in to publish a verified row.")}`);
     say(grey("  Skip with --anonymous; the row is then marked unverified."));
-    const result = await signIn(api);
+    const result = await signIn(api, signInOptions(argv));
     if (!result.ok) return 1;
     auth = await readAuth();
   }

--- a/packages/cli/src/desktop.ts
+++ b/packages/cli/src/desktop.ts
@@ -1,0 +1,90 @@
+/**
+ * Talking to the desktop: the clipboard, and the browser.
+ *
+ * Both are conveniences layered over output that already stands on its own. The device code
+ * and the URL are printed before either is attempted, so a machine with no clipboard tool, no
+ * browser, or no graphical session at all loses nothing — which is the common case over SSH
+ * and inside containers, exactly where a coding agent tends to run.
+ *
+ * Nothing here throws. A failed convenience must not fail a sign-in.
+ */
+import { spawn } from "node:child_process";
+
+/** Candidate commands per platform, tried in order until one exits cleanly. */
+const CLIPBOARD: Record<string, string[][]> = {
+  darwin: [["pbcopy"]],
+  win32: [["clip"]],
+  // wl-copy first: a Wayland session usually has no working xclip, and trying it first
+  // means the common modern case succeeds on the first attempt rather than the third.
+  linux: [["wl-copy"], ["xclip", "-selection", "clipboard"], ["xsel", "--clipboard", "--input"]],
+};
+
+const BROWSER: Record<string, string[]> = {
+  darwin: ["open"],
+  win32: ["cmd", "/c", "start", ""],
+  linux: ["xdg-open"],
+};
+
+function run(cmd: string[], input?: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(cmd[0]!, cmd.slice(1), { stdio: input === undefined ? "ignore" : ["pipe", "ignore", "ignore"] });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    // ENOENT for a tool that is not installed arrives as an event, not a throw.
+    child.on("error", () => resolve(false));
+    child.on("close", (code) => resolve(code === 0));
+
+    if (input !== undefined && child.stdin) {
+      child.stdin.on("error", () => resolve(false));
+      child.stdin.end(input);
+    }
+  });
+}
+
+/** Put text on the clipboard. Returns whether it worked, and never throws. */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  for (const cmd of CLIPBOARD[process.platform] ?? []) {
+    if (await run(cmd, text)) return true;
+  }
+  return false;
+}
+
+/**
+ * Open a URL in the user's own browser.
+ *
+ * RFC 8252 requires a native app to hand authorization to an external user-agent rather than
+ * an embedded one, and RFC 8628 §3.3.1 explicitly permits "any method that results in the
+ * browser being opened with the URI". This is that method.
+ *
+ * Success here means the launcher exited cleanly, not that anyone saw a window — over SSH,
+ * xdg-open can succeed against a display nobody is looking at. That is why the URL is
+ * printed either way.
+ */
+export async function openBrowser(url: string): Promise<boolean> {
+  const cmd = BROWSER[process.platform];
+  if (!cmd) return false;
+  return run([...cmd, url]);
+}
+
+/**
+ * GitHub's device response carries no `verification_uri_complete` — RFC 8628 §3.2 makes that
+ * field optional and GitHub omits it, so there is no protocol-blessed pre-filled URL to use.
+ *
+ * The verification page does accept a `user_code` query parameter that fills the box, which
+ * is undocumented and therefore best-effort: it is used for the browser launch only, while
+ * the bare URI GitHub actually returned is what gets printed.
+ */
+export function prefilled(verificationUri: string, userCode: string): string {
+  try {
+    const url = new URL(verificationUri);
+    url.searchParams.set("user_code", userCode);
+    return url.toString();
+  } catch {
+    return verificationUri;
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -66,6 +66,8 @@ const COMMANDS: Record<string, Command> = {
     summary: "put your row on the public board",
     flags: [
       ["--anonymous", "publish without signing in; the row is marked unverified"],
+      ["--no-clipboard", "signing in: do not copy the device code"],
+      ["--no-browser", "signing in: do not open the verification page"],
       ["--dry-run", "print the exact bytes and send nothing"],
       ["--api <url>", `default ${DEFAULT_API}`],
       ["--handle <name>", ""],
@@ -99,7 +101,21 @@ const COMMANDS: Record<string, Command> = {
       "Scheduling has to run locally. The logs live on this machine and nowhere else, so a\n" +
       "GitHub Action cannot do this for you: there is nothing for it to read.",
   },
-  login: { summary: "prove your GitHub handle (device flow, no password)" },
+  login: {
+    summary: "prove your GitHub handle (device flow, no password)",
+    flags: [
+      ["--no-clipboard", "do not copy the device code"],
+      ["--no-browser", "do not open the verification page"],
+      ["--force", "sign in again when already signed in"],
+    ],
+    detail:
+      "Device flow, because a CLI cannot keep a secret. GitHub still requires a client secret\n" +
+      "for the redirect-based flow even with PKCE, so shipping that in a public package would\n" +
+      "mean publishing the secret — and a localhost callback breaks over SSH and in containers\n" +
+      "anyway, which is where a coding agent usually runs.\n\n" +
+      "The code is copied and the page is opened with it pre-filled, but both are conveniences:\n" +
+      "the URL and the code are printed first and remain correct if either quietly fails.",
+  },
   logout: { summary: "forget this machine" },
   whoami: { summary: "who this machine is signed in as" },
 };

--- a/packages/cli/test/auth.test.js
+++ b/packages/cli/test/auth.test.js
@@ -167,3 +167,39 @@ test("the banner degrades rather than wrapping or leaking into pipes", async () 
     assert.ok(printable.length <= 100, `banner line exceeds the terminal: ${printable.length}`);
   }
 });
+
+test("the verification URL is offered pre-filled, without losing the plain one", async () => {
+  // GitHub does not return verification_uri_complete — RFC 8628 makes it optional and GitHub
+  // omits it — but the verification page accepts a user_code parameter that fills the box.
+  // That is undocumented, so it is used for the browser launch only; what gets printed is
+  // whatever GitHub actually sent.
+  const { prefilled } = await import(join(HERE, "..", ".build", "desktop.js"));
+
+  assert.equal(
+    prefilled("https://github.com/login/device", "WDJB-MJHT"),
+    "https://github.com/login/device?user_code=WDJB-MJHT",
+  );
+
+  // An enterprise host with an existing query string keeps it.
+  assert.equal(
+    prefilled("https://ghe.example.com/login/device?foo=1", "AAAA-BBBB"),
+    "https://ghe.example.com/login/device?foo=1&user_code=AAAA-BBBB",
+  );
+
+  // Anything unparseable falls back rather than throwing mid sign-in.
+  assert.equal(prefilled("not a url", "AAAA-BBBB"), "not a url");
+});
+
+test("a missing clipboard tool fails quietly rather than failing the sign-in", async () => {
+  // The clipboard is a convenience over output that already stands alone. On a machine with
+  // no clipboard tool — a container, a bare SSH session — this must return false, not throw.
+  const { copyToClipboard } = await import(join(HERE, "..", ".build", "desktop.js"));
+
+  const path = process.env.PATH;
+  process.env.PATH = "/nonexistent";
+  try {
+    assert.equal(await copyToClipboard("WDJB-MJHT"), false);
+  } finally {
+    process.env.PATH = path;
+  }
+});

--- a/packages/cli/test/auth.test.js
+++ b/packages/cli/test/auth.test.js
@@ -96,9 +96,9 @@ async function walk(dir) {
 }
 
 test("the help text names the same API the CLI actually posts to", async () => {
-  // These drifted once: the default moved to tokenchit.vercel.app while --help still
-  // advertised tokenchit-site.vercel.app, a host that 404s. Anyone who copied the URL out of
-  // --help would have pointed publish at nothing.
+  // These drifted once: the default moved on while --help still advertised a host that
+  // 404s, so anyone who copied the URL out of --help pointed publish at nothing. The host has
+  // changed twice since; the point is that only one of them is written down.
   //
   // Asserted against rendered output rather than the source string, so the help stays free to
   // interpolate the constant instead of repeating it.

--- a/packages/core/src/card-svg.ts
+++ b/packages/core/src/card-svg.ts
@@ -17,7 +17,7 @@
  *     origin, so it is sanitised to [A-Za-z0-9_-]{1,16} and XML-escaped.
  */
 
-import { DARK, esc, FONT, LIGHT, render, type Palette } from "./svg.js";
+import { CARD_HOST, DARK, esc, FONT, LIGHT, render, type Palette } from "./svg.js";
 import { agentMark, ICON_VIEWBOX } from "./agent-icons.js";
 
 export type Layout = "default" | "compact";
@@ -84,6 +84,12 @@ export function formatSynced(at: Date | string, now: Date = new Date()): string 
  * rather than leaving a sub-pixel gap at the right edge.
  * Reproduces the design's numbers: 439 -> 255/92/53/39, 292 -> 169/61/35/27.
  */
+/** A legend share. Anything present but below half a percent is "<1%", never "0%". */
+export function formatShare(pct: number): string {
+  if (pct > 0 && pct < 0.5) return "<1%";
+  return `${Math.round(pct)}%`;
+}
+
 export function segmentWidths(mix: MixEntry[], track: number): number[] {
   const total = mix.reduce((a, m) => a + m.pct, 0);
   if (total <= 0 || mix.length === 0) return [];
@@ -373,7 +379,11 @@ export function buildCardSvg(opts: CardOptions): string {
           },
           // Rounded here rather than by the caller: the legend sits at 8.5px in a fixed
           // slot, and one unrounded float ("98.677606%") overruns into the next entry.
-          text: `${m.agent} ${Math.round(m.pct)}%`,
+          //
+          // A share under half a percent rounds to "0%", which reads as "this agent did
+          // nothing" beside an agent that plainly did something — the legend would not list
+          // it otherwise. "<1%" is the same width and says what is true.
+          text: `${m.agent} ${formatShare(m.pct)}`,
         }),
       );
     });
@@ -390,7 +400,7 @@ export function buildCardSvg(opts: CardOptions): string {
     render({
       tag: "text",
       attrs: { ...cls("ft"), x: g.footer.left, y: g.footer.y, ...footAttrs },
-      text: "TOKENCHIT.APP",
+      text: CARD_HOST,
     }),
   );
   parts.push(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@
  * happened the first time this was one barrel.
  */
 export * from "./agent-icons.js";
+export * from "./svg.js";
 export * from "./card-svg.js";
 export * from "./types.js";
 export * from "./aggregate.js";

--- a/packages/core/src/recap-svg.ts
+++ b/packages/core/src/recap-svg.ts
@@ -1,6 +1,6 @@
 import { handleSize, sanitizeHandle, type Theme } from "./card-svg.js";
 import { RAMP, type Recap } from "./recap.js";
-import { DARK, esc, FONT, LIGHT, render } from "./svg.js";
+import { CARD_HOST, DARK, esc, FONT, LIGHT, render } from "./svg.js";
 
 /**
  * The year-in-review, as one committable SVG.
@@ -274,7 +274,7 @@ export function buildRecapSvg(opts: RecapCardOptions): string {
     render({
       tag: "text",
       attrs: { ...cls("ft"), x: PAD, y: H - 14, "font-family": FONT, "font-size": 8, "letter-spacing": 1, fill: pal.footer },
-      text: "TOKENCHIT.APP",
+      text: CARD_HOST,
     }),
   );
   parts.push(

--- a/packages/core/src/svg.ts
+++ b/packages/core/src/svg.ts
@@ -44,11 +44,14 @@ export const DARK: Palette = {
 /**
  * The host stamped on every card and recap.
  *
- * It said TOKENCHIT.APP, which does not resolve — a watermark on a file people commit into
- * their repositories, pointing at nothing. This is the host that actually serves the site;
- * when the .app domain is bought, this is the one string to change.
+ * It read TOKENCHIT.APP for a while before that domain existed — a watermark on a file people
+ * commit into their repositories, pointing at nothing. It briefly named the vercel.app
+ * deployment instead, and now names the domain for real.
+ *
+ * One constant, shared by the card and the recap, so the two cannot disagree about where a
+ * reader should go.
  */
-export const CARD_HOST = "TOKENCHIT.VERCEL.APP";
+export const CARD_HOST = "TOKENCHIT.APP";
 
 export const FONT = "'JetBrains Mono', ui-monospace, monospace";
 

--- a/packages/core/src/svg.ts
+++ b/packages/core/src/svg.ts
@@ -41,6 +41,15 @@ export const DARK: Palette = {
   segments: ["#C6FF3D", "#FFFFFF", "#6E6E66", "#3A3A34"],
 };
 
+/**
+ * The host stamped on every card and recap.
+ *
+ * It said TOKENCHIT.APP, which does not resolve — a watermark on a file people commit into
+ * their repositories, pointing at nothing. This is the host that actually serves the site;
+ * when the .app domain is bought, this is the one string to change.
+ */
+export const CARD_HOST = "TOKENCHIT.VERCEL.APP";
+
 export const FONT = "'JetBrains Mono', ui-monospace, monospace";
 
 export const esc = (s: string) =>

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -45,6 +45,52 @@ export const LIMITS = {
   maxHandleLength: 39,
 } as const;
 
+/**
+ * The review band: plausible enough to accept, unusual enough not to rank unexamined.
+ *
+ * LIMITS above are hard rejections — arithmetically impossible or far past anything a person
+ * produces. Between "normal" and "impossible" sits a range that a heavy real user might reach
+ * and a fabricator certainly would, and rejecting it outright would turn a false positive into
+ * a locked-out user.
+ *
+ * So a submission in this band is stored and returned to its owner as normal, and marked for
+ * review, which keeps it off the public board until a human looks. Half the hard limit, which
+ * is still about 1.6x the busiest day in the corpus these figures were measured against.
+ */
+export const REVIEW = {
+  tokensPerDay: LIMITS.maxTokensPerDay / 2,
+  costPerDay: LIMITS.maxCostPerDay / 2,
+} as const;
+
+/**
+ * Why a submission should be held back from the board, or null to publish it.
+ *
+ * Separate from validatePayload because the outcomes differ: that returns errors and the
+ * submission is refused, this returns a reason and the submission is kept. A caller that
+ * conflated them would either publish what it should hold or reject what it should keep.
+ */
+export function reviewReason(p: Payload): string | null {
+  // Days arrive split by agent, so a day is only unusual once its agents are summed — three
+  // agents each sitting just under the bar is one day far over it.
+  const byDay = new Map<string, { tokens: number; cost: number }>();
+  for (const d of p.days) {
+    const acc = byDay.get(d.day) ?? { tokens: 0, cost: 0 };
+    acc.tokens += d.tokens;
+    acc.cost += d.equivCostUsd;
+    byDay.set(d.day, acc);
+  }
+
+  for (const [day, acc] of byDay) {
+    if (acc.tokens > REVIEW.tokensPerDay) {
+      return `${day} reports ${acc.tokens.toLocaleString()} tokens, above the review threshold`;
+    }
+    if (acc.cost > REVIEW.costPerDay) {
+      return `${day} reports $${acc.cost.toFixed(2)}, above the review threshold`;
+    }
+  }
+  return null;
+}
+
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   aggregate,
   buildCardSvg,
+  CARD_HOST,
   formatShare,
   reviewReason,
   REVIEW,
@@ -310,9 +311,11 @@ test("a present-but-tiny agent share is never rendered as 0%", () => {
   assert.doesNotMatch(svg, /codex 0%/);
 });
 
-test("the card stamps a host that actually resolves", () => {
-  // It stamped TOKENCHIT.APP, which does not resolve — a watermark on a file people commit
-  // into their repositories, pointing at nothing.
+test("the card stamps the host from one shared constant", () => {
+  // It once stamped TOKENCHIT.APP before that domain existed — a watermark on a file people
+  // commit into their repositories, pointing at nothing. The domain is real now, but the
+  // lesson is the constant: the card and the recap must not disagree about where to send a
+  // reader, and neither may hardcode a host of its own.
   const svg = buildCardSvg({
     handle: "dev",
     tokens: "1B",
@@ -321,6 +324,6 @@ test("the card stamps a host that actually resolves", () => {
     mix: [{ agent: "claude-code", pct: 100 }],
     syncedAt: "SYNCED 0M AGO",
   });
-  assert.doesNotMatch(svg, /TOKENCHIT\.APP/);
-  assert.match(svg, /TOKENCHIT\.VERCEL\.APP/);
+  assert.match(svg, new RegExp(CARD_HOST.replace(/\./g, "\\.")));
+  assert.doesNotMatch(svg, /VERCEL/, "the deployment host should not be stamped on a card");
 });

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   aggregate,
   buildCardSvg,
+  formatShare,
   reviewReason,
   REVIEW,
   formatTokens,
@@ -280,4 +281,46 @@ test("review looks at a whole day, not one agent at a time", () => {
 
   assert.ok(reviewReason({ days }), "summed across agents this day is over the threshold");
   assert.equal(reviewReason({ days: [days[0]] }), null, "any one of them alone is not");
+});
+
+
+test("a present-but-tiny agent share is never rendered as 0%", () => {
+  // codex at 0.4% and opencode at 0.2% both rounded to "0%" on the live card, which reads as
+  // "this agent did nothing" beside an agent that plainly did something — the legend would
+  // not list it otherwise.
+  assert.equal(formatShare(0.4), "<1%");
+  assert.equal(formatShare(0.2), "<1%");
+  assert.equal(formatShare(0), "0%", "a genuine zero still reads as zero");
+  assert.equal(formatShare(99.5), "100%");
+  assert.equal(formatShare(58), "58%");
+
+  const svg = buildCardSvg({
+    handle: "dev",
+    tokens: "10.4B",
+    spend: "$7,005",
+    streak: "25d",
+    mix: [
+      { agent: "claude-code", pct: 99.4 },
+      { agent: "codex", pct: 0.4 },
+      { agent: "opencode", pct: 0.2 },
+    ],
+    syncedAt: "SYNCED 0M AGO",
+  });
+  assert.match(svg, /codex &lt;1%/, "the card should say <1%, not 0%");
+  assert.doesNotMatch(svg, /codex 0%/);
+});
+
+test("the card stamps a host that actually resolves", () => {
+  // It stamped TOKENCHIT.APP, which does not resolve — a watermark on a file people commit
+  // into their repositories, pointing at nothing.
+  const svg = buildCardSvg({
+    handle: "dev",
+    tokens: "1B",
+    spend: "$1",
+    streak: "1d",
+    mix: [{ agent: "claude-code", pct: 100 }],
+    syncedAt: "SYNCED 0M AGO",
+  });
+  assert.doesNotMatch(svg, /TOKENCHIT\.APP/);
+  assert.match(svg, /TOKENCHIT\.VERCEL\.APP/);
 });

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -4,6 +4,8 @@ import { test } from "node:test";
 import {
   aggregate,
   buildCardSvg,
+  reviewReason,
+  REVIEW,
   formatTokens,
   formatUsd,
   handleSize,
@@ -250,4 +252,32 @@ test("a long handle is shrunk to fit rather than cut short", () => {
   const shrunk = handleSize(long, 20, 439);
   assert.ok(shrunk < 20 && shrunk > 10, `expected a smaller readable size, got ${shrunk}`);
   assert.ok((long.length + 1) * 0.6 * shrunk <= 439, "must fit the 439px track");
+});
+
+
+test("a plausible-but-extreme day is held for review, not rejected", () => {
+  // The hard limits reject the arithmetically impossible. Between "normal" and "impossible"
+  // sits a range a heavy real user might reach and a fabricator certainly would; rejecting
+  // that outright turns a false positive into a locked-out user, so it is kept and held.
+  const day = (tokens, cost) => ({ day: "2026-09-01", agent: "claude-code", tokens, equivCostUsd: cost });
+
+  assert.equal(reviewReason({ days: [day(600_000_000, 400)] }), null, "a busy real day publishes");
+
+  const held = reviewReason({ days: [day(REVIEW.tokensPerDay + 1, 400)] });
+  assert.match(held ?? "", /2026-09-01/, "an extreme day names itself in the reason");
+});
+
+test("review looks at a whole day, not one agent at a time", () => {
+  // Three agents each sitting just under the bar is one day far over it. Checking rows
+  // individually is exactly how a split submission would walk past the threshold.
+  const third = Math.ceil(REVIEW.tokensPerDay / 3) + 1;
+  const days = ["claude-code", "codex", "opencode"].map((agent) => ({
+    day: "2026-09-01",
+    agent,
+    tokens: third,
+    equivCostUsd: 1,
+  }));
+
+  assert.ok(reviewReason({ days }), "summed across agents this day is over the threshold");
+  assert.equal(reviewReason({ days: [days[0]] }), null, "any one of them alone is not");
 });

--- a/scripts/qa-board.mjs
+++ b/scripts/qa-board.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * QA for the two board behaviours that cannot be exercised with real data.
+ *
+ *   node scripts/qa-board.mjs            # run both checks, then clean up
+ *   node scripts/qa-board.mjs --keep     # leave the rows behind to inspect by hand
+ *
+ * Why a script rather than clicking around: the review threshold sits above any day a real
+ * corpus produces, and verified-first ordering needs a second competitor on a board that
+ * currently has one row. Both need data that has to be made up on purpose.
+ *
+ * It talks to a local dev server over HTTP — the same path the CLI takes — so what it proves
+ * is that the real route flags and orders correctly, not that a function returns the right
+ * value in isolation. Cleanup goes straight to Postgres, because there is deliberately no
+ * delete endpoint.
+ *
+ * Everything it creates is under handles prefixed `qa-`, and it removes them at the end.
+ */
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const API = process.env.QA_API ?? "http://localhost:3000";
+const KEEP = process.argv.includes("--keep");
+
+const REVIEW_TOKENS_PER_DAY = 1_000_000_000;
+
+let pass = 0;
+let fail = 0;
+
+const ok = (msg) => {
+  pass++;
+  console.log(`  \u001b[32m✓\u001b[0m ${msg}`);
+};
+const bad = (msg, detail) => {
+  fail++;
+  console.log(`  \u001b[31m✗\u001b[0m ${msg}`);
+  if (detail !== undefined) console.log(`      ${String(detail).slice(0, 300)}`);
+};
+
+/** Next.js only loads .env.local for itself; this script has to read it the same way. */
+async function databaseUrl() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  for (const file of [".env.local", ".env"]) {
+    try {
+      const text = await readFile(join(ROOT, "apps/site", file), "utf8");
+      const line = text.split("\n").find((l) => l.trim().startsWith("DATABASE_URL="));
+      if (line) return line.slice(line.indexOf("=") + 1).trim().replace(/^["']|["']$/g, "");
+    } catch {
+      /* next candidate */
+    }
+  }
+  return null;
+}
+
+/**
+ * A submission that passes every hard limit.
+ *
+ * `perDay` is the knob: below the review threshold it should publish and rank, above it the
+ * row should be stored and withheld. Cost is derived from tokens at a rate inside the
+ * plausibility band, because a made-up cost is exactly what the ratio check exists to catch.
+ */
+function payload(handle, { days, perDay }) {
+  const RATE = 6.7e-7; // USD per token — mid-band, nowhere near either bound
+  const rows = [];
+  for (let i = 0; i < days; i++) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    rows.push({
+      day: d.toISOString().slice(0, 10),
+      agent: "claude-code",
+      tokens: perDay,
+      equivCostUsd: Number((perDay * RATE).toFixed(4)),
+    });
+  }
+  rows.reverse();
+
+  const tokens = rows.reduce((a, r) => a + r.tokens, 0);
+  // Summed from the rows rather than computed independently: the server checks that the
+  // headline agrees with the series, and two separate calculations is how they drift.
+  const cost = Number(rows.reduce((a, r) => a + r.equivCostUsd, 0).toFixed(2));
+
+  return {
+    handle,
+    tokens,
+    equivCostUsd: cost,
+    pricedShare: 1,
+    streakDays: days,
+    activeDays: days,
+    firstDay: rows[0].day,
+    lastDay: rows[rows.length - 1].day,
+    agents: [{ agent: "claude-code", tokens }],
+    models: [{ model: "claude-opus-5", tokens, equivCostUsd: cost, priced: true }],
+    days: rows,
+    clientVersion: "qa",
+  };
+}
+
+async function publish(body) {
+  const res = await fetch(`${API}/api/submissions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+/** GET /api/submissions returns { window, rows }. */
+async function board(window = "all") {
+  const res = await fetch(`${API}/api/submissions?window=${window}`);
+  const body = await res.json().catch(() => null);
+  return body?.rows ?? [];
+}
+
+async function main() {
+  console.log(`\n  QA against ${API}\n`);
+
+  try {
+    await fetch(`${API}/api/submissions?window=all`);
+  } catch {
+    console.error(`  Cannot reach ${API}. Start it with: npm run dev\n`);
+    process.exit(1);
+  }
+
+  // ── 1. a day over the threshold is kept, and withheld ────────────────────────────────
+  console.log("  [1] a day above the review threshold");
+
+  const overHandle = "qa-over-threshold";
+  const over = await publish(payload(overHandle, { days: 2, perDay: REVIEW_TOKENS_PER_DAY + 1 }));
+
+  if (over.status === 201) ok("accepted rather than rejected (201)");
+  else bad(`expected 201, got ${over.status}`, JSON.stringify(over.body));
+
+  if (typeof over.body?.review === "string" && over.body.review) {
+    ok(`review reason returned: ${over.body.review}`);
+  } else {
+    bad("no review reason on the response — the row would be withheld silently", JSON.stringify(over.body));
+  }
+
+  const listedOver = (await board("all")).some((r) => r.handle === overHandle);
+  if (!listedOver) ok("held row does not appear on the board");
+  else bad("held row is on the board — the flag is not being applied");
+
+  // ── 2. a big-but-plausible unverified row cannot outrank a verified one ───────────────
+  console.log("\n  [2] verified outranks unverified");
+
+  const richHandle = "qa-unverified-rich";
+  // Every day stays under the review threshold, so this row is published normally. Its total
+  // is far above any real row, which is the whole point: tokens alone would put it first.
+  const rich = await publish(payload(richHandle, { days: 30, perDay: 900_000_000 }));
+  if (rich.status === 201) ok(`published ${(rich.body?.tokens / 1e9).toFixed(1)}B tokens, unverified`);
+  else bad(`expected 201, got ${rich.status}`, JSON.stringify(rich.body));
+
+  if (!rich.body?.review) ok("not held for review — every day is under the threshold");
+  else bad(`unexpectedly held: ${rich.body.review}`);
+
+  const rows = await board("all");
+  const richRow = rows.find((r) => r.handle === richHandle);
+  const verified = rows.filter((r) => r.tier === "verified");
+
+  if (!richRow) {
+    bad("the unverified row is missing from the board entirely");
+  } else if (verified.length === 0) {
+    console.log(
+      "      \u001b[33m!\u001b[0m no verified row on this board, so ordering proves nothing.",
+    );
+    console.log("        Run `tokenchit login && tokenchit publish` first, then re-run.");
+  } else {
+    const lastVerified = Math.max(...verified.map((r) => rows.indexOf(r)));
+    const richIndex = rows.indexOf(richRow);
+    if (richIndex > lastVerified) {
+      ok(
+        `ranked #${richIndex + 1}, below every verified row, despite the most tokens on the board`,
+      );
+    } else {
+      bad(`ranked #${richIndex + 1}, above a verified row — ordering is still tokens-only`);
+    }
+  }
+
+  // ── cleanup ──────────────────────────────────────────────────────────────────────────
+  console.log("");
+  if (KEEP) {
+    console.log(`  --keep: leaving ${overHandle} and ${richHandle} in place.`);
+    console.log("  Remove them later by re-running without --keep.\n");
+  } else {
+    const url = await databaseUrl();
+    if (!url) {
+      console.log("  \u001b[33m!\u001b[0m No DATABASE_URL found — nothing was deleted.");
+      console.log("    Remove the test rows with:");
+      console.log(`    DELETE FROM users WHERE handle LIKE 'qa-%';\n`);
+    } else {
+      const { default: pg } = await import("pg");
+      const client = new pg.Client({ connectionString: url });
+      await client.connect();
+      // user_days and submissions are FK'd to users; deleting the user takes the rest.
+      const res = await client.query("DELETE FROM users WHERE handle LIKE 'qa-%' RETURNING handle");
+      await client.end();
+      console.log(`  cleaned up: ${res.rows.map((r) => r.handle).join(", ") || "nothing to remove"}`);
+    }
+  }
+
+  console.log(`\n  ${pass} passed, ${fail} failed\n`);
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("\n  qa script failed:", err.message, "\n");
+  process.exit(1);
+});


### PR DESCRIPTION
Items #1 and #2 from the research, in one PR.

## #1 — The differentiator was never stated

The verified finding: **everything tokenchit ships is table stakes.** Four active projects pair local agent-log parsing with a leaderboard and profile pages; two also ship a README card. One of them — `burnlog` — parses the same three agents, ships GitHub sign-in, a leaderboard and an SVG badge.

The one structural difference is that our card is **generated locally and committed**, not served from an endpoint. The page never said so. The evidence that this matters comes from the canonical project's own docs:

> "The public Vercel instance… is best-effort and can be unreliable due to rate limits and traffic spikes." — github-readme-stats

Its cache floors are worse than its README table admits — `src/common/cache.js` on master enforces `STATS_CARD.MIN = 43200s` (12h) and `TOP_LANGS_CARD.MIN = 172800s` (48h), clamped upward regardless of what you ask for.

So the lede now says what the card is instead of leaving it to be inferred:

> The card is a file you commit, not a URL you depend on — nothing to rate-limit, nothing to go down, and it keeps working if this site does not.

The first chip becomes `no hosted endpoint`. This also fixes an accuracy problem: the old lede said "Nothing is uploaded" on a page that also sells `publish`.

## #2 — Ranking and trust

**Verified rows now rank first.** The board ordered by `t.tokens DESC` alone. `tier` was stored, displayed and ignored — an unverified row could outrank a signed-in one, so the badge told you nothing about the ordering it sat in. Signing in is the only thing that ties a row to a GitHub account, so it is the only thing that can carry a position. Unverified rows still appear with their figures.

**`flagged` was a dead safety valve.** It has existed since `001_initial.sql`, is read by `board-query`, `board-totals` and `profile` — and **nothing ever wrote to it**. The hide path was complete except for the part that could fire it.

`reviewReason()` now fills that gap for the band between normal and arithmetically impossible:

```
hard reject (LIMITS):  2,000,000,000 tokens/day   $5,000/day
held for review:       1,000,000,000 tokens/day   $2,500/day
busiest real day:        607,735,742 tokens
```

Rejecting that band outright would turn a false positive into a locked-out user, so the submission is stored, returned to its owner, and kept off the board.

**A held row is announced, not hidden.** `publish` says so, names the day that tripped it, and states nothing was rejected. Silently withholding someone's row looks like a bug to the person it happened to.

**The check sums a day across agents**, because three agents each just under the bar is one day well over it — that has a mutation-checked test, verified to fail when the summing is removed.

**The board states its own rule** now, in the page and the README. A ranking whose rules are not written down is one nobody can check.

38 core + 11 CLI tests, lint and site build pass.