### PR TITLE
Explain the Claude Code gap where people actually hit it

### DIFF
--- a/banner.html
+++ b/banner.html
@@ -1,0 +1,172 @@
+<title>tokenchit launch banner</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,600;12..96,800&family=JetBrains+Mono:wght@400;500;700&display=swap">
+
+<style>
+  :root {
+    --ink: #0B0B09;
+    --ground: #FDFDF5;
+    --lime: #C6FF3D;
+    --coral: #FF5C3D;
+    --yellow: #FFD23D;
+    --grid: #E6E4D8;
+    --faint: #6E6C60;
+    --page: #EFEEE6;
+  }
+
+  /* The page around the banner adapts; the banner itself does not. It is a fixed brand
+     artifact destined for a screenshot, so its colours are the brand's in every context. */
+  :root:not([data-theme="light"]) { --page: #EFEEE6; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) { --page: #17170F; } }
+  :root[data-theme="dark"] { --page: #17170F; }
+
+  body {
+    margin: 0;
+    background: var(--page);
+    color: var(--ink);
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    padding: 28px 16px 40px;
+  }
+
+  .hint {
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--faint);
+  }
+
+  /* Exactly LinkedIn's 1.91:1 link ratio, so a screenshot needs no cropping. */
+  .banner {
+    width: 1200px;
+    height: 627px;
+    flex: none;
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr 560px;
+    align-items: center;
+    gap: 56px;
+    padding: 0 64px;
+    box-sizing: border-box;
+    background-color: var(--ground);
+    background-image:
+      linear-gradient(var(--grid) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+    background-size: 34px 34px;
+    border: 3px solid var(--ink);
+    overflow: hidden;
+  }
+
+  .brand { display: flex; align-items: center; gap: 14px; margin-bottom: 26px; }
+
+  .wordmark {
+    display: inline-block;
+    padding: 9px 15px;
+    background: var(--lime);
+    border: 2.5px solid var(--ink);
+    box-shadow: 5px 5px 0 var(--ink);
+    font-family: "Bricolage Grotesque", sans-serif;
+    font-weight: 800;
+    font-size: 25px;
+    letter-spacing: -0.02em;
+  }
+
+  .url { font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--faint); }
+
+  h1 {
+    font-family: "Bricolage Grotesque", sans-serif;
+    font-weight: 800;
+    font-size: 62px;
+    line-height: 0.98;
+    letter-spacing: -0.03em;
+    margin: 0 0 22px;
+    text-wrap: balance;
+  }
+
+  /* The one word the whole pitch turns on gets the accent; nothing else competes. */
+  .mark {
+    background: var(--lime);
+    box-shadow: 4px 4px 0 var(--ink);
+    padding: 0 6px;
+  }
+
+  .lede {
+    font-size: 15.5px;
+    line-height: 1.62;
+    margin: 0 0 26px;
+    max-width: 46ch;
+    color: #2A2A22;
+  }
+
+  .cmd {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 13px 17px;
+    background: #FFFFFF;
+    border: 2.5px solid var(--ink);
+    box-shadow: 5px 5px 0 var(--lime);
+    font-size: 15px;
+    font-weight: 500;
+  }
+  .prompt { color: var(--faint); }
+
+  .chips { display: flex; gap: 9px; margin-bottom: 24px; }
+  .chip {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    padding: 5px 9px;
+    border: 2px solid var(--ink);
+  }
+  .chipInk { background: var(--ink); color: var(--ground); }
+  .chipLime { background: var(--lime); }
+  .chipWhite { background: #FFFFFF; }
+
+  /* The card is the product. It sits at its true 495x195 with the same hard shadow the site
+     uses, rather than being redrawn or scaled into a mockup. */
+  .cardWrap { display: flex; flex-direction: column; align-items: flex-end; gap: 13px; }
+  .card { border: 3px solid var(--ink); box-shadow: 9px 9px 0 var(--ink); background: #FFFFFF; line-height: 0; }
+  .card svg { display: block; width: 495px; height: 195px; }
+  .caption { font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint); text-align: right; }
+  .caption b { color: var(--ink); font-weight: 700; }
+
+  .rule { height: 3px; background: var(--ink); margin: 0 0 26px; width: 78px; }
+</style>
+
+<p class="hint">screenshot the block below — 1200 × 627, LinkedIn's link ratio</p>
+
+<div class="banner">
+  <div>
+    <div class="brand">
+      <span class="wordmark">tokenchit</span>
+      <span class="url">tokenchit.app</span>
+    </div>
+
+    <div class="chips">
+      <span class="chip chipInk">no hosted endpoint</span>
+      <span class="chip chipLime">parsed locally</span>
+      <span class="chip chipWhite">MIT</span>
+    </div>
+
+    <h1>Receipts for your <span class="mark">robots.</span></h1>
+    <div class="rule"></div>
+
+    <p class="lede">
+      Reads the logs Claude Code, Codex and OpenCode already write to your disk, and renders
+      a stat card straight into your README. A file you commit — not a URL you depend on.
+    </p>
+
+    <div class="cmd"><span class="prompt">$</span>npx -y @tokenchit/cli@latest generate</div>
+  </div>
+
+  <div class="cardWrap">
+    <div class="card"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 495 195" width="495" height="195" role="img" aria-label="tokenchit stats for @iyashjayesh"><style>@media (prefers-color-scheme:dark){.fr{fill:#101010;stroke:#2E2E28}.hd,.vl{fill:#FFFFFF}.hl,.rl{stroke:#2E2E28}.lb{fill:#6E6E66}.lg{fill:#9A9A92}.ft{fill:#55554E}.s1{fill:#FFFFFF}.s2{fill:#6E6E66}.ic1{fill:#8A8A82}.ic2{fill:#FFFFFF}}</style><rect class="fr" x="1" y="1" width="493" height="193" fill="#FFFFFF" stroke="#101010" stroke-width="2"/><text class="hd" x="28" y="44" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="20" font-weight="800" fill="#101010">@iyashjayesh</text><line class="hl" x1="28" y1="62" x2="467" y2="62" stroke="#E4E2D8" stroke-width="1"/><text class="lb" x="28" y="88" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="8.5" font-weight="700" letter-spacing="1.8" fill="#A5A59D">TOKENS</text><text class="vl" x="28" y="122" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="30" font-weight="800" fill="#101010">10.6B</text><text class="lb" x="184" y="88" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="8.5" font-weight="700" letter-spacing="1.8" fill="#A5A59D">EQUIV. COST</text><text class="vl" x="184" y="122" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="30" font-weight="800" fill="#101010">$7,140</text><text class="lb" x="340" y="88" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="8.5" font-weight="700" letter-spacing="1.8" fill="#A5A59D">STREAK</text><text class="vl" x="340" y="122" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="30" font-weight="800" fill="#101010">26d</text><rect class="s0" x="28" y="138" width="437" height="6" fill="#C6FF3D"/><rect class="s1" x="465" y="138" width="2" height="6" fill="#101010"/><rect class="s2" x="467" y="138" width="0" height="6" fill="#8A8A82"/><path class="ic0" transform="translate(28 156) scale(0.3333)" d="m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z" fill="#D97757"/><text class="lg" x="40" y="163" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="8.5" fill="#55554E">claude-code 99%</text><path class="ic1" transform="translate(150 156) scale(0.3333)" d="M4 6l6 6-6 6V6zm8 10h8v2h-8z" fill="#55554E"/><text class="lg" x="162" y="163" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="8.5" fill="#55554E">codex &lt;1%</text><path class="ic2" transform="translate(260 156) scale(0.3333)" d="M22 24H2V0h20zM17 4.8H7v14.4h10z" fill="#000000"/><text class="lg" x="272" y="163" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="8.5" fill="#55554E">opencode &lt;1%</text><text class="ft" x="28" y="182" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="8" letter-spacing="1.4" fill="#C0BEB6">TOKENCHIT.APP</text><text class="ft" x="467" y="182" text-anchor="end" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="8" letter-spacing="1.4" fill="#C0BEB6">SYNCED 0M AGO</text></svg></div>
+    <p class="caption">a real card, committed &mdash; <b>10.6B tokens</b> &middot; 26-day streak</p>
+  </div>
+</div>

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -4,18 +4,21 @@ import { dirname, relative, resolve } from "node:path";
 import {
   aggregate,
   buildCardSvg,
+  formatTokens,
   PRICES_GENERATED,
   sanitizeHandle,
   toCardOptions,
+  type AgentId,
   type Layout,
+  type Stats,
   type Theme,
 } from "@tokenchit/core";
-import { readAll } from "@tokenchit/core/adapters";
+import { claudeRoots, readAll, readClaudeStatsPanels } from "@tokenchit/core/adapters";
 
 import { flag, has, oneOf } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
 import { renderStats } from "../stats-view.js";
-import { bold, dim, green, grey, say, spin, under, warn } from "../ui.js";
+import { bold, dim, green, grey, note, say, spin, under, warn, yellow } from "../ui.js";
 
 const LAYOUTS = ["default", "compact"] as const satisfies readonly Layout[];
 const THEMES = ["auto", "light", "dark"] as const satisfies readonly Theme[];
@@ -90,6 +93,8 @@ export async function sync(argv: string[], chained = false): Promise<number> {
   const svg = buildCardSvg(toCardOptions(stats, { handle, layout, theme }));
   const target = resolve(process.cwd(), out);
 
+  await explainClaudeGap(stats, config.agents);
+
   for (const line of renderStats(stats, handle, !chained)) {
     say(chained && line !== "" ? under(line.replace(/^ {2}/, "")) : line);
   }
@@ -132,4 +137,37 @@ export async function sync(argv: string[], chained = false): Promise<number> {
   say();
 
   return 0;
+}
+
+/**
+ * Say why Claude Code's own Stats panel reads higher, before anyone has to go looking.
+ *
+ * This is the single most common question the tool produces, and it was answered only in the
+ * README — which nobody reads before running a command. It prints only when the two numbers
+ * actually disagree by enough to notice, so a machine where they agree stays quiet.
+ *
+ * To stderr, and never in --json: it is an aside about someone else's number, not part of the
+ * aggregate a caller asked for.
+ */
+async function explainClaudeGap(stats: Stats, agents: readonly AgentId[]): Promise<void> {
+  if (!agents.includes("claude-code")) return;
+
+  const ours = stats.byAgent.get("claude-code") ?? 0;
+  if (ours <= 0) return;
+
+  const panels = await readClaudeStatsPanels(await claudeRoots()).catch(() => []);
+  const theirs = panels.reduce((a, p) => a + p.tokens, 0);
+
+  // A small difference is the day still in progress, not the thing being explained.
+  if (theirs <= ours * 1.15) return;
+
+  note();
+  note(`  ${yellow("!")} ${bold("Claude Code's Stats panel will show more than this.")}`);
+  note(`      ${grey("its panel")}  ${bold(formatTokens(theirs))}`);
+  note(`      ${grey("this")}       ${bold(formatTokens(ours))}  ${grey("claude-code only")}`);
+  note();
+  note(grey("      The panel counts an API call once per streaming rewrite, and keeps totals"));
+  note(grey("      for transcripts Claude Code has since deleted. This counts one row per"));
+  note(grey("      call, from the transcripts still on disk. Neither is wrong; they answer"));
+  note(grey("      different questions — tokenchit.app explains it in full."));
 }

--- a/packages/core/src/adapters/claude-code.ts
+++ b/packages/core/src/adapters/claude-code.ts
@@ -20,7 +20,7 @@ import { walkFiles } from "./walk.js";
  * on a machine with several accounts the other three still hold real tokens, and a card
  * claiming to total your usage should not omit them because of one environment variable.
  */
-async function defaultRoots(): Promise<string[]> {
+export async function claudeRoots(): Promise<string[]> {
   const roots = new Set<string>();
 
   const configured = process.env["CLAUDE_CONFIG_DIR"];
@@ -86,7 +86,7 @@ type ClaudeLine = {
  */
 export function createClaudeCode(roots?: string[] | string): Adapter {
   const resolve = async (): Promise<string[]> =>
-    roots === undefined ? defaultRoots() : Array.isArray(roots) ? roots : [roots];
+    roots === undefined ? claudeRoots() : Array.isArray(roots) ? roots : [roots];
 
   return {
     id: "claude-code",

--- a/packages/core/src/adapters/claude-stats.ts
+++ b/packages/core/src/adapters/claude-stats.ts
@@ -1,0 +1,75 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/**
+ * What Claude Code's own Stats panel will say.
+ *
+ * The panel does not read transcripts. It reads a cumulative `stats-cache.json` beside them,
+ * and that file differs from the transcripts in two ways that both make it larger:
+ *
+ * It counts each API call once per streaming rewrite. Claude Code rewrites an assistant
+ * message as it streams, so one call leaves several `usage` records carrying the same growing
+ * figures, and the cache sums them as written. Measured on one machine, 51,373 usage records
+ * represented 23,644 real calls, and the cache matched the naive sum of all of them to the
+ * exact token on 28 of 57 days — and the deduplicated total on none.
+ *
+ * It also outlives the transcripts. Claude Code deletes old ones; the cache keeps their
+ * totals, so it covers a longer period than any transcript parser can see.
+ *
+ * This is read only to explain the difference to someone comparing the two numbers. It is
+ * never added to a total and never published — deflating it is impossible anyway, since the
+ * inflation factor varied between 1.15x and 2.18x across days on the same corpus.
+ */
+export type ClaudeStatsPanel = {
+  /** Lifetime tokens as the panel reports them. */
+  tokens: number;
+  /** Which config directory it came from, for a message that has to name one. */
+  root: string;
+};
+
+type StatsCache = { modelUsage?: Record<string, Record<string, unknown>> };
+
+/** Sum the per-model totals the way the panel does. */
+function total(cache: StatsCache): number {
+  let sum = 0;
+  for (const models of Object.values(cache.modelUsage ?? {})) {
+    if (!models || typeof models !== "object") continue;
+    for (const value of Object.values(models)) {
+      if (typeof value === "number" && Number.isFinite(value)) sum += value;
+    }
+  }
+  return sum;
+}
+
+/**
+ * Read every stats cache beside the given transcript roots.
+ *
+ * Takes the roots rather than finding its own, so this can only ever look where the adapter
+ * was already looking. A missing or unreadable cache is an absent answer, not an error: the
+ * file is Claude Code's, its shape is not promised, and nothing here is worth failing a sync
+ * over.
+ */
+export async function readClaudeStatsPanels(
+  roots: string[],
+): Promise<ClaudeStatsPanel[]> {
+  const seen = new Set<string>();
+  const panels: ClaudeStatsPanel[] = [];
+
+  for (const root of roots) {
+    // roots are `<config>/projects`; the cache sits beside that directory, not inside it.
+    const dir = dirname(root);
+    const path = join(dir, "stats-cache.json");
+    if (seen.has(path)) continue;
+    seen.add(path);
+
+    try {
+      const cache = JSON.parse(await readFile(path, "utf8")) as StatsCache;
+      const tokens = total(cache);
+      if (tokens > 0) panels.push({ tokens, root: dir });
+    } catch {
+      /* absent, unreadable, or a shape we do not recognise — all mean "cannot say" */
+    }
+  }
+
+  return panels;
+}

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -50,3 +50,6 @@ export async function* readAll(
     onProgress?.({ agent: adapter.id, events });
   }
 }
+
+export { claudeRoots } from "./claude-code.js";
+export * from "./claude-stats.js";

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -327,3 +327,40 @@ test("the card stamps the host from one shared constant", () => {
   assert.match(svg, new RegExp(CARD_HOST.replace(/\./g, "\\.")));
   assert.doesNotMatch(svg, /VERCEL/, "the deployment host should not be stamped on a card");
 });
+
+test("the stats-panel reader sums a cache the way the panel does, and is quiet when it cannot", async () => {
+  // Claude Code's panel reads a cumulative stats-cache.json, not the transcripts. Reading it
+  // is the only way to explain the difference to someone comparing the two numbers — and a
+  // missing or unrecognised file must be an absent answer rather than a failed sync, because
+  // the file is Claude Code's and its shape is not promised to us.
+  const { readClaudeStatsPanels } = await import("@tokenchit/core/adapters");
+  const { mkdtemp, mkdir, writeFile } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const home = await mkdtemp(join(tmpdir(), "tokenchit-stats-"));
+  const cfg = join(home, ".claude");
+  await mkdir(join(cfg, "projects"), { recursive: true });
+  await writeFile(
+    join(cfg, "stats-cache.json"),
+    JSON.stringify({
+      modelUsage: {
+        "claude-opus-5": { inputTokens: 1000, outputTokens: 500, cacheReadInputTokens: 8500 },
+        "claude-haiku-4-5": { inputTokens: 10, outputTokens: 5 },
+      },
+    }),
+  );
+
+  const [panel] = await readClaudeStatsPanels([join(cfg, "projects")]);
+  assert.equal(panel?.tokens, 10015, "every numeric field across every model is summed");
+  assert.equal(panel?.root, cfg, "the config directory is named, not the projects dir");
+
+  // A directory with no cache at all says nothing rather than throwing.
+  const bare = await mkdtemp(join(tmpdir(), "tokenchit-bare-"));
+  assert.deepEqual(await readClaudeStatsPanels([join(bare, "projects")]), []);
+
+  // Neither does an unparseable one.
+  const broken = await mkdtemp(join(tmpdir(), "tokenchit-broken-"));
+  await writeFile(join(broken, "stats-cache.json"), "{ not json");
+  assert.deepEqual(await readClaudeStatsPanels([join(broken, "projects")]), []);
+});


### PR DESCRIPTION
Several people have now compared tokenchit against Claude Code's own Stats panel and found different numbers. The explanation existed **only in the README** — which nobody reads before running a command — so everyone rediscovers the same confusion alone.

`sync` now reads the same `stats-cache.json` the panel reads and, when the two disagree by more than 15%, says so:

```
  ! Claude Code's Stats panel will show more than this.
      its panel  27.8B
      this       10.6B  claude-code only

      The panel counts an API call once per streaming rewrite, and keeps totals
      for transcripts Claude Code has since deleted. This counts one row per
      call, from the transcripts still on disk. Neither is wrong; they answer
      different questions — tokenchit.app explains it in full.
```

That 27.8B is the exact figure that started this investigation weeks ago.

## Why the panel reads higher

Both causes push the same direction, and both were measured rather than assumed:

- **Streaming rewrites.** Claude Code rewrites an assistant message as it streams, so one call leaves several `usage` records with the same growing figures. On this corpus, **51,373 usage records represented 23,644 real API calls** — and the cache matched the naive sum of all 51,373 to the exact token on **28 of 57 days**, the deduplicated total on **none**.
- **Deleted transcripts.** The panel keeps totals after the transcripts are gone. One directory had 29 days on disk against 70 the panel remembered.

Deduplicating is safe: all 16,975 repeated message ids carried **exactly one `requestId`**, and collapsing by `message.id` and by `requestId` agreed to within 0.002%.

## Boundaries

- **Read to explain, never to add.** The cache is not summed into any total. Deflating it is impossible anyway — the inflation factor ranged 1.15×–2.18× across days on one corpus, so there is no constant to divide out.
- **Only looks beside roots the adapter already walks**, so it cannot read anywhere the tool was not already reading.
- **A missing or unparseable cache is an absent answer, not an error.** The file is Claude Code's and its shape is not promised to us. Tested all three: a real cache, no cache, and one that will not parse.
- **Only speaks when the numbers disagree by >15%**, so a machine where they agree stays quiet and a day-in-progress difference is not worth a paragraph.
- **stderr, never `--json`** — it is an aside about somebody else's number, not part of the aggregate a caller asked for. Verified `--json` still parses.

All four privacy tests still pass, including `net.isolated` and `paths.absent`.

59 tests, lint and build pass.