### PR TITLE
Say "leader board" and point it at the leaderboard

### DIFF
--- a/apps/site/components/site-header.module.css
+++ b/apps/site/components/site-header.module.css
@@ -61,6 +61,13 @@
   text-transform: uppercase;
 }
 
+/* "Leader board" is two words at 0.1em tracking, sat beside a button in a single-row header.
+   Left to wrap it breaks across two lines on a narrow window and drags the row's height with
+   it — one label should not be able to change the shape of the header. */
+.nav a {
+  white-space: nowrap;
+}
+
 /* Press physics unique to this button: the shadow is spent as the button travels
    into it, so rest/hover/active read as one solid object being pushed down. */
 .signIn {

--- a/apps/site/components/site-header.tsx
+++ b/apps/site/components/site-header.tsx
@@ -10,20 +10,16 @@ import { PRIMARY_COMMAND, VERSION_LABEL } from "@/lib/cli";
 const LOGIN = PRIMARY_COMMAND;
 
 /*
- * Two destinations, not five.
+ * One destination.
  *
- * Verify, privacy and recap were anchors into the homepage — three links that scroll you
- * somewhere on a page you may not be on, competing for attention with the two things anyone
- * actually navigates to. The sections still exist and still have their ids; they are reached
- * by reading the page, which is what a one-page site is for.
+ * This was five links, then two. "Card" pointed at a section of the homepage, which is not
+ * somewhere anyone navigates to — it is somewhere you arrive by reading. The leaderboard is
+ * the only page on this site that is not the homepage, so it is the only thing a nav has to
+ * do, and it says what it is rather than making the reader guess what "board" means.
  *
- * Root-relative rather than bare fragments: these render on /u/<handle> and /board too, where
- * "#card" would point at an anchor that does not exist on the page.
+ * The sections all still exist and still have their ids. The wordmark is the way home.
  */
-const NAV = [
-  { href: "/#card", label: "card" },
-  { href: "/board", label: "board" },
-];
+const NAV = [{ href: "/board", label: "leader board" }];
 
 /**
  * The header's one action.


### PR DESCRIPTION
```
before   CARD   BOARD        [ VERIFY WITH THE CLI ]
after    LEADER BOARD        [ VERIFY WITH THE CLI ]
```

**`CARD` went rather than being renamed.** It pointed at `/#card`, a section of the homepage — not somewhere anyone navigates to, and inert as a destination from every other page. Renaming it to "Leader Board" while `BOARD` also pointed at `/board` would have put two identically-targeted links side by side, so the pair collapses into one.

**`BOARD` became `LEADER BOARD`** because it says what it is. "Board" makes the reader work out what kind.

The leaderboard is the only page on this site that is not the homepage, so it is the only thing a nav has to do. The wordmark handles the way back.

One detail: the label is `white-space: nowrap`. Two words at 0.1em tracking, beside a button in a single-row header, will break onto a second line on a narrow window and take the header's height with it — one label should not be able to change the shape of the header.

If you did want two items, say which second destination and I will add it; every other section is on the homepage, which is why there is nothing obvious to pair this with.

58 tests, lint and build pass.