### PR TITLE
Release v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,7 +8199,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -8250,7 +8250,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Bumps `@tokenchit/cli` and `@tokenchit/core` to **0.6.0**.

**Merging this publishes to npm.** The release workflow publishes whenever the version field names something npm does not have, then tags `v0.6.0`.

### Why minor

`login` behaves visibly differently: it parks the device code with the site and opens a page showing it with a copy button and the two steps, rather than leaving the code in a terminal to be selected. New behaviour in the same command, backwards compatible.

The site half of this (#59) is already on `main` and deployed, and `006_login_sessions.sql` is already applied — so this bump is what makes the CLI actually use it. Until it lands, `npx @tokenchit/cli@latest login` still opens GitHub directly.

### Since 0.5.0

- `login` opens tokenchit instead of GitHub; the page reports **signed in as @you** when the terminal finishes
- Only the `user_code` is sent — the `device_code` never leaves the CLI
- Falls back to opening GitHub directly if the site is down or `--no-browser` is passed; the code and URL are printed either way
- No longer claims the code is pre-filled — GitHub ignores `?user_code=`, tested
- Does not skip the account picker — it would choose the account silently, and choosing which identity signs in is what this flow is for

---

91 tests, lint and build clean.