### PR TITLE
Release v0.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,7 +8199,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -8250,7 +8250,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Two user-facing fixes, both for things people are hitting right now.

**#50 — a real user was locked out.** Their busiest day was 3,374,192,877 tokens against a 2,000,000,000 ceiling calibrated against one other machine, whose peak was 607M. Volume alone is never impossible, so it no longer rejects — it goes to the review band, where a false positive is a delay rather than a locked door. Verified against the exact payload that failed: no errors, not held.

**#49 — the Claude Code mismatch is explained where people hit it.** `sync` now reads the same `stats-cache.json` the Stats panel reads and, when the two disagree by more than 15%, prints both figures and why. The panel counts an API call once per streaming rewrite and keeps totals for transcripts it has deleted; this counts one row per call from transcripts still on disk.

Also: the site favicon was Next's default Vercel triangle. It is now the wordmark badge reduced to what survives at 16px.

Verified locally with the exact gate CI runs: build, 61 tests, lint. `--version` reports 0.4.7 and the site badge renders `v0.4.7 · MIT`.