### PR TITLE
Release v0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,7 +8199,7 @@
     },
     "packages/cli": {
       "name": "@tokenchit/cli",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "bin": {
         "tokenchit": "dist/index.js"
@@ -8250,7 +8250,7 @@
     },
     "packages/core": {
       "name": "@tokenchit/core",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Read your local AI coding agent logs and render a stat card into your repo.",
   "keywords": [
     "tokens",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenchit/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Internal engine for @tokenchit/cli: agent-log adapters, aggregation and the SVG builders. Not published; bundled into the CLI.",
   "license": "MIT",


### PR DESCRIPTION
Bumps `@tokenchit/cli` and `@tokenchit/core` to **0.6.1**.

**Merging this publishes to npm.** The release workflow publishes whenever the version field names something npm does not have, then tags `v0.6.1`.

### Why patch

One mislabelled value, no new behaviour.

The recap's streak tile is named `longestStreak`, renders as STREAK on the recap card and in `tokenchit recap`, and was assigned `stats.streakDays` — documented as *"consecutive local days with activity, ending today or yesterday"*, i.e. the **current** run. In a year in review the two are barely related: read it in January and it reports the day or two since the new year, while the year's best might have been thirty in June.

It now counts the longest unbroken run inside the year the recap covers. A run that ended in a previous year is not reported as this year's.

### Why this is the only CLI-facing change

Everything else merged since 0.6.0 (#61) is the website, which ships on deploy rather than through npm — link previews for the landing page and the board, the profile share button, held rows kept out of those previews, a profile rank that agrees with the board's, and a hero that fits its own install command.

That fix lives in `packages/core`, so it only reaches users on a version bump. Hence this.

---

65 core tests (one new, covering a 12-day run in June against a 2-day current run), 23 CLI, 4 site. Lint and build clean.