### PR TITLE
Fix the sparkline rendering empty on every row

### DIFF
--- a/apps/site/lib/board-query.ts
+++ b/apps/site/lib/board-query.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { pool } from "@/lib/db";
+import { densify } from "@/lib/spark";
 import {
   MOVEMENT_DAYS,
   SPARK_DAYS,
@@ -127,30 +128,11 @@ export async function readBoard(
     ),
     // null means "not ranked a week ago" — a new entrant, not a row that held position 0.
     previousRank: r.previous_rank === null ? null : Number(r.previous_rank),
-    spark: densify(r.spark_dates as string[] | null, r.spark_days as string[] | null),
+    spark: densify(
+      r.spark_dates as (string | Date)[] | null,
+      r.spark_days as string[] | null,
+      SPARK_DAYS,
+    ),
   }));
 }
 
-/**
- * Turn the days a user actually has into one value per day, zeros included.
- *
- * The query returns only days with activity, because storing a row per idle day would be a
- * lot of nothing. A sparkline needs the gaps though — without them a fortnight off looks like
- * the bars simply moving closer together, which reads as steady work.
- */
-function densify(dates: string[] | null, values: string[] | null): number[] {
-  const out = new Array<number>(SPARK_DAYS).fill(0);
-  if (!dates || !values) return out;
-
-  const byDay = new Map<string, number>();
-  dates.forEach((d, i) => byDay.set(String(d).slice(0, 10), Number(values[i] ?? 0)));
-
-  const today = new Date();
-  for (let i = 0; i < SPARK_DAYS; i++) {
-    const d = new Date(today);
-    d.setDate(d.getDate() - (SPARK_DAYS - 1 - i));
-    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-    out[i] = byDay.get(key) ?? 0;
-  }
-  return out;
-}

--- a/apps/site/lib/spark.ts
+++ b/apps/site/lib/spark.ts
@@ -1,0 +1,48 @@
+/**
+ * A local `YYYY-MM-DD` key, from either a string or a Date.
+ *
+ * node-pg hands back a `date` column as a JS Date at local midnight, not as a string. The
+ * first version of this assumed strings and did `String(value).slice(0, 10)`, which turns a
+ * Date into "Thu Sep 03" — a key that matches nothing, so every day looked idle and every
+ * sparkline rendered empty.
+ *
+ * Built from local parts rather than toISOString(), which would shift the day backwards for
+ * anyone west of UTC and quietly move activity onto the wrong date.
+ */
+export function dayKey(value: string | Date): string {
+  if (typeof value === "string") return value.slice(0, 10);
+  const y = value.getFullYear();
+  const m = String(value.getMonth() + 1).padStart(2, "0");
+  const d = String(value.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * One value per day for the sparkline window, oldest first, zeros included.
+ *
+ * The query returns only days with activity, because a row per idle day would be a great deal
+ * of nothing stored. The gaps have to come back here: without them a fortnight off looks like
+ * the bars simply moving closer together, which reads as steady work.
+ *
+ * Takes its length as an argument and imports nothing, so it can be tested by plain node
+ * without the bundler that resolves the "@/" alias.
+ */
+export function densify(
+  dates: (string | Date)[] | null,
+  values: (string | number)[] | null,
+  days: number,
+  today = new Date(),
+): number[] {
+  const out = new Array<number>(days).fill(0);
+  if (!dates || !values) return out;
+
+  const byDay = new Map<string, number>();
+  dates.forEach((d, i) => byDay.set(dayKey(d), Number(values[i] ?? 0)));
+
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - (days - 1 - i));
+    out[i] = byDay.get(dayKey(d)) ?? 0;
+  }
+  return out;
+}

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -8,7 +8,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "node --experimental-strip-types --test test/*.test.js"
   },
   "dependencies": {
     "@tokenchit/core": "*",

--- a/apps/site/test/spark.test.js
+++ b/apps/site/test/spark.test.js
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { dayKey, densify } from "../lib/spark.ts";
+
+test("a date key is built the same way from a string and from a Date", () => {
+  // node-pg returns a `date` column as a JS Date at local midnight, not a string. The first
+  // version assumed strings and did String(value).slice(0, 10), which turns a Date into
+  // "Thu Sep 03" — a key matching nothing, so every day looked idle and every sparkline on
+  // the board rendered empty.
+  assert.equal(dayKey("2026-09-03"), "2026-09-03");
+  assert.equal(dayKey("2026-09-03T00:00:00.000Z"), "2026-09-03");
+  assert.equal(dayKey(new Date(2026, 8, 3)), "2026-09-03");
+  assert.equal(dayKey(new Date(2026, 0, 7)), "2026-01-07", "single digits pad");
+});
+
+test("a Date from the driver lands on the right day of the series", () => {
+  const today = new Date(2026, 8, 30);
+  const spark = densify([new Date(2026, 8, 30), new Date(2026, 8, 28)], [500, 100], 30, today);
+
+  assert.equal(spark.at(-1), 500, "today is the last bar");
+  assert.equal(spark.at(-3), 100, "two days ago is two bars back");
+  assert.equal(spark.at(-2), 0, "the day between them stays a gap");
+  assert.equal(
+    spark.reduce((a, b) => a + b, 0),
+    600,
+    "nothing is invented and nothing is lost",
+  );
+});
+
+test("idle days are kept rather than collapsed", () => {
+  // Without the zeros a fortnight off looks like the bars moving closer together, which
+  // reads as steady work.
+  const today = new Date(2026, 8, 30);
+  const spark = densify([new Date(2026, 8, 30), new Date(2026, 8, 1)], [1, 1], 30, today);
+
+  assert.equal(spark.length, 30);
+  assert.equal(spark.filter((v) => v === 0).length, 28, "the gap survives as gaps");
+});
+
+test("no rows at all is a flat series, not a crash", () => {
+  assert.deepEqual(densify(null, null, 30), new Array(30).fill(0));
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "npm run build -w @tokenchit/core && npm run build -w @tokenchit/cli && npm run build -w tokenchit-site",
     "build:core": "npm run build -w @tokenchit/core",
     "dev": "npm run dev -w tokenchit-site",
-    "test": "npm run build:core && npm run build -w @tokenchit/cli && npm run test -w @tokenchit/core && npm run test -w @tokenchit/cli",
+    "test": "npm run build:core && npm run build -w @tokenchit/cli && npm run test -w @tokenchit/core && npm run test -w @tokenchit/cli && npm run test -w tokenchit-site",
     "cli": "node packages/cli/dist/index.js",
     "db:migrate": "node apps/site/db/migrate.mjs",
     "version:set": "node scripts/version.mjs"


### PR DESCRIPTION
Every sparkline on the live board is empty — every bar zero, every cell showing the em-dash placeholder. I only found it because I checked the deployed HTML after merging.

```
node-pg returns a `date` column as a JS Date at local midnight, not a string.

String(new Date('2026-09-03')).slice(0, 10)  ->  "Thu Sep 03"
the key densify builds                       ->  "2026-09-03"
match?                                       ->  false
```

No key ever matched, so every day looked idle. **The query was correct the whole time** — the data arrived and was discarded one line later.

I shipped it because I assumed the driver returned strings and never rendered the page to find out otherwise.

## The fix, and the adjacent mistake avoided

Keys are built from **local** date parts, not `toISOString()`. That would shift the day backwards for anyone west of UTC and quietly move activity onto the wrong date — the same class of bug, one timezone over.

## Why it wasn't caught

`apps/site` **had no test script at all.** Every test in this repo lives in `packages/`, so nothing that runs in the browser or against the driver was ever asserted.

`densify` now lives in `lib/spark.ts`, imports nothing, and takes its length as an argument — so plain node can test it without the bundler that resolves the `@/` alias. Four tests:

- a `Date` from the driver lands on the right bar
- the day between two entries stays a gap
- a month-long gap survives as gaps rather than collapsing
- no rows at all is a flat series, not a crash

Mutation-checked: restoring `String(value).slice(0, 10)` makes them fail.

The site workspace now has a `test` script and the root suite runs it, so this class of bug has somewhere to be caught next time. **58 tests** total now (40 core + 14 CLI + 4 site), lint and build pass.