### PR TITLE
Stop schedule writing an npx cache path into a cron job

### DIFF
--- a/packages/cli/src/commands/schedule.ts
+++ b/packages/cli/src/commands/schedule.ts
@@ -20,18 +20,38 @@ export async function schedule(argv: string[]): Promise<number> {
   const every: Every = oneOf(flag(argv, "--every"), EVERY, "every") ?? "daily";
   const cron = has(argv, "--cron") || process.platform !== "darwin";
 
-  // The path this process was started from, so the entry runs the same install the person is
-  // already using rather than whatever a future PATH happens to resolve.
+  /*
+   * A scheduled job has to survive longer than the process writing it.
+   *
+   * Using this process's own path is right for an installed copy and wrong under npx, where
+   * argv[1] points into ~/.npm/_npx/<hash>/ — a cache keyed to the exact version, pruned by
+   * npm, and never updated. A LaunchAgent pointing there runs today, pins itself to whichever
+   * version happened to be current, and one `npm cache clean` later fails every morning
+   * without saying so.
+   *
+   * So an npx run emits the durable npx command instead, and says the quieter thing is a
+   * global install.
+   */
   const entry = process.argv[1];
-  const command = entry
-    ? `${process.execPath} ${entry} publish`
-    : "npx @tokenchit/cli publish";
+  const viaNpx = !entry || /[\\/]_npx[\\/]/.test(entry);
+  const command = viaNpx
+    ? "npx -y @tokenchit/cli@latest publish"
+    : `${process.execPath} ${entry} publish`;
   const cwd = process.cwd();
 
   say();
   say(`  ${bold("Publishing is not automatic.")} ${grey("Your logs are local, so the schedule")}`);
   say(`  ${grey("has to be local too — CI has nothing to read.")}`);
   say();
+
+  if (viaNpx) {
+    // Said before the entry rather than after it, because it changes what someone should copy.
+    say(`  ${grey("Running under npx, so this uses")} ${bold("npx -y @tokenchit/cli@latest")}${grey(",")}`);
+    say(`  ${grey("which re-checks the registry on every run. For a job that fires daily:")}`);
+    say(`    ${bold("npm i -g @tokenchit/cli")}`);
+    say(`  ${grey("then re-run")} ${bold("tokenchit schedule")} ${grey("for an entry that starts faster.")}`);
+    say();
+  }
 
   if (cron) {
     const when = every === "hourly" ? "0 * * * *" : "0 9 * * *";

--- a/packages/cli/test/auth.test.js
+++ b/packages/cli/test/auth.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, readdir, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, stat, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { test } from "node:test";
@@ -202,4 +202,27 @@ test("a missing clipboard tool fails quietly rather than failing the sign-in", a
   } finally {
     process.env.PATH = path;
   }
+});
+
+test("schedule never bakes an npx cache path into a scheduled job", async () => {
+  // argv[1] under npx points into ~/.npm/_npx/<hash>/, a cache keyed to the exact version,
+  // pruned by npm and never updated. A LaunchAgent pointing there runs today, pins itself to
+  // whichever version happened to be current, and fails silently every morning after a
+  // `npm cache clean`. It must emit a durable command instead.
+  //
+  // Reproduced the way npx actually does it — the binary really is invoked from inside a
+  // _npx path — rather than by faking argv, which would not exercise the same code path.
+  const box = await sandbox();
+  const binDir = join(box.home, ".npm", "_npx", "d414d16f3454c6a4", "node_modules", ".bin");
+  await mkdir(binDir, { recursive: true });
+  const shim = join(binDir, "tokenchit");
+  await symlink(CLI, shim);
+
+  const { stdout } = await run(process.execPath, [shim, "schedule", "--cron"], {
+    cwd: box.cwd,
+    env: { ...process.env, HOME: box.home, NO_COLOR: "1" },
+  });
+
+  assert.ok(!stdout.includes("_npx"), `an npx cache path leaked into the entry:\n${stdout}`);
+  assert.match(stdout, /npx -y @tokenchit\/cli@latest publish/, "expected the durable command");
 });


### PR DESCRIPTION
Your `schedule` output contained this:

```xml
<string>/Users/yash/.npm/_npx/d414d16f3454c6a4/node_modules/.bin/tokenchit</string>
```

That is an npx **cache** directory — there are 15 of them on that machine. It is keyed to the exact version resolved at the time, pruned by npm, and never updated. A LaunchAgent pointing there:

- runs correctly today,
- pins itself to 0.4.4 forever,
- and fails silently every morning after a `npm cache clean`.

Reading `argv[1]` is right for an installed copy and wrong under npx — which is how the site tells everyone to run this, so **the common path was the broken one**.

An npx run now emits `npx -y @tokenchit/cli@latest publish`, which keeps working and stays current, and says plainly that a global install makes the job start faster:

```
  Running under npx, so this uses npx -y @tokenchit/cli@latest,
  which re-checks the registry on every run. For a job that fires daily:
    npm i -g @tokenchit/cli
  then re-run tokenchit schedule for an entry that starts faster.

  0 9 * * * cd /path && npx -y @tokenchit/cli@latest publish >/dev/null 2>&1
```

The test reproduces npx rather than faking it — a real symlink inside a real `_npx` path, invoked for real, because faking `argv` would not exercise the code that matters. Mutation-checked: it fails when the path check is removed.

## It also settles the stall

`schedule` reads no logs and makes no network call — it prints a plist and exits. It still hung after `Ok to proceed?`, with a Braille spinner on screen. **That spinner is npm's, not ours** (same frames, which is why it looked like ours). The wait is npm installing the package, before any of this code runs.

Nothing in the CLI can shorten that. `npm i -g @tokenchit/cli` avoids it entirely, which is now recommended in the one place it matters most.

54 tests, lint and build pass.