### PR TITLE
Release v0.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,7 +8199,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -8250,7 +8250,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Ships #41.

**The scan says where it is.** `readAll` reports the adapter and event count, so `reading opencode… 216 events` with a moving number is a wait and the same line frozen names what to blame. Previously the spinner said `reading local agent logs…` and nothing else, which made a wedged run indistinguishable from a working one.

**A spinner bug this surfaced:** `update()` only took effect on the next 80ms frame, so an adapter finishing inside one tick was never drawn — `codex` and `opencode` were invisible, and a hang in either would have shown `claude-code` frozen and pointed at the wrong file. It redraws on update now.

**`npx -y`** in the site and README, so the first run does not stop on `Ok to proceed?`. Global install documented for repeat use.

Verified locally with the exact gate CI runs: build, 53 tests, lint. `--version` reports 0.4.4 and the site badge renders `v0.4.4 · MIT`.