### PR TITLE
Rank movement and a thirty-day sparkline

### DIFF
--- a/apps/site/app/board/board.module.css
+++ b/apps/site/app/board/board.module.css
@@ -347,3 +347,31 @@
   font-size: 9px;
   text-transform: uppercase;
 }
+
+/* ── Sparkline ───────────────────────────────────────────────────────────── */
+
+.wSpark {
+  width: 130px;
+}
+
+.sparkCell {
+  padding-top: 6px;
+  padding-bottom: 4px;
+}
+
+.spark {
+  display: block;
+}
+
+.sparkBar {
+  fill: var(--ink);
+}
+
+/* Drawn at zero height, so an idle day occupies its slot without claiming activity. */
+.sparkGap {
+  fill: none;
+}
+
+.sparkEmpty {
+  color: var(--text-faint);
+}

--- a/apps/site/app/board/board.module.css
+++ b/apps/site/app/board/board.module.css
@@ -314,3 +314,36 @@
   font-weight: 800;
   letter-spacing: -0.01em;
 }
+
+/* ── Rank movement ───────────────────────────────────────────────────────── */
+
+.move {
+  display: inline-block;
+  margin-left: 7px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  vertical-align: middle;
+}
+
+.moveUp {
+  color: #3F8F2E;
+}
+
+.moveDown {
+  color: var(--coral, #FF5C3D);
+}
+
+/* Present but quiet: a row that has not moved should not compete with one that has. */
+.moveFlat {
+  color: var(--text-faint);
+}
+
+.moveNew {
+  background: var(--lime);
+  border: 1.5px solid var(--ink);
+  padding: 0 4px;
+  font-size: 9px;
+  text-transform: uppercase;
+}

--- a/apps/site/app/board/page.tsx
+++ b/apps/site/app/board/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { formatTokens, formatUsd } from "@tokenchit/core";
 
 import { PageShell } from "@/components/page-shell";
-import { isWindow, WINDOWS, type BoardWindow } from "@/lib/board";
+import { isWindow, WINDOWS, type BoardRow, type BoardWindow } from "@/lib/board";
 import { readBoard } from "@/lib/board-query";
 import { readBoardTotals } from "@/lib/board-totals";
 
@@ -21,6 +21,40 @@ export const metadata: Metadata = {
 /** Gold, silver, bronze. Only the top three; everyone else takes the default fill. */
 const MEDALS = ["#FFD23D", "#E4E2D8", "#F0B37E"] as const;
 const SEGMENTS = [styles.seg0, styles.seg1, styles.seg2] as const;
+
+/**
+ * How a row has moved since a week ago.
+ *
+ * `previousRank` is null for someone who was not ranked then — a new entrant, not a row that
+ * held position zero, and the difference matters because "NEW" is the more interesting fact.
+ *
+ * A row can fall without doing anything wrong: if two people pass it, it drops two places on
+ * unchanged usage. That is what a ranking means, and showing it is more honest than showing
+ * only the rises.
+ */
+function movement(r: BoardRow) {
+  if (r.previousRank === null) {
+    return <span className={`${styles.move} ${styles.moveNew}`}>new</span>;
+  }
+  const delta = r.previousRank - r.rank;
+  if (delta === 0) {
+    return (
+      <span className={`${styles.move} ${styles.moveFlat}`} title="unchanged since last week">
+        –
+      </span>
+    );
+  }
+  const up = delta > 0;
+  return (
+    <span
+      className={`${styles.move} ${up ? styles.moveUp : styles.moveDown}`}
+      title={`${up ? "up" : "down"} ${Math.abs(delta)} since last week`}
+    >
+      {up ? "▲" : "▼"}
+      {Math.abs(delta)}
+    </span>
+  );
+}
 
 /** A page that fits on a screen rather than becoming a scroll. */
 const PER_PAGE = 25;
@@ -115,7 +149,7 @@ export default async function BoardPage({
               </tr>
             </thead>
             <tbody>
-              {rows.map((r, i) => {
+              {rows.map((r) => {
                 const mix = Object.entries(r.mix).sort((a, b) => b[1] - a[1]);
                 const mixTotal = mix.reduce((a, [, n]) => a + n, 0);
                 return (
@@ -123,10 +157,11 @@ export default async function BoardPage({
                     <td>
                       <span
                         className={styles.rank}
-                        style={{ background: i < 3 ? MEDALS[i] : "var(--surface)" }}
+                        style={{ background: r.rank <= 3 ? MEDALS[r.rank - 1] : "var(--surface)" }}
                       >
                         {r.rank}
                       </span>
+                      {movement(r)}
                     </td>
                     <td>
                       <Link href={`/u/${r.handle}`} className={styles.dev}>

--- a/apps/site/app/board/page.tsx
+++ b/apps/site/app/board/page.tsx
@@ -56,6 +56,49 @@ function movement(r: BoardRow) {
   );
 }
 
+/**
+ * Thirty days of daily tokens as a bar chart, scaled to the row's own peak.
+ *
+ * Per-row rather than shared: the point is the shape of one person's month, and scaling every
+ * row to the board's busiest day would flatten everyone below the leader into a straight line.
+ * The comparison between people is the tokens column, which is already there.
+ */
+function Spark({ days }: { days: number[] }) {
+  const peak = Math.max(...days, 0);
+  if (peak <= 0) return <span className={styles.sparkEmpty}>—</span>;
+
+  const w = 3;
+  const gap = 1;
+  const h = 18;
+
+  return (
+    <svg
+      className={styles.spark}
+      width={days.length * (w + gap)}
+      height={h}
+      viewBox={`0 0 ${days.length * (w + gap)} ${h}`}
+      role="img"
+      aria-label={`Daily tokens over the last ${days.length} days`}
+    >
+      {days.map((v, i) => {
+        // A day with activity is never invisible: a real but tiny value still gets a pixel,
+        // because "nothing happened" and "barely anything happened" are different facts.
+        const bar = v <= 0 ? 0 : Math.max(1.5, (v / peak) * h);
+        return (
+          <rect
+            key={i}
+            x={i * (w + gap)}
+            y={h - bar}
+            width={w}
+            height={bar}
+            className={v > 0 ? styles.sparkBar : styles.sparkGap}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
 /** A page that fits on a screen rather than becoming a scroll. */
 const PER_PAGE = 25;
 
@@ -143,6 +186,7 @@ export default async function BoardPage({
                 <th className={styles.wRank}>rank</th>
                 <th>developer</th>
                 <th className={styles.wMix}>agent mix</th>
+                <th className={styles.wSpark}>last 30d</th>
                 <th className={`${styles.wNum} ${styles.num}`}>tokens</th>
                 <th className={`${styles.wNum} ${styles.num}`}>equiv. cost</th>
                 <th className={`${styles.wStreak} ${styles.num}`}>streak</th>
@@ -191,6 +235,9 @@ export default async function BoardPage({
                           />
                         ))}
                       </div>
+                    </td>
+                    <td className={styles.sparkCell}>
+                      <Spark days={r.spark} />
                     </td>
                     <td className={`${styles.num} ${styles.tokens}`}>
                       {formatTokens(r.tokens)}

--- a/apps/site/lib/board-query.ts
+++ b/apps/site/lib/board-query.ts
@@ -1,7 +1,13 @@
 import "server-only";
 
 import { pool } from "@/lib/db";
-import { MOVEMENT_DAYS, WINDOW_DAYS, type BoardRow, type BoardWindow } from "@/lib/board";
+import {
+  MOVEMENT_DAYS,
+  SPARK_DAYS,
+  WINDOW_DAYS,
+  type BoardRow,
+  type BoardWindow,
+} from "@/lib/board";
 
 /**
  * Read the board for one window.
@@ -67,6 +73,16 @@ export async function readBoard(
        FROM submissions
        ORDER BY user_id, received_at DESC
      ),
+     spark_rolled AS (
+       SELECT user_id, array_agg(t ORDER BY dt) AS days, array_agg(dt ORDER BY dt) AS dates
+       FROM (
+         SELECT user_id, day AS dt, SUM(tokens) AS t
+         FROM user_days
+         WHERE day > CURRENT_DATE - $5::int
+         GROUP BY user_id, day
+       ) x
+       GROUP BY user_id
+     ),
      ranked_now AS (
        SELECT e.id, e.handle, e.tier, t.tokens, t.cost, t.mix,
               ROW_NUMBER() OVER (ORDER BY (e.tier = 'verified') DESC, t.tokens DESC) AS rank
@@ -85,13 +101,16 @@ export async function readBoard(
      )
      SELECT r.handle, r.tier, r.tokens, r.cost, r.mix, r.rank,
             COALESCE(l.streak_days, 0) AS streak_days,
-            rb.rank AS previous_rank
+            rb.rank AS previous_rank,
+            sp.days AS spark_days,
+            sp.dates AS spark_dates
      FROM ranked_now r
      LEFT JOIN latest l  ON l.user_id = r.id
      LEFT JOIN ranked_before rb ON rb.user_id = r.id
+     LEFT JOIN spark_rolled sp ON sp.user_id = r.id
      ORDER BY r.rank
      LIMIT $2 OFFSET $3`,
-    [WINDOW_DAYS[window], limit, offset, MOVEMENT_DAYS],
+    [WINDOW_DAYS[window], limit, offset, MOVEMENT_DAYS, SPARK_DAYS],
   );
 
   return rows.map((r) => ({
@@ -108,5 +127,30 @@ export async function readBoard(
     ),
     // null means "not ranked a week ago" — a new entrant, not a row that held position 0.
     previousRank: r.previous_rank === null ? null : Number(r.previous_rank),
+    spark: densify(r.spark_dates as string[] | null, r.spark_days as string[] | null),
   }));
+}
+
+/**
+ * Turn the days a user actually has into one value per day, zeros included.
+ *
+ * The query returns only days with activity, because storing a row per idle day would be a
+ * lot of nothing. A sparkline needs the gaps though — without them a fortnight off looks like
+ * the bars simply moving closer together, which reads as steady work.
+ */
+function densify(dates: string[] | null, values: string[] | null): number[] {
+  const out = new Array<number>(SPARK_DAYS).fill(0);
+  if (!dates || !values) return out;
+
+  const byDay = new Map<string, number>();
+  dates.forEach((d, i) => byDay.set(String(d).slice(0, 10), Number(values[i] ?? 0)));
+
+  const today = new Date();
+  for (let i = 0; i < SPARK_DAYS; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - (SPARK_DAYS - 1 - i));
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    out[i] = byDay.get(key) ?? 0;
+  }
+  return out;
 }

--- a/apps/site/lib/board-query.ts
+++ b/apps/site/lib/board-query.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { pool } from "@/lib/db";
-import { WINDOW_DAYS, type BoardRow, type BoardWindow } from "@/lib/board";
+import { MOVEMENT_DAYS, WINDOW_DAYS, type BoardRow, type BoardWindow } from "@/lib/board";
 
 /**
  * Read the board for one window.
@@ -24,7 +24,19 @@ export async function readBoard(
   offset = 0,
 ): Promise<BoardRow[]> {
   const { rows } = await pool.query(
-    `WITH windowed AS (
+    `WITH eligible AS (
+       /* Everyone whose latest submission is not held for review. Computed once and reused by
+          both rankings, so a flagged row cannot be absent from one and present in the other —
+          which would make every position below it move for no reason. */
+       SELECT u.id, u.handle, u.tier
+       FROM users u
+       LEFT JOIN LATERAL (
+         SELECT flagged, streak_days FROM submissions
+         WHERE user_id = u.id ORDER BY received_at DESC LIMIT 1
+       ) l ON true
+       WHERE COALESCE(l.flagged, false) = false
+     ),
+     windowed AS (
        SELECT d.user_id, d.agent,
               SUM(d.tokens)   AS tokens,
               SUM(d.cost_usd) AS cost
@@ -40,29 +52,52 @@ export async function readBoard(
        FROM windowed
        GROUP BY user_id
      ),
+     before AS (
+       /* The same window, shifted back. user_days keeps the whole daily series, so the board
+          as it stood a week ago is a query rather than a snapshot — no extra table, and no
+          waiting for history to start accumulating. */
+       SELECT d.user_id, SUM(d.tokens) AS tokens
+       FROM user_days d
+       WHERE d.day >= CURRENT_DATE - $1::int - $4::int
+         AND d.day <  CURRENT_DATE - $4::int
+       GROUP BY d.user_id
+     ),
      latest AS (
-       SELECT DISTINCT ON (user_id) user_id, streak_days, flagged
+       SELECT DISTINCT ON (user_id) user_id, streak_days
        FROM submissions
        ORDER BY user_id, received_at DESC
+     ),
+     ranked_now AS (
+       SELECT e.id, e.handle, e.tier, t.tokens, t.cost, t.mix,
+              ROW_NUMBER() OVER (ORDER BY (e.tier = 'verified') DESC, t.tokens DESC) AS rank
+       FROM totals t
+       JOIN eligible e ON e.id = t.user_id
+     ),
+     ranked_before AS (
+       /* Tier is today's, because no historical tier is stored. Someone who verified this week
+          therefore shows the rise that verifying earned them, which is the honest reading of
+          what changed. */
+       SELECT b.user_id,
+              ROW_NUMBER() OVER (ORDER BY (e.tier = 'verified') DESC, b.tokens DESC) AS rank
+       FROM before b
+       JOIN eligible e ON e.id = b.user_id
+       WHERE b.tokens > 0
      )
-     SELECT u.handle, u.tier, t.tokens, t.cost, t.mix,
-            COALESCE(l.streak_days, 0) AS streak_days
-     FROM totals t
-     JOIN users u ON u.id = t.user_id
-     LEFT JOIN latest l ON l.user_id = t.user_id
-     WHERE COALESCE(l.flagged, false) = false
-     /* Verified first, then tokens. A tier that is displayed but never affects position is
-        decoration: an unverified row could outrank a signed-in one, so the badge told you
-        nothing about the ranking you were reading. Signing in is the only thing that ties a
-        row to a GitHub account, so it is the only thing that can carry a ranking. */
-     ORDER BY (u.tier = 'verified') DESC, t.tokens DESC
+     SELECT r.handle, r.tier, r.tokens, r.cost, r.mix, r.rank,
+            COALESCE(l.streak_days, 0) AS streak_days,
+            rb.rank AS previous_rank
+     FROM ranked_now r
+     LEFT JOIN latest l  ON l.user_id = r.id
+     LEFT JOIN ranked_before rb ON rb.user_id = r.id
+     ORDER BY r.rank
      LIMIT $2 OFFSET $3`,
-    [WINDOW_DAYS[window], limit, offset],
+    [WINDOW_DAYS[window], limit, offset, MOVEMENT_DAYS],
   );
 
-  return rows.map((r, i) => ({
-    // Rank is the position on the whole board, not within this page — page two starts at 26.
-    rank: offset + i + 1,
+  return rows.map((r) => ({
+    // Ranked in SQL now, because the previous ranking has to be computed over everyone
+    // rather than over one page: a row's movement depends on people who are not on it.
+    rank: Number(r.rank),
     handle: r.handle,
     tier: r.tier,
     tokens: Number(r.tokens),
@@ -71,5 +106,7 @@ export async function readBoard(
     mix: Object.fromEntries(
       Object.entries(r.mix as Record<string, string>).map(([a, n]) => [a, Number(n)]),
     ),
+    // null means "not ranked a week ago" — a new entrant, not a row that held position 0.
+    previousRank: r.previous_rank === null ? null : Number(r.previous_rank),
   }));
 }

--- a/apps/site/lib/board.ts
+++ b/apps/site/lib/board.ts
@@ -14,7 +14,19 @@ export type BoardRow = {
   streakDays: number;
   /** Agent id to tokens, over the same window as the rest of the row. */
   mix: Record<string, number>;
+  /**
+   * Where this row stood a week ago, or null if it was not on the board then.
+   *
+   * Derived rather than recorded: user_days holds the whole daily series, so the same window
+   * shifted back seven days gives the ranking as it was, without a snapshot table and without
+   * waiting for history to accumulate.
+   */
+  previousRank: number | null;
 };
+
+/** How far back "movement" looks. A week is long enough to mean something and short enough to
+ *  still be about now. */
+export const MOVEMENT_DAYS = 7;
 
 export const WINDOWS = [
   { key: "year", label: "this year" },

--- a/apps/site/lib/board.ts
+++ b/apps/site/lib/board.ts
@@ -22,7 +22,18 @@ export type BoardRow = {
    * waiting for history to accumulate.
    */
   previousRank: number | null;
+  /**
+   * Daily tokens for the last SPARK_DAYS days, oldest first, zeros included.
+   *
+   * Two people with the same total are indistinguishable on a leaderboard until you can see
+   * the shape of it — one steady, one a single enormous week. Zeros are kept rather than
+   * skipped so a gap reads as a gap instead of the bars simply moving closer together.
+   */
+  spark: number[];
 };
+
+/** A month is long enough to show a rhythm and short enough to fit beside a row. */
+export const SPARK_DAYS = 30;
 
 /** How far back "movement" looks. A week is long enough to mean something and short enough to
  *  still be about now. */


### PR DESCRIPTION
Both board insights, and one of them corrects something I told you.

## Rank movement needs no snapshot table

I said this required a new table and weeks of accumulating history before it could exist. **That was wrong.** `user_days` already holds the whole daily series, so the board as it stood a week ago is the same query over a window shifted back seven days. No new table, no scheduled job, and it is correct the day it ships rather than in a month.

```
▲2   climbed two places
▼3   fell three
–    unchanged
new  was not ranked a week ago
```

Three details that decide whether this is honest:

- **`new` rather than a climb from an imaginary position.** `previousRank` is null for someone who was not ranked then, and that is the more interesting fact about them.
- **Falls are shown, not just rises.** A row can drop two places on unchanged usage because two people passed it. That is what a ranking means.
- **Both rankings use the same eligible set**, so a held-for-review row cannot be absent from one and present in the other — which would move every position below it for no reason.

Tier is today's in both, since no historical tier is stored. Someone who verified this week shows the rise verifying earned them, which is what actually changed.

**Verified two ways:** against the live database, and the arithmetic proved separately over synthetic rows — a climber reads `up 2`, a faller `down 3`, an unchanged row that was overtaken `down 1`, and a first-time entrant `new`.

## Sparkline

Thirty days per row. The two rows on the board have **28 and 19 active days** out of 30 — the totals column cannot tell you that, and it is the more interesting fact about them.

- **Scaled per row**, not across the board: scaling everyone to the leader's busiest day flattens every other row into a straight line. Comparing people is what the tokens column does; this is for comparing a person with themselves.
- **Idle days kept as gaps.** The query returns only days with activity — a row per idle day would be a lot of nothing stored — so `densify` puts the zeros back. Without them a fortnight off looks like the bars moving closer together, which reads as steady work.
- **Any activity gets at least a pixel and a half.** "Nothing happened" and "barely anything happened" should not render alike.

## A bug pagination introduced yesterday

Medals were painted by row index: `i < 3`. On page two that would have crowned ranks **26, 27 and 28**. They follow the rank now.

54 tests, lint and build pass.