### PR TITLE
Quote the panel figure someone can actually see

### DIFF
--- a/packages/core/src/adapters/claude-stats.ts
+++ b/packages/core/src/adapters/claude-stats.ts
@@ -1,5 +1,9 @@
-import { readFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { createInterface } from "node:readline";
 import { dirname, join } from "node:path";
+
+import { walkFiles } from "./walk.js";
 
 /**
  * What Claude Code's own Stats panel will say.
@@ -42,15 +46,82 @@ type StatsCache = {
   modelUsage?: Record<string, Record<string, unknown>>;
   dailyActivity?: { date?: unknown }[];
   dailyModelTokens?: { date?: unknown; tokensByModel?: Record<string, unknown> }[];
+  /** The last day the cache was computed for. Everything after it is missing from it. */
+  lastComputedDate?: unknown;
 };
+
+/**
+ * The four fields that are tokens.
+ *
+ * modelUsage also carries costUSD, contextWindow, maxOutputTokens and webSearchRequests.
+ * Summing every numeric field happened to be harmless on the machines checked, where those
+ * are zero, but a context window counted as tokens is wrong in kind rather than in degree.
+ */
+const TOKEN_FIELDS = [
+  "inputTokens",
+  "outputTokens",
+  "cacheReadInputTokens",
+  "cacheCreationInputTokens",
+] as const;
 
 /** Sum the per-model totals the way the panel does. */
 function total(cache: StatsCache): number {
   let sum = 0;
   for (const models of Object.values(cache.modelUsage ?? {})) {
     if (!models || typeof models !== "object") continue;
-    for (const value of Object.values(models)) {
+    for (const field of TOKEN_FIELDS) {
+      const value = (models as Record<string, unknown>)[field];
       if (typeof value === "number" && Number.isFinite(value)) sum += value;
+    }
+  }
+  return sum;
+}
+
+/**
+ * What the cache has not caught up with yet.
+ *
+ * `stats-cache.json` is computed to a date and no further, so a panel opened today shows the
+ * cache plus today's work, while the file alone is short by exactly that. Measured against
+ * two real accounts, the file read 18.17b and 10.57b while the panels showed 18.3b and 11.0b.
+ *
+ * Counted the way the panel counts — every usage record, no deduplication — because the point
+ * is to reproduce the figure on somebody's screen, not to be right about billing. Files
+ * untouched since the cache was computed cannot contain anything newer than it, so only the
+ * recently modified ones are opened.
+ */
+async function sinceComputed(projects: string, lastComputed: string): Promise<number> {
+  const after = Date.parse(`${lastComputed}T23:59:59.999Z`);
+  if (Number.isNaN(after)) return 0;
+
+  let sum = 0;
+  for await (const file of walkFiles(projects, ".jsonl")) {
+    const info = await stat(file).catch(() => null);
+    if (!info || info.mtimeMs < after) continue;
+
+    const lines = createInterface({
+      input: createReadStream(file, { encoding: "utf8" }),
+      crlfDelay: Infinity,
+    });
+
+    for await (const line of lines) {
+      if (!line.includes('"usage"')) continue;
+
+      let row: { timestamp?: unknown; message?: { usage?: Record<string, unknown> } };
+      try {
+        row = JSON.parse(line) as typeof row;
+      } catch {
+        continue;
+      }
+
+      const ts = typeof row.timestamp === "string" ? Date.parse(row.timestamp) : NaN;
+      if (Number.isNaN(ts) || ts <= after) continue;
+
+      const usage = row.message?.usage;
+      if (!usage) continue;
+      for (const field of ["input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"]) {
+        const value = usage[field];
+        if (typeof value === "number" && Number.isFinite(value)) sum += value;
+      }
     }
   }
   return sum;
@@ -79,7 +150,11 @@ export async function readClaudeStatsPanels(
 
     try {
       const cache = JSON.parse(await readFile(path, "utf8")) as StatsCache;
-      const tokens = total(cache);
+      const lastComputed =
+        typeof cache.lastComputedDate === "string" ? cache.lastComputedDate : null;
+      const tokens =
+        total(cache) +
+        (lastComputed ? await sinceComputed(root, lastComputed).catch(() => 0) : 0);
       const days = (cache.dailyActivity ?? []).filter((d) => typeof d?.date === "string").length;
 
       const daily = (cache.dailyModelTokens ?? [])

--- a/packages/core/test/aggregate.test.js
+++ b/packages/core/test/aggregate.test.js
@@ -347,7 +347,16 @@ test("the stats-panel reader sums a cache the way the panel does, and is quiet w
     JSON.stringify({
       modelUsage: {
         "claude-opus-5": { inputTokens: 1000, outputTokens: 500, cacheReadInputTokens: 8500 },
-        "claude-haiku-4-5": { inputTokens: 10, outputTokens: 5 },
+        "claude-haiku-4-5": {
+          inputTokens: 10,
+          outputTokens: 5,
+          // Not tokens, and must not be counted as such. Harmless where these are zero, but
+          // a context window summed into a token total is wrong in kind, not degree.
+          costUSD: 1234.56,
+          contextWindow: 200_000,
+          maxOutputTokens: 64_000,
+          webSearchRequests: 12,
+        },
       },
       // How many days it remembers is the honest half of the difference: deleted transcripts
       // are real work, and the size of that blind spot can be stated exactly as days.
@@ -488,4 +497,49 @@ test("without enough overlap the estimate is silence, not a guess", async () => 
     ),
     null,
   );
+});
+
+test("the panel figure includes days the cache has not computed yet", async () => {
+  // stats-cache.json is computed to a date and no further, so a panel opened today shows the
+  // cache plus today's work while the file alone is short by exactly that. Against two real
+  // accounts the file read 18.17b and 10.57b while the panels showed 18.3b and 11.0b — the
+  // gap being that day. An explainer that prints a third number nobody recognises is worse
+  // than one that prints none.
+  const { readClaudeStatsPanels } = await import("@tokenchit/core/adapters");
+  const { mkdtemp, mkdir, writeFile } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const cfg = await mkdtemp(join(tmpdir(), "tokenchit-lag-"));
+  const projects = join(cfg, "projects", "repo");
+  await mkdir(projects, { recursive: true });
+
+  await writeFile(
+    join(cfg, "stats-cache.json"),
+    JSON.stringify({
+      lastComputedDate: "2026-09-03",
+      modelUsage: { "claude-opus-5": { cacheReadInputTokens: 1_000_000 } },
+      dailyActivity: [{ date: "2026-09-03" }],
+    }),
+  );
+
+  const line = (ts, tokens) =>
+    JSON.stringify({
+      timestamp: ts,
+      message: { id: `m-${ts}`, usage: { cache_read_input_tokens: tokens } },
+    });
+
+  await writeFile(
+    join(projects, "session.jsonl"),
+    [
+      // Already inside the cache's figure; adding it again would double-count.
+      line("2026-09-03T10:00:00.000Z", 500_000),
+      // After the cache was computed, so the panel shows it and the file does not.
+      line("2026-09-04T09:00:00.000Z", 250_000),
+      line("2026-09-04T11:00:00.000Z", 250_000),
+    ].join("\n"),
+  );
+
+  const [panel] = await readClaudeStatsPanels([join(cfg, "projects")]);
+  assert.equal(panel?.tokens, 1_500_000, "the cache plus only what came after it");
 });


### PR DESCRIPTION
The explainer printed **27.8B** while the two Stats panels on this machine read **18.3b** and **11.0b** — 29.3b together.

That line exists so a person comparing the two numbers recognises theirs. Printing a third number nobody sees is worse than printing none.

## Cause

`stats-cache.json` carries `lastComputedDate` and stops there. The panel adds the current day live, so the file alone is short by exactly that:

```
                    panel      file only     now
.claude             18.3b      18.17b        18.27b
.claude-personal    11.0b      10.57b        11.04b
                    ─────                    ──────
                    29.3b                    29.31b
```

Reading the cache plus everything after `lastComputedDate` closes it.

Counted **the way the panel counts** — every usage record, no deduplication — because the point is to reproduce a figure on somebody's screen, not to be right about billing. The deduplicated number is already printed on the line beneath it. Only files modified since the cache was computed are opened, since an untouched file cannot hold anything newer.

## A second thing, found while in there

`modelUsage` also carries `costUSD`, `contextWindow`, `maxOutputTokens` and `webSearchRequests` — and this summed **every numeric field** it found.

Those are all zero on both accounts here, so nothing was wrong in practice. But a context window counted as tokens is wrong in kind rather than in degree, and a machine that populates them would report nonsense. Restricted to the four token fields; the test fixture now carries the other four, and mutation-checking confirms it fails if the restriction is removed.

## Unchanged

The published total, the card, and the board. Only the `its panel` figure in that one explanatory block. All four privacy tests still pass.

66 tests, lint and build pass.