### PR TITLE
Release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,7 +8199,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.4.8",
+      "version": "0.5.0",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -8250,7 +8250,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.4.8",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Bumps `@tokenchit/cli` and `@tokenchit/core` to **0.5.0**.

**Merging this publishes to npm.** The release workflow runs on every push to `main` and publishes whenever the version field names something npm does not have, then creates the `v0.5.0` tag. Nothing else here needs doing.

### Why minor, not patch

Observable behaviour changes, not only defects fixed:

- The headline figure moves — the estimate reaches past retention into the lifetime rollup, and nets what is already counted
- `tokenchit ledger` is a new command
- Payloads the server used to accept now answer 422 — wrong types, missing `firstDay`, a submission claiming nothing

Someone pinning `~0.4.8` should not receive that quietly.

### Since 0.4.8

**Accounting** — the `modelUsage` rollup outlives the rotating daily window, so part of a machine's history is knowable only from it; that part is now priced and netted against days already held. `firstSessionDate` is read at last. `total()` sums four named token fields rather than every number in the entry.

**The board** — an unauthenticated POST could write any handle including a verified one, and a payload with no days erased a row's history; both closed. Signing in no longer launders figures published under a squatted handle. API keys can be revoked. Held-for-review rows stay off the board, the profile ranking and the embeddable card alike.

**The CLI** — `publish --dry-runn` published for real; unknown flags are refused. One unreadable transcript aborted a whole scan. `recap` read logs directly while everything else read the ledger, so the two disagreed after retention.

**The site** — avatars on every surface that names a person, served from our own origin. Faces embedded in the cards themselves. Handle search, a podium, a marker on rows gone quiet, and an open-source ticker.

---

91 tests. Build and lint clean. QA run against a fresh schema and a production build: 20 checks, 0 failures.

**Not covered:** the GitHub OAuth round-trip was never exercised end to end, and no site change has met production data. The takeover flag and the profile rank CTE both alter what existing users see on first deploy.