### PR TITLE
Put the board first, and cut the nav to two

### DIFF
--- a/apps/site/app/board/board.module.css
+++ b/apps/site/app/board/board.module.css
@@ -256,3 +256,61 @@
   color: var(--ink);
   font-weight: 700;
 }
+
+/* ── Pagination ──────────────────────────────────────────────────────────── */
+
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 14px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.pageLinks {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.pager a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 2px solid var(--lime);
+  padding-bottom: 1px;
+}
+
+.pager a:hover {
+  background: var(--lime);
+}
+
+/* Kept in the layout rather than hidden: the controls should not move as you page. */
+.disabled {
+  opacity: 0.35;
+}
+
+.range,
+.pageOf {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Notes, below the table ──────────────────────────────────────────────── */
+
+.notes {
+  margin-top: 40px;
+  border-top: 2px solid var(--ink);
+  padding-top: 18px;
+}
+
+.notesHead {
+  margin: 0 0 10px;
+  font-family: var(--font-display), sans-serif;
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}

--- a/apps/site/app/board/page.tsx
+++ b/apps/site/app/board/page.tsx
@@ -22,18 +22,31 @@ export const metadata: Metadata = {
 const MEDALS = ["#FFD23D", "#E4E2D8", "#F0B37E"] as const;
 const SEGMENTS = [styles.seg0, styles.seg1, styles.seg2] as const;
 
+/** A page that fits on a screen rather than becoming a scroll. */
+const PER_PAGE = 25;
+
 export default async function BoardPage({
   searchParams,
 }: {
-  searchParams: Promise<{ window?: string }>;
+  searchParams: Promise<{ window?: string; page?: string }>;
 }) {
-  const requested = (await searchParams).window ?? null;
+  const params = await searchParams;
+  const requested = params.window ?? null;
   const window: BoardWindow = isWindow(requested) ? requested : "year";
 
+  const page = Math.max(1, Number(params.page ?? 1) || 1);
+  const offset = (page - 1) * PER_PAGE;
+
   const [rows, totals] = await Promise.all([
-    readBoard(window, 100).catch(() => []),
+    readBoard(window, PER_PAGE, offset).catch(() => []),
     readBoardTotals(window).catch(() => null),
   ]);
+
+  const total = totals?.developers ?? rows.length;
+  const lastPage = Math.max(1, Math.ceil(total / PER_PAGE));
+  const from = total === 0 ? 0 : offset + 1;
+  const to = offset + rows.length;
+  const href = (p: number) => `/board?window=${window}${p > 1 ? `&page=${p}` : ""}`;
 
   const summary: [string, string][] = totals
     ? [
@@ -51,21 +64,12 @@ export default async function BoardPage({
         <span className={styles.sticker}>opt-in</span>
       </header>
 
+      {/* One line, because someone arriving here came to read a ranking. The rules that
+          govern it are worth stating and are stated — underneath the table, where they answer
+          a question the reader has by then actually formed. */}
       <p className={styles.intro}>
-        Everyone who ran <span className={styles.strong}>{cmd("publish")}</span>. Rank is
-        total tokens over the selected window, and every column — cost, agent mix — covers
-        that same window. It is a usage count, not a skill score.
-      </p>
-
-      {/* Stated rather than left to be inferred from the ordering. A ranking whose rules are
-          not written down is one nobody can check, and the verified-first rule in particular
-          is invisible until it costs someone a place. */}
-      <p className={styles.intro}>
-        <span className={styles.strong}>How this is ranked.</span> Verified rows first, then
-        tokens. Signing in is the only thing that ties a row to a GitHub account, so it is the
-        only thing that can carry a position — an unverified row still appears and still shows
-        its figures, it just cannot outrank a verified one. Submissions far outside the range
-        of real usage are held for review and do not appear until a person has looked at them.
+        Everyone who ran <span className={styles.strong}>{cmd("publish")}</span>. A usage
+        count over the selected window, not a skill score.
       </p>
 
       <nav className={styles.windows} aria-label="Time window">
@@ -166,13 +170,57 @@ export default async function BoardPage({
         </div>
       )}
 
-      <p className={styles.foot}>
-        A <span className={styles.strong}>cli</span> badge means the numbers were self-reported
-        without a GitHub sign-in; those rows stay on the board rather than being hidden, because
-        a visible unverified row is more honest than a quietly filtered one. Streak is the
-        current run of active days, which is not a windowed figure. Figures are self-reported
-        and bounded for plausibility, not audited.
-      </p>
+      {rows.length > 0 && (
+        /* Shown even on a single page, because "1–2 of 2" answers "is this everyone?" — which
+           is the first thing a ranking makes someone wonder, and a bare table never says. */
+        <nav className={styles.pager} aria-label="Board pages">
+          <span className={styles.range}>
+            {from}–{to} of {total}
+          </span>
+
+          <span className={styles.pageLinks}>
+            {page > 1 ? (
+              <Link href={href(page - 1)} rel="prev">
+                ← prev
+              </Link>
+            ) : (
+              <span className={styles.disabled}>← prev</span>
+            )}
+            <span className={styles.pageOf}>
+              page {page} of {lastPage}
+            </span>
+            {page < lastPage ? (
+              <Link href={href(page + 1)} rel="next">
+                next →
+              </Link>
+            ) : (
+              <span className={styles.disabled}>next →</span>
+            )}
+          </span>
+        </nav>
+      )}
+
+      {/* The rules live here rather than above the table. A reader arriving at a leaderboard
+          wants the leaderboard; the question "why is that one first?" only forms once they
+          have seen it, and this is where they are when they ask. */}
+      <section className={styles.notes}>
+        <h2 className={styles.notesHead}>How this is ranked</h2>
+        <p className={styles.foot}>
+          Verified rows first, then tokens over the selected window. Signing in is the only
+          thing that ties a row to a GitHub account, so it is the only thing that can carry a
+          position — an unverified row still appears with its figures, it just cannot outrank a
+          verified one. Every column covers the same window as the rank.
+        </p>
+        <p className={styles.foot}>
+          A <span className={styles.strong}>cli</span> badge means the numbers were
+          self-reported without a GitHub sign-in; those rows stay on the board rather than being
+          hidden, because a visible unverified row is more honest than a quietly filtered one.
+          Streak is the current run of active days, which is not a windowed figure. Submissions
+          far outside the range of real usage are held for review and do not appear until a
+          person has looked. Figures are self-reported and bounded for plausibility, not
+          audited.
+        </p>
+      </section>
     </PageShell>
   );
 }

--- a/apps/site/components/site-header.module.css
+++ b/apps/site/components/site-header.module.css
@@ -13,6 +13,18 @@
   gap: 12px;
 }
 
+/* The anchor wraps the badge; the badge keeps its own shadow and colour. */
+.home {
+  display: inline-block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.home:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
+}
+
 .wordmark {
   display: inline-block;
   padding: 10px 16px;

--- a/apps/site/components/site-header.tsx
+++ b/apps/site/components/site-header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 
 import { GithubMark } from "./github-mark";
@@ -8,14 +9,20 @@ import { PRIMARY_COMMAND, VERSION_LABEL } from "@/lib/cli";
 
 const LOGIN = PRIMARY_COMMAND;
 
-// Root-relative, not bare fragments: these render on /u/<handle> and /board too, where a
-// bare "#card" points at an anchor that does not exist on the page.
+/*
+ * Two destinations, not five.
+ *
+ * Verify, privacy and recap were anchors into the homepage — three links that scroll you
+ * somewhere on a page you may not be on, competing for attention with the two things anyone
+ * actually navigates to. The sections still exist and still have their ids; they are reached
+ * by reading the page, which is what a one-page site is for.
+ *
+ * Root-relative rather than bare fragments: these render on /u/<handle> and /board too, where
+ * "#card" would point at an anchor that does not exist on the page.
+ */
 const NAV = [
   { href: "/#card", label: "card" },
   { href: "/board", label: "board" },
-  { href: "/#verification", label: "verify" },
-  { href: "/#privacy", label: "privacy" },
-  { href: "/#recap", label: "recap" },
 ];
 
 /**
@@ -49,7 +56,11 @@ export function SiteHeader() {
   return (
     <header className={styles.header}>
       <div className={styles.brand}>
-        <span className={styles.wordmark}>tokenchit</span>
+        {/* The wordmark is the way home, which is what every reader already assumes. It was
+            inert on /board and /u/<handle> — the two pages where someone most needs it. */}
+        <Link href="/" className={styles.home} aria-label="tokenchit home">
+          <span className={styles.wordmark}>tokenchit</span>
+        </Link>
         <span className={styles.version}>{VERSION_LABEL}</span>
       </div>
 

--- a/apps/site/lib/board-query.ts
+++ b/apps/site/lib/board-query.ts
@@ -18,7 +18,11 @@ import { WINDOW_DAYS, type BoardRow, type BoardWindow } from "@/lib/board";
  * Streak is the exception and is deliberately not windowed: it is a current-streak count, and
  * "your streak, but only counting last week" is not something anyone means.
  */
-export async function readBoard(window: BoardWindow, limit = 25): Promise<BoardRow[]> {
+export async function readBoard(
+  window: BoardWindow,
+  limit = 25,
+  offset = 0,
+): Promise<BoardRow[]> {
   const { rows } = await pool.query(
     `WITH windowed AS (
        SELECT d.user_id, d.agent,
@@ -52,12 +56,13 @@ export async function readBoard(window: BoardWindow, limit = 25): Promise<BoardR
         nothing about the ranking you were reading. Signing in is the only thing that ties a
         row to a GitHub account, so it is the only thing that can carry a ranking. */
      ORDER BY (u.tier = 'verified') DESC, t.tokens DESC
-     LIMIT $2`,
-    [WINDOW_DAYS[window], limit],
+     LIMIT $2 OFFSET $3`,
+    [WINDOW_DAYS[window], limit, offset],
   );
 
   return rows.map((r, i) => ({
-    rank: i + 1,
+    // Rank is the position on the whole board, not within this page — page two starts at 26.
+    rank: offset + i + 1,
     handle: r.handle,
     tier: r.tier,
     tokens: Number(r.tokens),


### PR DESCRIPTION
## The board leads with the board

Someone opening `/board` came for a ranking and met **two paragraphs of rules** before seeing a single row. Those rules are worth stating — a ranking nobody can check is not worth reading — but the question *"why is that one first?"* only forms **after** you have seen the ranking. They now sit under the table, where the reader is when they ask.

Above the table is one line. Below it: window filter → totals → table → pagination → the rules.

## Pagination

Replaces a hardcoded `limit = 100`. Twenty-five a page, `LIMIT/OFFSET`, with rank reflecting the whole board rather than the page — **page two starts at 26**, not 1.

Two details that are easy to get wrong:

- The range shows `1–2 of 2` **even when everything fits on one page**. "Is this everyone?" is the first thing a leaderboard makes someone wonder, and a bare table never answers it.
- Prev/next stay in the layout when disabled, greyed, so the controls do not shift under the cursor as you page.

## Nav: two items

`verify`, `privacy` and `recap` were anchors that scroll you into a page you may not be on, competing for attention with the two things anyone actually navigates to. The sections and their ids are untouched — they are reached by reading the page, which is what a one-page site is for.

## The wordmark is a link

It was inert on `/board` and `/u/<handle>` — the two pages where someone most needs it, and where every reader already expects it to work. Uses `next/link` (the linter was right to insist).

54 tests, lint and build pass.