### PR TITLE
Release v0.4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,7 +8199,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -8250,7 +8250,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Two fixes found by watching real users, plus the estimate.

**#53 — codex was counting inherited totals.** Codex reports a running total per rollout file, and the adapter took the final reading. Correct for a fresh session; wrong for a resumed one, which starts at whatever the previous session reached and gets counted again, once per resume, compounding. A user's codex days read 42.9M → 2.78B → 24.6B → 42.4B while their claude-code days over the same week were 4M–782M. Each file now contributes its growth. Costs 0.42% on a real corpus — one turn per file — against an overcount with no bound.

**#52 — the daily ceiling is 1e12**, raised after a second real user was refused. Review moves to 1e11. A limit set from the machines we have seen will be wrong for the next one, and being wrong there costs somebody their submission.

**#52 also adds the honest correction to the Claude Code gap.** On days where both sources exist, the cache's figure over the deduplicated figure is how much that machine's cache overstates; applying that median to the days only the cache has estimates what deleted transcripts held. Shown, never published — the board ranks what can be checked.

Verified locally with the exact gate CI runs: build, 65 tests, lint. `--version` reports 0.4.8 and the site badge renders `v0.4.8 · MIT`.