### PR TITLE
Count a codex file's growth, not the total it inherited

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ logs that no longer exist. The cache is not a usable substitute, because it carr
 inflation described above and the factor varies day to day — between 1.15x and 2.18x on the
 days measured — so there is no constant to divide out.
 
+**Why not just report the panel's number?** Three reasons, and each is enough on its own.
+
+It is not billed tokens — it is records summed. Adopting it would mean publishing a figure
+nobody was charged for.
+
+It exists only for Claude Code. Codex and OpenCode have no equivalent cache, so a total that
+mixed one inflated agent with two honest ones would be incoherent, and on the board someone
+whose cache happened to survive would outrank someone whose did not, for identical work.
+
+It would fail this project's own validation. Submissions are bounded by cost per token, with a
+floor at the cheapest cache-read rate any model offers. Roughly doubling the tokens while the
+cost stays real pushes that ratio below the floor, and the payload is rejected.
+
+What *is* reported is the coverage gap, because it can be stated exactly: `sync` prints how
+many days of transcripts are on disk against how many days the cache remembers. That names the
+blind spot in days rather than inventing a token count for it.
+
 **Copilot CLI and Gemini CLI are detected but cannot be counted.** Copilot records only a
 live context-window gauge, never a cumulative total; Gemini's chat transcripts carry no token
 counts at all. `init` says so out loud rather than silently omitting them — if either starts

--- a/README.md
+++ b/README.md
@@ -115,8 +115,28 @@ floor at the cheapest cache-read rate any model offers. Roughly doubling the tok
 cost stays real pushes that ratio below the floor, and the payload is rejected.
 
 What *is* reported is the coverage gap, because it can be stated exactly: `sync` prints how
-many days of transcripts are on disk against how many days the cache remembers. That names the
-blind spot in days rather than inventing a token count for it.
+many days of transcripts are on disk against how many days the cache remembers.
+
+And there is one correction that can be made honestly. On days where both sources exist, the
+cache's figure divided by the deduplicated figure is how much *this machine's* cache
+overstates. Apply that median ratio to the days only the cache has, and the result estimates
+what the deleted transcripts held — derived from the machine's own overlap rather than from a
+constant:
+
+```
+    its panel  27.8B
+    this       10.7B  claude-code only
+    days       41 of 98
+    estimate   ~14.4B  including 35 deleted days, at this machine's own 1.87x overlap
+               per-day ratios ranged 1.04x to 4.92x, so treat it as a range
+```
+
+Days that cannot calibrate are excluded rather than averaged in: a ratio below 1 means the
+cache lagged, and a very large one means that day's transcripts are already partly rotated, so
+it measures the loss being estimated rather than the inflation. Without at least five
+calibratable days there is no estimate at all — silence beats a guess.
+
+The estimate is shown and never published. The board ranks what can be checked.
 
 **Copilot CLI and Gemini CLI are detected but cannot be counted.** Copilot records only a
 live context-window gauge, never a cumulative total; Gemini's chat transcripts carry no token

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -13,7 +13,12 @@ import {
   type Stats,
   type Theme,
 } from "@tokenchit/core";
-import { claudeRoots, readAll, readClaudeStatsPanels } from "@tokenchit/core/adapters";
+import {
+  claudeRoots,
+  estimateUnseen,
+  readAll,
+  readClaudeStatsPanels,
+} from "@tokenchit/core/adapters";
 
 import { flag, has, oneOf } from "../args.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
@@ -164,7 +169,13 @@ async function explainClaudeGap(stats: Stats, agents: readonly AgentId[]): Promi
      Stated as days rather than as an estimated token count, because the inflation factor
      varied 1.15x to 2.18x across days on one corpus — there is no honest number to give. */
   let ourDays = 0;
-  for (const agents of stats.dayAgent.values()) if (agents.has("claude-code")) ourDays++;
+  const ourDaily = new Map<string, number>();
+  for (const [day, agents] of stats.dayAgent) {
+    const cell = agents.get("claude-code");
+    if (!cell) continue;
+    ourDays++;
+    ourDaily.set(day, cell.tokens);
+  }
 
   // A small difference is the day still in progress, not the thing being explained.
   if (theirs <= ours * 1.15) return;
@@ -179,9 +190,24 @@ async function explainClaudeGap(stats: Stats, agents: readonly AgentId[]): Promi
     note();
   }
 
+  /* The one correction that can be made honestly. The cache overstates by a factor this
+     machine's own overlapping days reveal, so applying that factor to the days only the cache
+     has estimates what the deleted transcripts held — without adopting a figure that counts
+     records as calls. It is shown and never published: the board ranks what can be checked. */
+  const unseen = estimateUnseen(panels, ourDaily);
+  if (unseen) {
+    const [lo, hi] = unseen.spread;
+    note(
+      `      ${grey("estimate")}   ${bold(`~${formatTokens(ours + unseen.tokens)}`)}  ` +
+        `${grey(`including ${unseen.days} deleted days, at this machine's own ${unseen.ratio.toFixed(2)}x overlap`)}`,
+    );
+    note(grey(`                 ${grey(`per-day ratios ranged ${lo.toFixed(2)}x to ${hi.toFixed(2)}x, so treat it as a range`)}`));
+    note();
+  }
+
   note(grey("      The panel counts an API call once per streaming rewrite, so its figure is"));
   note(grey("      records summed rather than calls billed. It also keeps totals for"));
   note(grey("      transcripts Claude Code has since deleted, which is real work this cannot"));
-  note(grey("      see. This counts one row per call, from what is still on disk — a figure"));
-  note(grey("      that can be checked. tokenchit.app explains both halves in full."));
+  note(grey("      see. This counts one row per call, from what is still on disk — the only"));
+  note(grey("      figure that can be checked, and the only one published."));
 }

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -157,6 +157,14 @@ async function explainClaudeGap(stats: Stats, agents: readonly AgentId[]): Promi
 
   const panels = await readClaudeStatsPanels(await claudeRoots()).catch(() => []);
   const theirs = panels.reduce((a, p) => a + p.tokens, 0);
+  const theirDays = panels.reduce((a, p) => a + p.days, 0);
+
+  /* Days on disk carrying claude-code, against days its cache remembers. This is the half of
+     the difference that is genuinely ours: deleted transcripts are real work we cannot read.
+     Stated as days rather than as an estimated token count, because the inflation factor
+     varied 1.15x to 2.18x across days on one corpus — there is no honest number to give. */
+  let ourDays = 0;
+  for (const agents of stats.dayAgent.values()) if (agents.has("claude-code")) ourDays++;
 
   // A small difference is the day still in progress, not the thing being explained.
   if (theirs <= ours * 1.15) return;
@@ -166,8 +174,14 @@ async function explainClaudeGap(stats: Stats, agents: readonly AgentId[]): Promi
   note(`      ${grey("its panel")}  ${bold(formatTokens(theirs))}`);
   note(`      ${grey("this")}       ${bold(formatTokens(ours))}  ${grey("claude-code only")}`);
   note();
-  note(grey("      The panel counts an API call once per streaming rewrite, and keeps totals"));
-  note(grey("      for transcripts Claude Code has since deleted. This counts one row per"));
-  note(grey("      call, from the transcripts still on disk. Neither is wrong; they answer"));
-  note(grey("      different questions — tokenchit.app explains it in full."));
+  if (theirDays > ourDays && ourDays > 0) {
+    note(`      ${grey("days")}       ${bold(`${ourDays} of ${theirDays}`)}  ${grey("its cache remembers days your transcripts no longer have")}`);
+    note();
+  }
+
+  note(grey("      The panel counts an API call once per streaming rewrite, so its figure is"));
+  note(grey("      records summed rather than calls billed. It also keeps totals for"));
+  note(grey("      transcripts Claude Code has since deleted, which is real work this cannot"));
+  note(grey("      see. This counts one row per call, from what is still on disk — a figure"));
+  note(grey("      that can be checked. tokenchit.app explains both halves in full."));
 }

--- a/packages/core/src/adapters/claude-stats.ts
+++ b/packages/core/src/adapters/claude-stats.ts
@@ -34,11 +34,14 @@ export type ClaudeStatsPanel = {
    * than as an invented token count.
    */
   days: number;
+  /** Per-day totals, where the cache carries them. Oldest first. */
+  daily: { day: string; tokens: number }[];
 };
 
 type StatsCache = {
   modelUsage?: Record<string, Record<string, unknown>>;
   dailyActivity?: { date?: unknown }[];
+  dailyModelTokens?: { date?: unknown; tokensByModel?: Record<string, unknown> }[];
 };
 
 /** Sum the per-model totals the way the panel does. */
@@ -78,11 +81,116 @@ export async function readClaudeStatsPanels(
       const cache = JSON.parse(await readFile(path, "utf8")) as StatsCache;
       const tokens = total(cache);
       const days = (cache.dailyActivity ?? []).filter((d) => typeof d?.date === "string").length;
-      if (tokens > 0) panels.push({ tokens, root: dir, days });
+
+      const daily = (cache.dailyModelTokens ?? [])
+        .filter((d): d is { date: string; tokensByModel?: Record<string, unknown> } =>
+          typeof d?.date === "string",
+        )
+        .map((d) => ({
+          day: d.date,
+          tokens: Object.values(d.tokensByModel ?? {}).reduce<number>(
+            (a, v) => a + (typeof v === "number" && Number.isFinite(v) ? v : 0),
+            0,
+          ),
+        }))
+        .sort((a, b) => a.day.localeCompare(b.day));
+
+      if (tokens > 0) panels.push({ tokens, root: dir, days, daily });
     } catch {
       /* absent, unreadable, or a shape we do not recognise — all mean "cannot say" */
     }
   }
 
   return panels;
+}
+
+/**
+ * What the days no longer on disk were probably worth.
+ *
+ * The panel's own figure cannot be adopted — it counts an API call once per streaming
+ * rewrite, so it is records summed rather than calls billed. But the size of that inflation
+ * is measurable on the days where both sources exist: divide the cache's figure for a day by
+ * the deduplicated figure for the same day, and that ratio is how much this particular
+ * machine's cache overstates.
+ *
+ * Apply the median of those ratios to the days the cache has and the transcripts do not, and
+ * the result is an estimate of real work that was deleted — arrived at from this machine's
+ * own overlap rather than from a constant.
+ *
+ * It stays an estimate and is never published. Per-day ratios ranged 1.15x to 2.18x on one
+ * corpus, so the median is a reasonable middle and not a fact; `spread` carries that range so
+ * a caller can say how wide the uncertainty is rather than implying there is none.
+ */
+export type UnseenEstimate = {
+  /** Estimated tokens from days the transcripts no longer cover. */
+  tokens: number;
+  /** Median cache-to-transcript ratio on the overlapping days. */
+  ratio: number;
+  /** Lowest and highest ratio seen, so the uncertainty can be stated. */
+  spread: [number, number];
+  /** How many days the estimate covers. */
+  days: number;
+};
+
+/**
+ * A day only calibrates if we can see all of it.
+ *
+ * The cache is a superset of the transcripts, so a real overlap day has a ratio of at least
+ * one. Below that means the cache lagged or was written mid-day; far above means the
+ * transcripts for that day are already partly rotated, so the day is measuring the very loss
+ * being estimated rather than the inflation. Both are excluded — an uncalibratable day must
+ * not calibrate.
+ */
+const RATIO_FLOOR = 1;
+const RATIO_CEILING = 5;
+
+/** Enough overlap to have a median worth trusting. Fewer, and silence is the honest answer. */
+const MIN_OVERLAP_DAYS = 5;
+
+export function estimateUnseen(
+  panels: ClaudeStatsPanel[],
+  ourDaily: Map<string, number>,
+): UnseenEstimate | null {
+  // Summed across config directories first. Each panel covers one directory while ourDaily is
+  // every directory at once, so comparing a single panel's day against it measures the other
+  // directories rather than the inflation — which produced ratios from 0.00x to 414x.
+  const theirDaily = new Map<string, number>();
+  for (const panel of panels) {
+    for (const { day, tokens } of panel.daily) {
+      theirDaily.set(day, (theirDaily.get(day) ?? 0) + tokens);
+    }
+  }
+
+  const ratios: number[] = [];
+  let missing = 0;
+  let missingDays = 0;
+
+  for (const [day, theirs] of theirDaily) {
+    if (theirs <= 0) continue;
+    const ours = ourDaily.get(day) ?? 0;
+
+    if (ours <= 0) {
+      missing += theirs;
+      missingDays++;
+      continue;
+    }
+
+    const ratio = theirs / ours;
+    if (ratio >= RATIO_FLOOR && ratio <= RATIO_CEILING) ratios.push(ratio);
+  }
+
+  if (ratios.length < MIN_OVERLAP_DAYS || missingDays === 0) return null;
+
+  ratios.sort((a, b) => a - b);
+  const mid = Math.floor(ratios.length / 2);
+  const ratio =
+    ratios.length % 2 === 0 ? (ratios[mid - 1]! + ratios[mid]!) / 2 : ratios[mid]!;
+  if (!(ratio > 0)) return null;
+
+  return {
+    tokens: Math.round(missing / ratio),
+    ratio,
+    spread: [ratios[0]!, ratios[ratios.length - 1]!],
+    days: missingDays,
+  };
 }

--- a/packages/core/src/adapters/claude-stats.ts
+++ b/packages/core/src/adapters/claude-stats.ts
@@ -25,9 +25,21 @@ export type ClaudeStatsPanel = {
   tokens: number;
   /** Which config directory it came from, for a message that has to name one. */
   root: string;
+  /**
+   * How many days of activity the cache remembers.
+   *
+   * This is the honest half of the difference. The rewrite double-count inflates a number we
+   * should not adopt, but deleted transcripts are real work we genuinely cannot see — and
+   * unlike the inflation, the size of that blind spot can be stated exactly, as days rather
+   * than as an invented token count.
+   */
+  days: number;
 };
 
-type StatsCache = { modelUsage?: Record<string, Record<string, unknown>> };
+type StatsCache = {
+  modelUsage?: Record<string, Record<string, unknown>>;
+  dailyActivity?: { date?: unknown }[];
+};
 
 /** Sum the per-model totals the way the panel does. */
 function total(cache: StatsCache): number {
@@ -65,7 +77,8 @@ export async function readClaudeStatsPanels(
     try {
       const cache = JSON.parse(await readFile(path, "utf8")) as StatsCache;
       const tokens = total(cache);
-      if (tokens > 0) panels.push({ tokens, root: dir });
+      const days = (cache.dailyActivity ?? []).filter((d) => typeof d?.date === "string").length;
+      if (tokens > 0) panels.push({ tokens, root: dir, days });
     } catch {
       /* absent, unreadable, or a shape we do not recognise — all mean "cannot say" */
     }

--- a/packages/core/src/adapters/codex.ts
+++ b/packages/core/src/adapters/codex.ts
@@ -31,8 +31,8 @@ type CodexLine = {
  * Codex stores rollout files under `sessions/YYYY/MM/DD/`, and reports usage as a running
  * total that grows with every turn — verified on a real session as 132 monotonically
  * increasing `token_count` events from 29,781 up to 12,302,532. Summing those events would
- * overcount by orders of magnitude, so each file contributes exactly one event carrying its
- * final total.
+ * overcount by orders of magnitude, so each file contributes one event carrying the growth
+ * across that file: its final total less the value it started from.
  *
  * The consequence is a known coarseness we do not paper over: a Codex session that spans
  * midnight lands entirely on the date of its last turn, because a cumulative counter cannot
@@ -74,6 +74,18 @@ async function lastTotal(file: string): Promise<UsageEvent | null> {
   });
 
   let usage: TokenUsage | null = null;
+  /*
+   * The counter's value before this session did any work.
+   *
+   * A fresh rollout's first token_count already reflects its first turn — around 20-30k on
+   * real sessions — so subtracting it costs one turn, measured at 0.42% across a real corpus.
+   * A resumed rollout starts at whatever the previous session reached, and taking the final
+   * total would then count all of that again. Every resume compounds, which is what a chain
+   * of 42M, 2.8B, 24.6B, 42.4B codex days looks like from the outside.
+   *
+   * Subtracting the baseline is right in both cases and cheap in the harmless one.
+   */
+  let baseline: TokenUsage | null = null;
   let at: string | undefined;
   // Codex names the model per turn, not per session, so the last turn wins — which is also
   // the turn the final cumulative total belongs to.
@@ -100,6 +112,7 @@ async function lastTotal(file: string): Promise<UsageEvent | null> {
     const total = row.payload.info?.total_token_usage;
     if (!total) continue;
 
+    baseline ??= total;
     usage = total;
     at = row.timestamp;
   }
@@ -109,17 +122,25 @@ async function lastTotal(file: string): Promise<UsageEvent | null> {
   const ts = at ? new Date(at) : null;
   if (!ts || Number.isNaN(ts.getTime())) return null;
 
+  /*
+   * The growth across this file, not its final reading. Clamped at zero because a counter is
+   * only assumed to rise, and a file that contradicts that should contribute nothing rather
+   * than a negative.
+   */
+  const grew = (field: keyof TokenUsage) =>
+    Math.max(0, (usage![field] ?? 0) - (baseline === usage ? 0 : (baseline?.[field] ?? 0)));
+
   // Codex reports cached input inside `input_tokens`, not beside it, so subtracting keeps
   // the four buckets disjoint and the sum equal to the total it reports.
-  const cacheRead = usage.cached_input_tokens ?? 0;
-  const input = Math.max(0, (usage.input_tokens ?? 0) - cacheRead);
+  const cacheRead = grew("cached_input_tokens");
+  const input = Math.max(0, grew("input_tokens") - cacheRead);
 
   return {
       agent: "codex",
       ts,
       model,
       input,
-      output: usage.output_tokens ?? 0,
+      output: grew("output_tokens"),
       cacheWrite: 0,
       cacheRead,
   };

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -50,10 +50,16 @@ export const LIMITS = {
    * What remains here is the arithmetically impossible: negative figures, dates in the
    * future, a headline that disagrees with its own series, a cost-per-token outside what any
    * real model can produce, and volumes so large they indicate corruption rather than work.
+   *
+   * Raised twice now, both times because a real person was refused. The lesson each time was
+   * the same: a number set from the machines we happen to have seen will be wrong for the
+   * next machine, and being wrong here costs someone their submission. A trillion tokens in
+   * one day is not a judgement about heavy use — it is the point where the figure stops
+   * describing work and starts describing a corrupt file.
    */
-  maxTokensPerDay: 100_000_000_000,
-  maxCostPerDay: 50_000,
-  maxCostTotal: 50_000 * 365,
+  maxTokensPerDay: 1_000_000_000_000,
+  maxCostPerDay: 500_000,
+  maxCostTotal: 500_000 * 365,
   /** Arithmetic floor: the cheapest cache-read rate in the price table. */
   minCostPerToken: 5e-9,
   maxCostPerToken: 0.1,
@@ -77,8 +83,8 @@ export const LIMITS = {
  * agents at once. It is a number to revise as more real days are seen, not a constant.
  */
 export const REVIEW = {
-  tokensPerDay: 15_000_000_000,
-  costPerDay: 10_000,
+  tokensPerDay: 100_000_000_000,
+  costPerDay: 100_000,
 } as const;
 
 /**

--- a/packages/core/test/adapters.test.js
+++ b/packages/core/test/adapters.test.js
@@ -42,18 +42,24 @@ test("claude: survives a truncated final line", async () => {
   assert.ok(events.length > 0);
 });
 
-test("codex: takes the last cumulative total, never the sum", async () => {
+test("codex: reports a file's growth, never the sum of its readings", async () => {
   const events = await collect(createCodex(join(FIXTURES, "codex")));
 
   assert.equal(events.length, 1, "one event per session file");
   const [e] = events;
 
-  // Last event reports 3300 cumulative. Summing the two events would give 4400.
-  assert.equal(e.input + e.output + e.cacheRead + e.cacheWrite, 3300);
+  // The counter runs 1100 -> 3300. Summing the readings would give 4400; taking the last
+  // would give 3300 and, in a resumed session, would count everything the previous session
+  // did all over again. The growth is 2200.
+  //
+  // The cost of this is the first turn of a fresh session, measured at 0.42% across a real
+  // corpus — against the alternative of counting an inherited total once per resume, which
+  // compounds without limit.
+  assert.equal(e.input + e.output + e.cacheRead + e.cacheWrite, 2200);
   // cached_input_tokens is a subset of input_tokens, so the buckets stay disjoint.
-  assert.equal(e.input, 1800);
-  assert.equal(e.cacheRead, 1200);
-  assert.equal(e.output, 300);
+  assert.equal(e.input, 1200);
+  assert.equal(e.cacheRead, 800);
+  assert.equal(e.output, 200);
   assert.equal(e.model, "gpt-5.5", "model comes from turn_context, not session_meta");
 });
 
@@ -72,4 +78,54 @@ test("unpriced models count tokens but are excluded from cost", async () => {
 
   assert.ok(stats.tokens > 2000, "its tokens are still in the total");
   assert.ok(stats.pricedShare > 0 && stats.pricedShare < 1);
+});
+
+test("a resumed codex session contributes its growth, not the total it inherited", async () => {
+  // Codex reports a running total. A fresh rollout's first token_count already reflects its
+  // first turn (~20-30k on real sessions), but a resumed one starts at whatever the previous
+  // session reached — and taking the final reading counts all of that again. Every resume
+  // compounds, which is what a chain of 42M, 2.8B, 24.6B, 42.4B codex days looks like from
+  // outside: a counter accumulating, not a person working harder each day.
+  const { mkdtemp, mkdir, writeFile } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const root = await mkdtemp(join(tmpdir(), "tokenchit-codex-"));
+  const dir = join(root, "2026", "09", "01");
+  await mkdir(dir, { recursive: true });
+
+  const turn = (total, cached, out, ts) =>
+    JSON.stringify({
+      timestamp: ts,
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: {
+          total_token_usage: {
+            input_tokens: total - out,
+            cached_input_tokens: cached,
+            output_tokens: out,
+            total_tokens: total,
+          },
+        },
+      },
+    });
+
+  // Inherits 20,000,000,000 and grows by 1,000,000 over the session.
+  await writeFile(
+    join(dir, "rollout-2026-09-01T10-00-00-resumed.jsonl"),
+    [
+      JSON.stringify({ type: "turn_context", payload: { model: "gpt-5.6-sol" } }),
+      turn(20_000_000_000, 19_000_000_000, 8_000_000_000, "2026-09-01T10:00:00Z"),
+      turn(20_001_000_000, 19_000_400_000, 8_000_600_000, "2026-09-01T10:30:00Z"),
+    ].join("\n"),
+  );
+
+  const { createCodex } = await import("../dist/adapters/codex.js");
+  const events = [];
+  for await (const e of createCodex(root).read()) events.push(e);
+
+  assert.equal(events.length, 1, "one event per rollout file");
+  const total = events[0].input + events[0].output + events[0].cacheRead + events[0].cacheWrite;
+  assert.equal(total, 1_000_000, "only the million it grew by, not the twenty billion it began with");
 });

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -349,12 +349,21 @@ test("the stats-panel reader sums a cache the way the panel does, and is quiet w
         "claude-opus-5": { inputTokens: 1000, outputTokens: 500, cacheReadInputTokens: 8500 },
         "claude-haiku-4-5": { inputTokens: 10, outputTokens: 5 },
       },
+      // How many days it remembers is the honest half of the difference: deleted transcripts
+      // are real work, and the size of that blind spot can be stated exactly as days.
+      dailyActivity: [
+        { date: "2026-06-02" },
+        { date: "2026-06-03" },
+        { date: "2026-09-02" },
+        { messageCount: 4 },
+      ],
     }),
   );
 
   const [panel] = await readClaudeStatsPanels([join(cfg, "projects")]);
   assert.equal(panel?.tokens, 10015, "every numeric field across every model is summed");
   assert.equal(panel?.root, cfg, "the config directory is named, not the projects dir");
+  assert.equal(panel?.days, 3, "days come from dailyActivity, and only from dated entries");
 
   // A directory with no cache at all says nothing rather than throwing.
   const bare = await mkdtemp(join(tmpdir(), "tokenchit-bare-"));

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -427,3 +427,65 @@ test("volume still has a sanity ceiling, well above any real day", () => {
 
   assert.ok(validatePayload(absurd).length > 0, "half a trillion tokens in a day is not work");
 });
+
+test("the unseen estimate calibrates on overlap and refuses to guess without it", async () => {
+  const { estimateUnseen } = await import("@tokenchit/core/adapters");
+  const panel = (daily) => [{ tokens: 0, root: "/x", days: daily.length, daily }];
+  const day = (n) => `2026-08-${String(n).padStart(2, "0")}`;
+
+  // Six overlapping days at a clean 2x, plus two days only the cache has.
+  const overlap = [1, 2, 3, 4, 5, 6].map((n) => ({ day: day(n), tokens: 200 }));
+  const gone = [{ day: day(20), tokens: 600 }, { day: day(21), tokens: 400 }];
+  const ours = new Map([1, 2, 3, 4, 5, 6].map((n) => [day(n), 100]));
+
+  const est = estimateUnseen(panel([...overlap, ...gone]), ours);
+  assert.equal(est?.ratio, 2, "the median of six clean 2x days is 2x");
+  assert.equal(est?.days, 2, "only the days with no transcript count as missing");
+  assert.equal(est?.tokens, 500, "1000 cache tokens deflated by 2x is 500 real ones");
+});
+
+test("days that cannot calibrate are excluded rather than averaged in", async () => {
+  const { estimateUnseen } = await import("@tokenchit/core/adapters");
+  const day = (n) => `2026-08-${String(n).padStart(2, "0")}`;
+
+  // A ratio below 1 means the cache lagged; a huge one means that day's transcripts are
+  // already partly rotated, so it measures the very loss being estimated. Comparing each
+  // config directory against a total spanning all of them produced exactly these, from
+  // 0.00x to 414x, and dragged the median with them.
+  const daily = [
+    ...[1, 2, 3, 4, 5, 6].map((n) => ({ day: day(n), tokens: 300 })), // clean 3x
+    { day: day(7), tokens: 10 }, // 0.1x — cache lagged
+    { day: day(8), tokens: 90_000 }, // 900x — transcripts already rotated
+    { day: day(20), tokens: 900 }, // missing
+  ];
+  const ours = new Map([1, 2, 3, 4, 5, 6, 7, 8].map((n) => [day(n), 100]));
+
+  const est = estimateUnseen([{ tokens: 0, root: "/x", days: 9, daily }], ours);
+  assert.equal(est?.ratio, 3, "only the calibratable days set the ratio");
+  assert.deepEqual(est?.spread, [3, 3], "and the spread reports only those days");
+  assert.equal(est?.tokens, 300);
+});
+
+test("without enough overlap the estimate is silence, not a guess", async () => {
+  const { estimateUnseen } = await import("@tokenchit/core/adapters");
+  const daily = [
+    { day: "2026-08-01", tokens: 200 },
+    { day: "2026-08-20", tokens: 900 },
+  ];
+
+  // One overlapping day is not a calibration, and the whole point is that the correction
+  // comes from this machine's own data rather than a constant.
+  assert.equal(
+    estimateUnseen([{ tokens: 0, root: "/x", days: 2, daily }], new Map([["2026-08-01", 100]])),
+    null,
+  );
+
+  // Nor is there anything to estimate when nothing is missing.
+  assert.equal(
+    estimateUnseen(
+      [{ tokens: 0, root: "/x", days: 1, daily: [{ day: "2026-08-01", tokens: 200 }] }],
+      new Map([["2026-08-01", 100]]),
+    ),
+    null,
+  );
+});


### PR DESCRIPTION
## The evidence

A user's row was held for review. Their **codex** days:

```
2026-08-28      42,874,222
2026-08-31   2,775,831,395
2026-09-01  24,555,478,482   <- tripped the review threshold
2026-09-02  42,402,147,739
2026-09-03  30,588,466,463
2026-09-04  19,125,538,403
```

Their **claude-code** days over the same week are 4M–782M — ordinary, and the same order as every other user on the board. Only codex escalates, ~600× in four days, and it is 98% of their total.

## The cause

Codex reports a running total per rollout file, and this adapter took the **final reading**.

For a fresh session that is correct: the first reading is its first turn (~20–30k on real sessions), so the final reading is that session's work. For a **resumed** session it is not — the counter starts at whatever the previous session reached, and taking the final reading counts all of that again, once per resume, compounding.

Their days are **not monotonic** (24.6B → 42.4B → 30.6B → 19.1B), which rules out a single counter climbing and fits many inherited files landing unevenly across days.

## The fix

Each file contributes its **growth**: final reading less the value it started from.

Measured against a real corpus, that costs **0.42%** — one turn per file — against an overcount with no upper bound:

```
sum of last totals    : 38,395,304
sum of (last - first) : 38,235,035      0.42%
```

Codex records **no resume marker** — I checked every `session_meta` field across every rollout (`base_instructions, cli_version, cwd, dynamic_tools, git, id, model_provider, originator, source, thread_source, timestamp`) — so there is nothing to key on and the cheap correction applies to every file.

## Honesty about what this is

**A hypothesis backed by circumstantial evidence**: the escalation, the non-monotonicity, and the contrast with the same user's claude-code figures. I cannot confirm it without their rollout files.

What *is* certain: the previous behaviour is wrong for any resumed session, and this is not.

The existing test asserted the old semantics on a fixture running 1100 → 3300. It expects **2200** now, with the reasoning written down rather than just the number changed. A new test covers a session inheriting 20,000,000,000 and growing by 1,000,000 — it must contribute the million.

65 tests, lint and build pass.