### PR TITLE
Release v0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,7 +8199,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -8250,7 +8250,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Ships #38 — nine changes.

**Positioning.** The lede now states the differentiator instead of leaving it to be inferred: the card is a file you commit, not a URL you depend on.

**Ranking.** Verified rows rank first. `tier` was stored, displayed and ignored, so an unverified row could outrank a signed-in one.

**Review threshold.** `flagged` existed since the first migration and nothing ever wrote to it — the hide path was complete except for the part that could fire it. Submissions between normal and arithmetically impossible are now held, announced to their owner, and kept off the board.

**Hero and section 01** show a real board member's figures instead of invented ones under whatever handle was set.

**Card fixes.** `codex 0%` becomes `codex <1%` — 0.4% is not nothing. The footer stamps a host that resolves.

**Sign-in.** The device code is copied and the verification page opens pre-filled, so there is nothing to retype. Device flow stays: GitHub requires a client secret for the redirect flow even with PKCE.

**Domain.** Everything points at tokenchit.app. The old vercel.app host 301s, so cards already in READMEs keep working.

Plus `scripts/qa-board.mjs`, which exercises the two behaviours real data cannot reach.

Verified locally with the exact gate CI runs: build, 53 tests, lint. `--version` reports 0.4.3 and the site badge renders `v0.4.3 · MIT`.