### PR TITLE
Release v0.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,7 +8199,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -8250,7 +8250,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Ships #43.

`schedule` was writing an npx cache path into the entry it printed — `~/.npm/_npx/<hash>/node_modules/.bin/tokenchit`. That directory is keyed to the exact resolved version, pruned by npm, and never updated, so a saved LaunchAgent or crontab line would run today, pin itself to whichever version was current, and fail silently after any `npm cache clean`.

Reading `argv[1]` is correct for an installed copy and wrong under npx, which is how the site tells everyone to run it — so the common path was the broken one. It now emits `npx -y @tokenchit/cli@latest publish` and recommends a global install for a job that fires daily.

The test reproduces npx with a real symlink inside a real `_npx` path rather than faking `argv`. Mutation-checked.

Verified locally with the exact gate CI runs: build, 54 tests, lint. `--version` reports 0.4.5 and the site badge renders `v0.4.5 · MIT`.