### PR TITLE
Estimate the deleted days, and raise the ceiling to a trillion

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ logs that no longer exist. The cache is not a usable substitute, because it carr
 inflation described above and the factor varies day to day — between 1.15x and 2.18x on the
 days measured — so there is no constant to divide out.
 
+**Why not just report the panel's number?** Three reasons, and each is enough on its own.
+
+It is not billed tokens — it is records summed. Adopting it would mean publishing a figure
+nobody was charged for.
+
+It exists only for Claude Code. Codex and OpenCode have no equivalent cache, so a total that
+mixed one inflated agent with two honest ones would be incoherent, and on the board someone
+whose cache happened to survive would outrank someone whose did not, for identical work.
+
+It would fail this project's own validation. Submissions are bounded by cost per token, with a
+floor at the cheapest cache-read rate any model offers. Roughly doubling the tokens while the
+cost stays real pushes that ratio below the floor, and the payload is rejected.
+
+What *is* reported is the coverage gap, because it can be stated exactly: `sync` prints how
+many days of transcripts are on disk against how many days the cache remembers. That names the
+blind spot in days rather than inventing a token count for it.
+
 **Copilot CLI and Gemini CLI are detected but cannot be counted.** Copilot records only a
 live context-window gauge, never a cumulative total; Gemini's chat transcripts carry no token
 counts at all. `init` says so out loud rather than silently omitting them — if either starts

--- a/README.md
+++ b/README.md
@@ -115,8 +115,28 @@ floor at the cheapest cache-read rate any model offers. Roughly doubling the tok
 cost stays real pushes that ratio below the floor, and the payload is rejected.
 
 What *is* reported is the coverage gap, because it can be stated exactly: `sync` prints how
-many days of transcripts are on disk against how many days the cache remembers. That names the
-blind spot in days rather than inventing a token count for it.
+many days of transcripts are on disk against how many days the cache remembers.
+
+And there is one correction that can be made honestly. On days where both sources exist, the
+cache's figure divided by the deduplicated figure is how much *this machine's* cache
+overstates. Apply that median ratio to the days only the cache has, and the result estimates
+what the deleted transcripts held — derived from the machine's own overlap rather than from a
+constant:
+
+```
+    its panel  27.8B
+    this       10.7B  claude-code only
+    days       41 of 98
+    estimate   ~14.4B  including 35 deleted days, at this machine's own 1.87x overlap
+               per-day ratios ranged 1.04x to 4.92x, so treat it as a range
+```
+
+Days that cannot calibrate are excluded rather than averaged in: a ratio below 1 means the
+cache lagged, and a very large one means that day's transcripts are already partly rotated, so
+it measures the loss being estimated rather than the inflation. Without at least five
+calibratable days there is no estimate at all — silence beats a guess.
+
+The estimate is shown and never published. The board ranks what can be checked.
 
 **Copilot CLI and Gemini CLI are detected but cannot be counted.** Copilot records only a
 live context-window gauge, never a cumulative total; Gemini's chat transcripts carry no token

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -13,7 +13,12 @@ import {
   type Stats,
   type Theme,
 } from "@tokenchit/core";
-import { claudeRoots, readAll, readClaudeStatsPanels } from "@tokenchit/core/adapters";
+import {
+  claudeRoots,
+  estimateUnseen,
+  readAll,
+  readClaudeStatsPanels,
+} from "@tokenchit/core/adapters";
 
 import { flag, has, oneOf } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
@@ -164,7 +169,13 @@ async function explainClaudeGap(stats: Stats, agents: readonly AgentId[]): Promi
      Stated as days rather than as an estimated token count, because the inflation factor
      varied 1.15x to 2.18x across days on one corpus — there is no honest number to give. */
   let ourDays = 0;
-  for (const agents of stats.dayAgent.values()) if (agents.has("claude-code")) ourDays++;
+  const ourDaily = new Map<string, number>();
+  for (const [day, agents] of stats.dayAgent) {
+    const cell = agents.get("claude-code");
+    if (!cell) continue;
+    ourDays++;
+    ourDaily.set(day, cell.tokens);
+  }
 
   // A small difference is the day still in progress, not the thing being explained.
   if (theirs <= ours * 1.15) return;
@@ -179,9 +190,24 @@ async function explainClaudeGap(stats: Stats, agents: readonly AgentId[]): Promi
     note();
   }
 
+  /* The one correction that can be made honestly. The cache overstates by a factor this
+     machine's own overlapping days reveal, so applying that factor to the days only the cache
+     has estimates what the deleted transcripts held — without adopting a figure that counts
+     records as calls. It is shown and never published: the board ranks what can be checked. */
+  const unseen = estimateUnseen(panels, ourDaily);
+  if (unseen) {
+    const [lo, hi] = unseen.spread;
+    note(
+      `      ${grey("estimate")}   ${bold(`~${formatTokens(ours + unseen.tokens)}`)}  ` +
+        `${grey(`including ${unseen.days} deleted days, at this machine's own ${unseen.ratio.toFixed(2)}x overlap`)}`,
+    );
+    note(grey(`                 ${grey(`per-day ratios ranged ${lo.toFixed(2)}x to ${hi.toFixed(2)}x, so treat it as a range`)}`));
+    note();
+  }
+
   note(grey("      The panel counts an API call once per streaming rewrite, so its figure is"));
   note(grey("      records summed rather than calls billed. It also keeps totals for"));
   note(grey("      transcripts Claude Code has since deleted, which is real work this cannot"));
-  note(grey("      see. This counts one row per call, from what is still on disk — a figure"));
-  note(grey("      that can be checked. tokenchit.app explains both halves in full."));
+  note(grey("      see. This counts one row per call, from what is still on disk — the only"));
+  note(grey("      figure that can be checked, and the only one published."));
 }

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -157,6 +157,14 @@ async function explainClaudeGap(stats: Stats, agents: readonly AgentId[]): Promi
 
   const panels = await readClaudeStatsPanels(await claudeRoots()).catch(() => []);
   const theirs = panels.reduce((a, p) => a + p.tokens, 0);
+  const theirDays = panels.reduce((a, p) => a + p.days, 0);
+
+  /* Days on disk carrying claude-code, against days its cache remembers. This is the half of
+     the difference that is genuinely ours: deleted transcripts are real work we cannot read.
+     Stated as days rather than as an estimated token count, because the inflation factor
+     varied 1.15x to 2.18x across days on one corpus — there is no honest number to give. */
+  let ourDays = 0;
+  for (const agents of stats.dayAgent.values()) if (agents.has("claude-code")) ourDays++;
 
   // A small difference is the day still in progress, not the thing being explained.
   if (theirs <= ours * 1.15) return;
@@ -166,8 +174,14 @@ async function explainClaudeGap(stats: Stats, agents: readonly AgentId[]): Promi
   note(`      ${grey("its panel")}  ${bold(formatTokens(theirs))}`);
   note(`      ${grey("this")}       ${bold(formatTokens(ours))}  ${grey("claude-code only")}`);
   note();
-  note(grey("      The panel counts an API call once per streaming rewrite, and keeps totals"));
-  note(grey("      for transcripts Claude Code has since deleted. This counts one row per"));
-  note(grey("      call, from the transcripts still on disk. Neither is wrong; they answer"));
-  note(grey("      different questions — tokenchit.app explains it in full."));
+  if (theirDays > ourDays && ourDays > 0) {
+    note(`      ${grey("days")}       ${bold(`${ourDays} of ${theirDays}`)}  ${grey("its cache remembers days your transcripts no longer have")}`);
+    note();
+  }
+
+  note(grey("      The panel counts an API call once per streaming rewrite, so its figure is"));
+  note(grey("      records summed rather than calls billed. It also keeps totals for"));
+  note(grey("      transcripts Claude Code has since deleted, which is real work this cannot"));
+  note(grey("      see. This counts one row per call, from what is still on disk — a figure"));
+  note(grey("      that can be checked. tokenchit.app explains both halves in full."));
 }

--- a/packages/core/src/adapters/claude-stats.ts
+++ b/packages/core/src/adapters/claude-stats.ts
@@ -34,11 +34,14 @@ export type ClaudeStatsPanel = {
    * than as an invented token count.
    */
   days: number;
+  /** Per-day totals, where the cache carries them. Oldest first. */
+  daily: { day: string; tokens: number }[];
 };
 
 type StatsCache = {
   modelUsage?: Record<string, Record<string, unknown>>;
   dailyActivity?: { date?: unknown }[];
+  dailyModelTokens?: { date?: unknown; tokensByModel?: Record<string, unknown> }[];
 };
 
 /** Sum the per-model totals the way the panel does. */
@@ -78,11 +81,116 @@ export async function readClaudeStatsPanels(
       const cache = JSON.parse(await readFile(path, "utf8")) as StatsCache;
       const tokens = total(cache);
       const days = (cache.dailyActivity ?? []).filter((d) => typeof d?.date === "string").length;
-      if (tokens > 0) panels.push({ tokens, root: dir, days });
+
+      const daily = (cache.dailyModelTokens ?? [])
+        .filter((d): d is { date: string; tokensByModel?: Record<string, unknown> } =>
+          typeof d?.date === "string",
+        )
+        .map((d) => ({
+          day: d.date,
+          tokens: Object.values(d.tokensByModel ?? {}).reduce<number>(
+            (a, v) => a + (typeof v === "number" && Number.isFinite(v) ? v : 0),
+            0,
+          ),
+        }))
+        .sort((a, b) => a.day.localeCompare(b.day));
+
+      if (tokens > 0) panels.push({ tokens, root: dir, days, daily });
     } catch {
       /* absent, unreadable, or a shape we do not recognise — all mean "cannot say" */
     }
   }
 
   return panels;
+}
+
+/**
+ * What the days no longer on disk were probably worth.
+ *
+ * The panel's own figure cannot be adopted — it counts an API call once per streaming
+ * rewrite, so it is records summed rather than calls billed. But the size of that inflation
+ * is measurable on the days where both sources exist: divide the cache's figure for a day by
+ * the deduplicated figure for the same day, and that ratio is how much this particular
+ * machine's cache overstates.
+ *
+ * Apply the median of those ratios to the days the cache has and the transcripts do not, and
+ * the result is an estimate of real work that was deleted — arrived at from this machine's
+ * own overlap rather than from a constant.
+ *
+ * It stays an estimate and is never published. Per-day ratios ranged 1.15x to 2.18x on one
+ * corpus, so the median is a reasonable middle and not a fact; `spread` carries that range so
+ * a caller can say how wide the uncertainty is rather than implying there is none.
+ */
+export type UnseenEstimate = {
+  /** Estimated tokens from days the transcripts no longer cover. */
+  tokens: number;
+  /** Median cache-to-transcript ratio on the overlapping days. */
+  ratio: number;
+  /** Lowest and highest ratio seen, so the uncertainty can be stated. */
+  spread: [number, number];
+  /** How many days the estimate covers. */
+  days: number;
+};
+
+/**
+ * A day only calibrates if we can see all of it.
+ *
+ * The cache is a superset of the transcripts, so a real overlap day has a ratio of at least
+ * one. Below that means the cache lagged or was written mid-day; far above means the
+ * transcripts for that day are already partly rotated, so the day is measuring the very loss
+ * being estimated rather than the inflation. Both are excluded — an uncalibratable day must
+ * not calibrate.
+ */
+const RATIO_FLOOR = 1;
+const RATIO_CEILING = 5;
+
+/** Enough overlap to have a median worth trusting. Fewer, and silence is the honest answer. */
+const MIN_OVERLAP_DAYS = 5;
+
+export function estimateUnseen(
+  panels: ClaudeStatsPanel[],
+  ourDaily: Map<string, number>,
+): UnseenEstimate | null {
+  // Summed across config directories first. Each panel covers one directory while ourDaily is
+  // every directory at once, so comparing a single panel's day against it measures the other
+  // directories rather than the inflation — which produced ratios from 0.00x to 414x.
+  const theirDaily = new Map<string, number>();
+  for (const panel of panels) {
+    for (const { day, tokens } of panel.daily) {
+      theirDaily.set(day, (theirDaily.get(day) ?? 0) + tokens);
+    }
+  }
+
+  const ratios: number[] = [];
+  let missing = 0;
+  let missingDays = 0;
+
+  for (const [day, theirs] of theirDaily) {
+    if (theirs <= 0) continue;
+    const ours = ourDaily.get(day) ?? 0;
+
+    if (ours <= 0) {
+      missing += theirs;
+      missingDays++;
+      continue;
+    }
+
+    const ratio = theirs / ours;
+    if (ratio >= RATIO_FLOOR && ratio <= RATIO_CEILING) ratios.push(ratio);
+  }
+
+  if (ratios.length < MIN_OVERLAP_DAYS || missingDays === 0) return null;
+
+  ratios.sort((a, b) => a - b);
+  const mid = Math.floor(ratios.length / 2);
+  const ratio =
+    ratios.length % 2 === 0 ? (ratios[mid - 1]! + ratios[mid]!) / 2 : ratios[mid]!;
+  if (!(ratio > 0)) return null;
+
+  return {
+    tokens: Math.round(missing / ratio),
+    ratio,
+    spread: [ratios[0]!, ratios[ratios.length - 1]!],
+    days: missingDays,
+  };
 }

--- a/packages/core/src/adapters/claude-stats.ts
+++ b/packages/core/src/adapters/claude-stats.ts
@@ -25,9 +25,21 @@ export type ClaudeStatsPanel = {
   tokens: number;
   /** Which config directory it came from, for a message that has to name one. */
   root: string;
+  /**
+   * How many days of activity the cache remembers.
+   *
+   * This is the honest half of the difference. The rewrite double-count inflates a number we
+   * should not adopt, but deleted transcripts are real work we genuinely cannot see — and
+   * unlike the inflation, the size of that blind spot can be stated exactly, as days rather
+   * than as an invented token count.
+   */
+  days: number;
 };
 
-type StatsCache = { modelUsage?: Record<string, Record<string, unknown>> };
+type StatsCache = {
+  modelUsage?: Record<string, Record<string, unknown>>;
+  dailyActivity?: { date?: unknown }[];
+};
 
 /** Sum the per-model totals the way the panel does. */
 function total(cache: StatsCache): number {
@@ -65,7 +77,8 @@ export async function readClaudeStatsPanels(
     try {
       const cache = JSON.parse(await readFile(path, "utf8")) as StatsCache;
       const tokens = total(cache);
-      if (tokens > 0) panels.push({ tokens, root: dir });
+      const days = (cache.dailyActivity ?? []).filter((d) => typeof d?.date === "string").length;
+      if (tokens > 0) panels.push({ tokens, root: dir, days });
     } catch {
       /* absent, unreadable, or a shape we do not recognise — all mean "cannot say" */
     }

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -50,10 +50,16 @@ export const LIMITS = {
    * What remains here is the arithmetically impossible: negative figures, dates in the
    * future, a headline that disagrees with its own series, a cost-per-token outside what any
    * real model can produce, and volumes so large they indicate corruption rather than work.
+   *
+   * Raised twice now, both times because a real person was refused. The lesson each time was
+   * the same: a number set from the machines we happen to have seen will be wrong for the
+   * next machine, and being wrong here costs someone their submission. A trillion tokens in
+   * one day is not a judgement about heavy use — it is the point where the figure stops
+   * describing work and starts describing a corrupt file.
    */
-  maxTokensPerDay: 100_000_000_000,
-  maxCostPerDay: 50_000,
-  maxCostTotal: 50_000 * 365,
+  maxTokensPerDay: 1_000_000_000_000,
+  maxCostPerDay: 500_000,
+  maxCostTotal: 500_000 * 365,
   /** Arithmetic floor: the cheapest cache-read rate in the price table. */
   minCostPerToken: 5e-9,
   maxCostPerToken: 0.1,
@@ -77,8 +83,8 @@ export const LIMITS = {
  * agents at once. It is a number to revise as more real days are seen, not a constant.
  */
 export const REVIEW = {
-  tokensPerDay: 15_000_000_000,
-  costPerDay: 10_000,
+  tokensPerDay: 100_000_000_000,
+  costPerDay: 100_000,
 } as const;
 
 /**

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -349,12 +349,21 @@ test("the stats-panel reader sums a cache the way the panel does, and is quiet w
         "claude-opus-5": { inputTokens: 1000, outputTokens: 500, cacheReadInputTokens: 8500 },
         "claude-haiku-4-5": { inputTokens: 10, outputTokens: 5 },
       },
+      // How many days it remembers is the honest half of the difference: deleted transcripts
+      // are real work, and the size of that blind spot can be stated exactly as days.
+      dailyActivity: [
+        { date: "2026-06-02" },
+        { date: "2026-06-03" },
+        { date: "2026-09-02" },
+        { messageCount: 4 },
+      ],
     }),
   );
 
   const [panel] = await readClaudeStatsPanels([join(cfg, "projects")]);
   assert.equal(panel?.tokens, 10015, "every numeric field across every model is summed");
   assert.equal(panel?.root, cfg, "the config directory is named, not the projects dir");
+  assert.equal(panel?.days, 3, "days come from dailyActivity, and only from dated entries");
 
   // A directory with no cache at all says nothing rather than throwing.
   const bare = await mkdtemp(join(tmpdir(), "tokenchit-bare-"));

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -427,3 +427,65 @@ test("volume still has a sanity ceiling, well above any real day", () => {
 
   assert.ok(validatePayload(absurd).length > 0, "half a trillion tokens in a day is not work");
 });
+
+test("the unseen estimate calibrates on overlap and refuses to guess without it", async () => {
+  const { estimateUnseen } = await import("@tokenchit/core/adapters");
+  const panel = (daily) => [{ tokens: 0, root: "/x", days: daily.length, daily }];
+  const day = (n) => `2026-08-${String(n).padStart(2, "0")}`;
+
+  // Six overlapping days at a clean 2x, plus two days only the cache has.
+  const overlap = [1, 2, 3, 4, 5, 6].map((n) => ({ day: day(n), tokens: 200 }));
+  const gone = [{ day: day(20), tokens: 600 }, { day: day(21), tokens: 400 }];
+  const ours = new Map([1, 2, 3, 4, 5, 6].map((n) => [day(n), 100]));
+
+  const est = estimateUnseen(panel([...overlap, ...gone]), ours);
+  assert.equal(est?.ratio, 2, "the median of six clean 2x days is 2x");
+  assert.equal(est?.days, 2, "only the days with no transcript count as missing");
+  assert.equal(est?.tokens, 500, "1000 cache tokens deflated by 2x is 500 real ones");
+});
+
+test("days that cannot calibrate are excluded rather than averaged in", async () => {
+  const { estimateUnseen } = await import("@tokenchit/core/adapters");
+  const day = (n) => `2026-08-${String(n).padStart(2, "0")}`;
+
+  // A ratio below 1 means the cache lagged; a huge one means that day's transcripts are
+  // already partly rotated, so it measures the very loss being estimated. Comparing each
+  // config directory against a total spanning all of them produced exactly these, from
+  // 0.00x to 414x, and dragged the median with them.
+  const daily = [
+    ...[1, 2, 3, 4, 5, 6].map((n) => ({ day: day(n), tokens: 300 })), // clean 3x
+    { day: day(7), tokens: 10 }, // 0.1x — cache lagged
+    { day: day(8), tokens: 90_000 }, // 900x — transcripts already rotated
+    { day: day(20), tokens: 900 }, // missing
+  ];
+  const ours = new Map([1, 2, 3, 4, 5, 6, 7, 8].map((n) => [day(n), 100]));
+
+  const est = estimateUnseen([{ tokens: 0, root: "/x", days: 9, daily }], ours);
+  assert.equal(est?.ratio, 3, "only the calibratable days set the ratio");
+  assert.deepEqual(est?.spread, [3, 3], "and the spread reports only those days");
+  assert.equal(est?.tokens, 300);
+});
+
+test("without enough overlap the estimate is silence, not a guess", async () => {
+  const { estimateUnseen } = await import("@tokenchit/core/adapters");
+  const daily = [
+    { day: "2026-08-01", tokens: 200 },
+    { day: "2026-08-20", tokens: 900 },
+  ];
+
+  // One overlapping day is not a calibration, and the whole point is that the correction
+  // comes from this machine's own data rather than a constant.
+  assert.equal(
+    estimateUnseen([{ tokens: 0, root: "/x", days: 2, daily }], new Map([["2026-08-01", 100]])),
+    null,
+  );
+
+  // Nor is there anything to estimate when nothing is missing.
+  assert.equal(
+    estimateUnseen(
+      [{ tokens: 0, root: "/x", days: 1, daily: [{ day: "2026-08-01", tokens: 200 }] }],
+      new Map([["2026-08-01", 100]]),
+    ),
+    null,
+  );
+});


### PR DESCRIPTION
## The ceiling, again

Another real user refused. Raised to **1e12 tokens** and **\$500k** a day; review moves to 1e11.

The lesson is the same both times: a limit set from the machines we happen to have seen will be wrong for the next one, and being wrong here costs somebody their submission. A trillion tokens in a day is where a figure stops describing work and starts describing a corrupt file — it is not a judgement about heavy use.

## Can we use the panel's number and correct it?

**Not as the figure.** It counts an API call once per streaming rewrite, so it is records summed rather than calls billed. It exists only for Claude Code, so a total mixing it with honest codex and opencode figures would be incoherent — and on the board, someone whose cache survived would outrank someone whose did not for identical work. And it would fail this project's own cost-per-token floor, which is the check that catches fabrication.

**But there is one honest correction.** On days where both sources exist, the cache's figure divided by the deduplicated figure is how much *this machine's* cache overstates. Apply that median to the days only the cache has:

```
    its panel  27.8B
    this       10.7B  claude-code only
    days       41 of 98
    estimate   ~14.4B  including 35 deleted days, at this machine's own 1.87x overlap
               per-day ratios ranged 1.04x to 4.92x, so treat it as a range
```

Calibrated from the machine's own overlap rather than from a constant. **~14.4B against ~14.0B derived weeks ago by an entirely different method** — two independent routes to the same number.

Shown, never published. The board ranks what can be checked.

## A bug that looking at the output caught

The first version produced ratios from **0.00× to 414×**. Each panel covers one config directory while our daily totals span all of them, so comparing a single panel's day against the combined total measured the *other directories* rather than the inflation. Summed by day first.

Days that cannot calibrate are now excluded rather than averaged in: below 1× the cache lagged; far above it, that day's transcripts are already partly rotated, so the day measures the loss being estimated rather than the inflation. Under five calibratable days there is no estimate at all — silence beats a guess. Three tests pin all of it.

64 tests, lint and build pass.