### PR TITLE
Share a profile, and let a link preview say what it is

### DIFF
--- a/apps/site/app/board/opengraph-image.tsx
+++ b/apps/site/app/board/opengraph-image.tsx
@@ -1,0 +1,121 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { ImageResponse } from "next/og";
+
+import { formatTokens, formatUsd } from "@tokenchit/core";
+
+import { DEFAULT_WINDOW } from "@/lib/board";
+import { readBoardTotals } from "@/lib/board-totals";
+
+export const runtime = "nodejs";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "The tokenchit board";
+
+/**
+ * The link preview for the board.
+ *
+ * Live figures rather than a static graphic: the board's whole claim is that these are real
+ * people's real usage, and a preview showing what it actually holds today says that better
+ * than any sentence. It reads the same totals the page does, so the two cannot disagree.
+ *
+ * Revalidated hourly. The board itself is revalidated far more often, but a link preview is
+ * fetched once by each platform and then cached on their side for far longer than an hour, so
+ * a tighter window would buy nothing and cost a database read on every crawl.
+ */
+export const revalidate = 3600;
+
+const INK = "#101010";
+const PAPER = "#FFFDF9";
+const LIME = "#C6FF3D";
+const DIM = "#8A8A82";
+
+const font = readFile(join(process.cwd(), "assets", "jetbrains-mono-700.ttf"));
+
+export default async function Image() {
+  // A preview that fails is a link with no image at all, which is worse than one with dashes.
+  const totals = await readBoardTotals(DEFAULT_WINDOW).catch(() => null);
+
+  const stats: [string, string][] = [
+    ["DEVELOPERS", totals ? String(totals.developers) : "—"],
+    ["TOKENS", totals ? formatTokens(totals.tokens) : "—"],
+    ["EQUIV. COST", totals ? formatUsd(totals.equivCostUsd) : "—"],
+  ];
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          width: "100%",
+          height: "100%",
+          background: PAPER,
+          fontFamily: "JetBrains Mono",
+          padding: 64,
+          border: `16px solid ${INK}`,
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+            <div style={{ fontSize: 68, fontWeight: 800, color: INK, letterSpacing: -2 }}>
+              The board
+            </div>
+            <div
+              style={{
+                display: "flex",
+                background: "#FFD23D",
+                border: `4px solid ${INK}`,
+                padding: "6px 14px",
+                fontSize: 20,
+                fontWeight: 700,
+                color: INK,
+              }}
+            >
+              OPT-IN
+            </div>
+          </div>
+
+          <div style={{ display: "flex", height: 5, background: INK, marginTop: 26 }} />
+
+          <div style={{ display: "flex", marginTop: 24, fontSize: 26, color: DIM }}>
+            Everyone who ran tokenchit publish. A usage count, not a skill score.
+          </div>
+
+          <div style={{ display: "flex", gap: 72, marginTop: 48 }}>
+            {stats.map(([label, value]) => (
+              <div key={label} style={{ display: "flex", flexDirection: "column" }}>
+                <div style={{ fontSize: 22, color: DIM, letterSpacing: 3 }}>{label}</div>
+                <div style={{ fontSize: 78, fontWeight: 800, color: INK, letterSpacing: -3 }}>
+                  {value}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <div
+            style={{
+              display: "flex",
+              background: INK,
+              color: LIME,
+              padding: "12px 20px",
+              fontSize: 24,
+              fontWeight: 700,
+            }}
+          >
+            tokenchit
+          </div>
+          <div style={{ display: "flex", fontSize: 24, color: DIM }}>tokenchit.app/board</div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [{ name: "JetBrains Mono", data: await font, weight: 700, style: "normal" }],
+    },
+  );
+}

--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -24,14 +24,39 @@ const mono = JetBrains_Mono({
   display: "swap",
 });
 
+/** One sentence, shared by the page description and both preview cards so they cannot drift. */
+const DESCRIPTION =
+  "tokenchit reads your local Claude Code, Codex and OpenCode logs and renders one embeddable card straight into your repo. A file you commit, not a URL you depend on.";
+
 export const metadata: Metadata = {
   // Without this, relative metadata URLs resolve against the request origin, so a profile
   // shared from production would advertise a localhost preview image whenever the page was
   // rendered anywhere but the live host.
   metadataBase: new URL(SITE_URL),
   title: "tokenchit — receipts for your robots",
-  description:
-    "tokenchit reads your local Claude Code, Codex and OpenCode logs and renders one embeddable card straight into your repo. A file you commit, not a URL you depend on.",
+  description: DESCRIPTION,
+
+  /*
+   * Without these, a paste of the bare domain into Slack, a DM or a LinkedIn post unfurled as
+   * a bare "Web Link" and nothing else: the profile pages carried a preview and the page they
+   * invite people to try did not. Every page inherits this and overrides what it needs —
+   * `/u/[handle]` sets its own title and description, and the file-based opengraph-image
+   * convention supplies each route's image without being named here.
+   */
+  openGraph: {
+    type: "website",
+    siteName: "tokenchit",
+    title: "tokenchit — receipts for your robots",
+    description: DESCRIPTION,
+    url: SITE_URL,
+  },
+  twitter: {
+    // The wide format, because the image is a 1200x630 card whose figures are unreadable at
+    // the small square size the default `summary` gives it.
+    card: "summary_large_image",
+    title: "tokenchit — receipts for your robots",
+    description: DESCRIPTION,
+  },
 };
 
 export default function RootLayout({

--- a/apps/site/app/opengraph-image.tsx
+++ b/apps/site/app/opengraph-image.tsx
@@ -1,0 +1,123 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { ImageResponse } from "next/og";
+
+import { PRIMARY_COMMAND } from "@/lib/cli";
+
+export const runtime = "nodejs";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "tokenchit — receipts for your AI coding agents";
+
+/**
+ * The link preview for tokenchit itself.
+ *
+ * Until this existed, every paste of the bare domain — into Slack, a DM, a LinkedIn post —
+ * unfurled as a bare "Web Link" with no image and no description. The profile pages had a
+ * preview and the thing they invite people to try did not, which is backwards: a profile link
+ * is a receipt shown to people who already know what this is, and the domain is the invitation.
+ *
+ * Static. It says the same thing for everyone, so it is generated once at build rather than
+ * per request, and nothing here touches the database.
+ *
+ * Satori supports a flexbox subset: every element with more than one child needs an explicit
+ * `display: flex`, there is no grid, and CSS custom properties do not resolve — so the palette
+ * is written in hex rather than referencing the design tokens, as the profile image does.
+ */
+const INK = "#101010";
+const PAPER = "#FFFDF9";
+const LIME = "#C6FF3D";
+const DIM = "#8A8A82";
+
+/** Bundled rather than fetched, so a preview never depends on a font CDN being reachable. */
+const font = readFile(join(process.cwd(), "assets", "jetbrains-mono-700.ttf"));
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          width: "100%",
+          height: "100%",
+          background: PAPER,
+          fontFamily: "JetBrains Mono",
+          padding: 64,
+          border: `16px solid ${INK}`,
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div
+            style={{
+              display: "flex",
+              alignSelf: "flex-start",
+              background: LIME,
+              border: `5px solid ${INK}`,
+              padding: "10px 22px",
+              fontSize: 52,
+              fontWeight: 800,
+              color: INK,
+              letterSpacing: -1,
+            }}
+          >
+            tokenchit
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              marginTop: 40,
+              fontSize: 46,
+              fontWeight: 800,
+              color: INK,
+              letterSpacing: -1.5,
+              lineHeight: 1.25,
+            }}
+          >
+            Receipts for your AI coding agents.
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              marginTop: 22,
+              fontSize: 26,
+              color: DIM,
+              lineHeight: 1.5,
+              maxWidth: 900,
+            }}
+          >
+            Reads Claude Code, Codex and OpenCode logs on your own machine and renders a stat
+            card you commit to your repo — a file, not a badge you rent.
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div style={{ display: "flex", height: 5, background: INK, marginBottom: 28 }} />
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+            <div
+              style={{
+                display: "flex",
+                background: INK,
+                color: LIME,
+                padding: "14px 22px",
+                fontSize: 24,
+                fontWeight: 700,
+              }}
+            >
+              {PRIMARY_COMMAND}
+            </div>
+            <div style={{ display: "flex", fontSize: 24, color: DIM }}>tokenchit.app</div>
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [{ name: "JetBrains Mono", data: await font, weight: 700, style: "normal" }],
+    },
+  );
+}

--- a/apps/site/app/u/[handle]/opengraph-image.tsx
+++ b/apps/site/app/u/[handle]/opengraph-image.tsx
@@ -45,12 +45,30 @@ export default async function Image({ params }: { params: Promise<{ handle: stri
   const handle = sanitizeHandle(decodeURIComponent((await params).handle));
   const profile = await readProfile(handle).catch(() => null);
 
-  const tokens = profile ? formatTokens(profile.tokens) : "—";
-  const cost = profile && profile.equivCostUsd > 0 ? formatUsd(profile.equivCostUsd) : "—";
-  const streak = profile ? `${profile.streakDays}d` : "—";
+  /*
+   * A held row's figures do not travel, here either.
+   *
+   * `api/card/[handle]/route.ts` blanks the card for a submission held for review, on the
+   * grounds that the point of holding is that nothing about the row circulates until somebody
+   * has looked at it. This file rendered the same three numbers unconditionally — and this is
+   * the image that unfurls in Slack, on X and on LinkedIn, so it circulates further than the
+   * card does. The gate was half a gate.
+   *
+   * Held reads as absent rather than as flagged: the same em dashes a handle with nothing
+   * published gets. The board does not announce who is under review, and neither does an image
+   * somebody may be about to post.
+   */
+  const held = profile?.underReview === true;
+  const shown = held ? null : profile;
+
+  const tokens = shown ? formatTokens(shown.tokens) : "—";
+  const cost = shown && shown.equivCostUsd > 0 ? formatUsd(shown.equivCostUsd) : "—";
+  const streak = shown ? `${shown.streakDays}d` : "—";
+  // Tier is an identity fact rather than a figure, so it survives the hold, as it does on the
+  // card: what is withheld is the unexamined numbers, not who the person is.
   const verified = profile?.tier === "verified";
 
-  const mix = Object.entries(profile?.mix ?? {}).sort((a, b) => b[1] - a[1]);
+  const mix = Object.entries(shown?.mix ?? {}).sort((a, b) => b[1] - a[1]);
   const mixTotal = mix.reduce((a, [, n]) => a + n, 0) || 1;
 
   const stats: [string, string][] = [

--- a/apps/site/app/u/[handle]/page.tsx
+++ b/apps/site/app/u/[handle]/page.tsx
@@ -7,6 +7,8 @@ import { buildCardSvg, formatSynced, formatTokens, formatUsd, sanitizeHandle } f
 import { ContributionGraph } from "@/components/contribution-graph";
 import { CopyButton } from "@/components/copy-button";
 import { PageShell } from "@/components/page-shell";
+import { ShareRow } from "@/components/share-row";
+import { PRIMARY_COMMAND } from "@/lib/cli";
 import { isWindow, WINDOW_DAYS, WINDOWS, type BoardWindow } from "@/lib/board";
 import { cardFigures } from "@/lib/card-figures";
 import { readProfile } from "@/lib/profile";
@@ -28,7 +30,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   if (!profile) return { title: "Not found · tokenchit" };
 
-  const summary = `${formatTokens(profile.tokens)} tokens across ${profile.activeDays} active days`;
+  /* The same hold the card and the OG image apply. This string is the unfurl's body text, so
+     leaving it unguarded would have put the withheld figures into the Slack preview of a page
+     whose image had just been blanked — half a gate again, one line further down. */
+  const summary = profile.underReview
+    ? "Held for review"
+    : `${formatTokens(profile.tokens)} tokens across ${profile.activeDays} active days`;
   return {
     title: `@${profile.handle} · tokenchit`,
     description: summary,
@@ -102,6 +109,49 @@ export default async function ProfilePage({ params, searchParams }: Props) {
           )}
         </div>
       </header>
+
+      {/*
+        * The post, composed on the server.
+        *
+        * Server-side so every copy is identical, and so a held row's figures can be left out:
+        * the og:image and og:description are already blanked for one, and a share button
+        * handing the numbers over in plain text would be the third hole in the same gate.
+        *
+        * Third person throughout — "Card:", not "Mine:". This page has no session and cannot
+        * know whether the reader is the person it describes, so anything possessive is wrong
+        * half the time. Naming the handle reads correctly posted by its owner or by anybody
+        * else.
+        *
+        * Two links because they answer different questions: the profile is the receipt, the
+        * bare domain is the invitation. Roughly 275 characters as X counts them for a handle
+        * of ordinary length, which leaves the common case inside one post.
+        */}
+      <ShareRow
+        handle={profile.handle}
+        text={
+          profile.underReview
+            ? [
+                `@${profile.handle} on tokenchit.`,
+                ``,
+                `tokenchit reads your AI coding agent logs locally and renders a card you commit to your README. Set up in ~10s:`,
+                ``,
+                PRIMARY_COMMAND,
+                ``,
+                `Card: ${SITE_URL}/u/${profile.handle}`,
+                `Try it: ${SITE_URL}`,
+              ].join("\n")
+            : [
+                `@${profile.handle} · ${formatTokens(profile.tokens)} tokens · ${profile.activeDays} active days · ${profile.streakDays}-day streak`,
+                ``,
+                `tokenchit reads your AI coding agent logs locally and renders a card you commit to your README. Set up in ~10s:`,
+                ``,
+                PRIMARY_COMMAND,
+                ``,
+                `Card: ${SITE_URL}/u/${profile.handle}`,
+                `Try it: ${SITE_URL}`,
+              ].join("\n")
+        }
+      />
 
       <p className={styles.since}>
         {profile.firstDay ? `First activity ${profile.firstDay}.` : "No activity yet."}{" "}

--- a/apps/site/components/analytics.tsx
+++ b/apps/site/components/analytics.tsx
@@ -71,11 +71,38 @@ export function Analytics() {
     const query = searchParams.toString();
     const path = query ? `${pathname}?${query}` : pathname;
 
+    /*
+     * Where the visit came from, which nothing here has ever recorded.
+     *
+     * Every argument about where this project should put effort — a README backlink, an
+     * og:image, a share button — rests on a guess about how people arrive, and the guess has
+     * never been checked. One field turns it into a measurement.
+     *
+     * The origin only, never the full referring URL: the question is which surface sends
+     * people, and the path someone was reading when they clicked is not ours to collect on a
+     * site whose first claim is that it collects almost nothing.
+     *
+     * Empty on a direct visit, and empty on a client-side navigation within the site, where
+     * `document.referrer` is the page they came from here. Both are honestly "none".
+     */
+    let source = "";
+    try {
+      const ref = document.referrer;
+      if (ref) {
+        const url = new URL(ref);
+        if (url.host !== window.location.host) source = url.host;
+      }
+    } catch {
+      // An unparseable referrer is no referrer.
+    }
+
     void started.then((log) =>
       log?.("page_view", {
         page_path: path,
         page_location: window.location.href,
         page_title: document.title,
+        // "none" rather than absent, so a direct visit is countable instead of missing.
+        referrer_host: source || "none",
       }),
     );
   }, [pathname, searchParams]);

--- a/apps/site/components/hero.module.css
+++ b/apps/site/components/hero.module.css
@@ -82,22 +82,29 @@
   text-wrap: pretty;
 }
 
+/* Wide enough for the command it holds. At 440px the string overflowed its own box and
+   scrolled under the copy button with no gap, which reads as the button covering the last
+   word rather than as a scrollable field — the one thing on the page somebody has to be able
+   to read in full. Sized to the content plus the button, and it still scrolls below that. */
 .install {
   display: flex;
   align-items: stretch;
   border: 2px solid var(--ink);
   box-shadow: 6px 6px 0 var(--lime);
   background: var(--surface);
-  max-width: 440px;
+  max-width: 540px;
 }
 
 .command {
-  padding: 15px 14px;
+  /* Extra on the right so the text and its cursor never touch the button, whatever the
+     viewport does to the clamped size above. */
+  padding: 15px 20px 15px 14px;
   /* <code> would otherwise fall back to the browser's default monospace face. */
   font-family: inherit;
   font-size: clamp(12.5px, 1.2vw, 15px);
   font-weight: 500;
   flex: 1;
+  min-width: 0;
   white-space: nowrap;
   overflow: auto;
 }
@@ -157,23 +164,7 @@
   color: var(--text-dim);
 }
 
-.handleRow {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 14px;
-}
 
-.input {
-  flex: 1;
-  min-width: 90px;
-  padding: 8px 10px;
-  background: var(--surface);
-  border: 2px solid var(--ink);
-  font-size: 12.5px;
-  font-weight: 500;
-  outline: none;
-}
 
 .input:focus {
   box-shadow: 3px 3px 0 var(--yellow);

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -3,7 +3,6 @@
 import { CopyButton } from "./copy-button";
 import type { Featured } from "@/lib/featured";
 import { StatCard } from "./stat-card";
-import { useSiteState } from "./site-state";
 import styles from "./hero.module.css";
 import { PRIMARY_COMMAND } from "@/lib/cli";
 
@@ -12,7 +11,7 @@ import { PRIMARY_COMMAND } from "@/lib/cli";
 const INSTALL = PRIMARY_COMMAND;
 
 export function Hero({ preview }: { preview: Featured }) {
-  const { handle, setHandle } = useSiteState();
+
 
   return (
     <section className={styles.hero}>
@@ -58,16 +57,6 @@ export function Hero({ preview }: { preview: Featured }) {
         </div>
 
         <StatCard preview={preview} />
-
-        <div className={styles.handleRow}>
-          <span className={styles.label}>handle</span>
-          <input
-            className={styles.input}
-            value={handle}
-            onChange={(e) => setHandle(e.target.value)}
-            spellCheck={false}
-          />
-        </div>
       </div>
     </section>
   );

--- a/apps/site/components/share-row.module.css
+++ b/apps/site/components/share-row.module.css
@@ -1,0 +1,59 @@
+.row {
+  margin: 0 0 20px;
+}
+
+.line {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+/* The page's primary treatment — ink fill, lime shadow — the same weight the active window
+   filter and the board's call to action carry. One button can afford it; the four it replaced
+   could not, which is part of why they read as clutter under the handle. */
+.share {
+  padding: 9px 16px;
+  border: 2px solid var(--ink);
+  background: var(--ink);
+  color: var(--lime);
+  box-shadow: 3px 3px 0 var(--lime);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.share:hover {
+  background: var(--coral);
+  color: var(--surface);
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+/* Quiet, and beside the button rather than over the page. It reports something that already
+   worked; it does not need to be read to carry on. */
+.status {
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+}
+
+.fallback {
+  width: min(560px, 100%);
+  margin-top: 10px;
+  padding: 12px;
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  line-height: 1.6;
+  resize: vertical;
+}
+
+.fallback:focus {
+  outline: none;
+  box-shadow: 3px 3px 0 var(--lime);
+}

--- a/apps/site/components/share-row.tsx
+++ b/apps/site/components/share-row.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { track } from "@/components/analytics";
+import styles from "./share-row.module.css";
+
+/**
+ * One button: copy the post, then say so beside it.
+ *
+ * The obvious build is a row of platform buttons, and it cannot be done honestly. X takes
+ * prefilled text through its intent endpoint; LinkedIn takes a URL and nothing else, because
+ * the parameters that carried text were removed and the API that composes a post needs a
+ * member OAuth token a site with no browser session cannot hold; Instagram has no web post
+ * intent at all and strips links from captions. A row of four would work as advertised on one.
+ *
+ * Copying sidesteps that: the clipboard is the one interface every platform accepts, and the
+ * person is going to their app anyway.
+ *
+ * The confirmation is a line of text, not a dialog. A modal interrupts, dims the page, takes
+ * focus and demands to be dismissed — a lot of ceremony to report that eight lines reached the
+ * clipboard, and it lands in front of the reader at the moment they are trying to leave for
+ * another tab.
+ */
+export function ShareRow({
+  handle,
+  text,
+}: {
+  handle: string;
+  /** The whole post, links included, composed on the server so every copy is identical. */
+  text: string;
+}) {
+  const [state, setState] = useState<"idle" | "copied" | "failed">("idle");
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  const share = async () => {
+    let ok = true;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Insecure origin, denied permission, no clipboard API. Announcing success here would be
+      // the worst failure available: the person switches app, pastes, and gets whatever was on
+      // the clipboard before.
+      ok = false;
+    }
+    track("share", { surface: "copy", handle, ok });
+    setState(ok ? "copied" : "failed");
+
+    if (timer.current) clearTimeout(timer.current);
+    // The failure stays put: it carries the only copy of the text, and clearing it would take
+    // away the way through. Success fades, having nothing left to say.
+    if (ok) timer.current = setTimeout(() => setState("idle"), 4000);
+  };
+
+  return (
+    <div className={styles.row}>
+      <div className={styles.line}>
+        <button className={styles.share} type="button" onClick={share}>
+          share on your socials
+        </button>
+
+        {/* Announced politely rather than assertively: it is a confirmation, not an alert, and
+            it must not interrupt whatever a screen reader is in the middle of. */}
+        <span className={styles.status} role="status" aria-live="polite">
+          {state === "copied" && "copied — paste it on your socials"}
+          {state === "failed" && "your browser blocked the copy — take it from below"}
+        </span>
+      </div>
+
+      {/* Only on failure, and inline rather than over the page. The happy path needs no escape
+          hatch; this one has no other way through. */}
+      {state === "failed" && (
+        <textarea className={styles.fallback} readOnly value={text} rows={6} />
+      )}
+    </div>
+  );
+}

--- a/apps/site/lib/profile.ts
+++ b/apps/site/lib/profile.ts
@@ -119,7 +119,7 @@ export async function readProfile(
        */
       pool.query<{ rank: string; total: string }>(
         `WITH eligible AS (
-           SELECT u.id
+           SELECT u.id, u.tier
            FROM users u
            LEFT JOIN LATERAL (
              SELECT flagged FROM submissions
@@ -127,13 +127,25 @@ export async function readProfile(
            ) l ON true
            WHERE COALESCE(l.flagged, false) = false
          ), totals AS (
-           SELECT d.user_id, SUM(d.tokens) AS tokens
+           SELECT d.user_id, e.tier, SUM(d.tokens) AS tokens
            FROM user_days d
            JOIN eligible e ON e.id = d.user_id
            WHERE d.day >= CURRENT_DATE - $2::int
-           GROUP BY d.user_id
+           GROUP BY d.user_id, e.tier
          ), ranked AS (
-           SELECT user_id, RANK() OVER (ORDER BY tokens DESC) AS rank,
+           /*
+            * The board's ordering, exactly: tier first, then tokens. This ranked on tokens
+            * alone, so a verified row that the board places above an unverified one with more
+            * tokens was told a different number on its own page — two ranks for one person,
+            * from two queries that disagreed about what ranking means.
+            *
+            * ROW_NUMBER rather than RANK for the same reason. RANK gives ties the same
+            * position and then skips, so the profile could say "4 of 23" where the board's
+            * ROW_NUMBER counted 5. Ranking is a position in a list here, not a competition
+            * classification, and two people on identical totals still occupy two rows.
+            */
+           SELECT user_id,
+                  ROW_NUMBER() OVER (ORDER BY (tier = 'verified') DESC, tokens DESC) AS rank,
                   COUNT(*) OVER () AS total
            FROM totals
          )

--- a/packages/core/src/recap.ts
+++ b/packages/core/src/recap.ts
@@ -69,6 +69,41 @@ export function scaleOf(values: number[]): number[] {
  * Day totals come from the raw counts, never the quantised level. Quantising first collapses
  * several days onto the same figure, which reads as a rendering bug rather than a fact.
  */
+/**
+ * The longest unbroken run of active days inside a year.
+ *
+ * `stats.streakDays` is the *current* run — "consecutive local days with activity, ending
+ * today or yesterday", per aggregate.ts — and this tile has always been labelled
+ * `longestStreak`, rendered as STREAK on the recap card and printed by `tokenchit recap`. In a
+ * year in review the two are barely related: read it in January and the current run is a day
+ * or two, while the year's best might have been thirty in June. The field name was right and
+ * the value was wrong.
+ *
+ * Counted over the calendar year the recap is about, not over all of history, for the same
+ * reason: a run that ended in a previous year is not this year's achievement.
+ */
+function longestRun(byDay: Map<string, number>, year: number): number {
+  const days = [...byDay.entries()]
+    .filter(([day, tokens]) => tokens > 0 && day.startsWith(`${year}-`))
+    .map(([day]) => day)
+    .sort();
+
+  let best = 0;
+  let run = 0;
+  let previous: number | null = null;
+
+  for (const day of days) {
+    // Parsed as UTC noon: the keys are local YYYY-MM-DD, and midnight in a zone that shifts
+    // for daylight saving can land a day either side of itself.
+    const at = Date.parse(`${day}T12:00:00Z`);
+    run = previous !== null && at - previous === 86_400_000 ? run + 1 : 1;
+    if (run > best) best = run;
+    previous = at;
+  }
+
+  return best;
+}
+
 export function buildRecap(stats: Stats, opts: { year?: number; now?: Date } = {}): Recap {
   const year = opts.year ?? (opts.now ?? new Date()).getFullYear();
 
@@ -100,7 +135,7 @@ export function buildRecap(stats: Stats, opts: { year?: number; now?: Date } = {
       totalTokens: formatTokens(stats.tokens),
       equivCost: stats.pricedShare > 0 ? formatUsd(stats.equivCostUsd, true) : "—",
       topModel,
-      longestStreak: `${stats.streakDays}d`,
+      longestStreak: `${longestRun(stats.byDay, year)}d`,
     },
     rows,
     peak: peakWindow(stats.byHour),

--- a/packages/core/test/recap.test.js
+++ b/packages/core/test/recap.test.js
@@ -105,3 +105,40 @@ test("dark recaps swap the coldest ramp step so empty cells are not near-white",
   assert.ok(!dark.includes(RAMP[0]), "dark must not paint near-white cells");
   assert.ok(dark.includes("#1C1C18"));
 });
+
+test("the streak tile is the year's longest run, not the current one", async () => {
+  /*
+   * The tile has always been named `longestStreak` and rendered as STREAK on the card, and it
+   * was assigned `stats.streakDays` — which aggregate documents as "consecutive local days
+   * with activity, ending today or yesterday", the *current* run. In a year in review the two
+   * are barely related: a recap read in January reports a day or two while the year's best may
+   * have been thirty in June. The name was right and the value was wrong.
+   */
+  const day = (month, date, hour = 10) => ({
+    agent: "claude-code",
+    ts: new Date(2026, month - 1, date, hour, 0, 0),
+    model: "claude-opus-5",
+    input: 1000,
+    output: 0,
+    cacheWrite: 0,
+    cacheRead: 0,
+  });
+
+  const events = [];
+  for (let d = 1; d <= 5; d++) events.push(day(3, d)); //  5 days in March
+  for (let d = 10; d <= 21; d++) events.push(day(6, d)); // 12 days in June — the longest
+  for (let d = 24; d <= 25; d++) events.push(day(5, d)); //  2 days ending "now"
+
+  const now = new Date(2026, 4, 25, 18, 0, 0);
+  const stats = await aggregate(events, { now });
+
+  assert.equal(stats.streakDays, 2, "the current run is the two days ending today");
+  assert.equal(
+    buildRecap(stats, { year: 2026, now }).tiles.longestStreak,
+    "12d",
+    "but the tile reports June's run, which is what a year in review is about",
+  );
+
+  // A run belonging to another year is not this year's achievement.
+  assert.equal(buildRecap(stats, { year: 2025, now }).tiles.longestStreak, "0d");
+});


### PR DESCRIPTION
Four commits, each standing alone.

### Stop a held row's figures travelling in a link preview

`api/card/[handle]` blanks the card for a submission held for review — the point of holding is that nothing about the row circulates until somebody looks. The OG **image** rendered the three figures unconditionally, and the `og:description` put them in the unfurl's body text. The gate stopped the card and let the two surfaces that travel furthest through.

Held reads as absent, not flagged: the em dashes an empty handle gets.

### Record which surface sent the visit

`page_view` never captured a referrer. Every argument about where to spend effort — README backlink, link preview, share button — rests on a guess about how people arrive. One field makes it a measurement.

Origin only, never the full referring URL. Direct visits and same-origin navigation both record `"none"` so they stay countable.

### One share button

A row of platform buttons cannot be built honestly: **X** takes prefilled text, **LinkedIn** takes a URL and nothing else (the text parameters were removed; the composing API needs a member OAuth token a site with no session cannot hold), **Instagram** has no web post intent at all. Four buttons, one working as advertised.

So it copies the post and says so in a line beside the button — no dialog. If the browser refuses the clipboard, it says that instead and shows the text inline, because announcing a copy that did not happen is the worst available failure.

Post is composed server-side, third person (the page has no session and cannot know who is reading), two links, ~275 chars as X counts them, no dollar figure.

### Give the site and the board a link preview

`layout.tsx` had no `openGraph` or `twitter` block, and neither `/` nor `/board` had an image — so every paste of the bare domain unfurled as a bare "Web Link". Backwards: the profile is a receipt for people who already know what this is, the domain is the invitation.

The board's preview reads live totals from the same query the page uses. Hourly revalidation; platforms cache unfurls far longer. 1200×630 PNG — SVG is not an option, which is why the profile image already was one.

---

91 tests, lint and build clean. Verified locally against Postgres: held vs clean profiles, all three OG images rendering as valid PNGs.

**After deploy:** LinkedIn and X cache unfurls. Re-scrape `tokenchit.app` and `/board` through `linkedin.com/post-inspector` and X's card validator, or they will keep serving the empty result they already have.