### PR TITLE
Add a GitHub Action, an MCP server, and a page per agent

### DIFF
--- a/.github/workflows/card.yml
+++ b/.github/workflows/card.yml
@@ -1,0 +1,33 @@
+# Keeps this repository's own tokenchit.svg fresh, and doubles as the live proof that the
+# action at the repo root works. If this workflow is red, the Marketplace listing is lying.
+#
+# It refreshes a card that `tokenchit publish` has already put on the board — the runner
+# cannot see local logs, so publishing still happens from a real machine.
+name: card
+
+on:
+  schedule:
+    # 06:00 UTC daily. The endpoint caches for four hours, so anything more frequent just
+    # re-fetches the same bytes and produces no commit.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+# Only one refresh at a time: two overlapping runs would race on the same push.
+concurrency:
+  group: card
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./
+        with:
+          handle: iyashjayesh
+          output: tokenchit.svg
+          commit-message: "chore: refresh tokenchit card"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,19 +43,30 @@ jobs:
       # The whole gate. `npm view` answers for the registry rather than for this checkout,
       # so a re-run, a revert or a second trigger for the same version all stop here instead
       # of failing loudly over work that is already done.
+      #
+      # Asked per package. The two are versioned together by scripts/version.mjs, but a run
+      # that publishes one and fails on the other must be able to finish the job on a re-run
+      # rather than seeing "cli is already up" and skipping the half that never went out.
       - name: Is this version unpublished?
         id: check
         run: |
           version=$(node -p "require('./packages/cli/package.json').version")
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-          if npm view "@tokenchit/cli@$version" version >/dev/null 2>&1; then
-            echo "@tokenchit/cli@$version is already on npm — nothing to release."
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "@tokenchit/cli@$version is not on npm — releasing."
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-          fi
+          any=false
+          for pkg in cli mcp; do
+            pv=$(node -p "require('./packages/$pkg/package.json').version")
+            if npm view "@tokenchit/$pkg@$pv" version >/dev/null 2>&1; then
+              echo "@tokenchit/$pkg@$pv is already on npm — skipping it."
+              echo "$pkg=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "@tokenchit/$pkg@$pv is not on npm — releasing it."
+              echo "$pkg=true" >> "$GITHUB_OUTPUT"
+              any=true
+            fi
+          done
+
+          echo "publish=$any" >> "$GITHUB_OUTPUT"
 
       # npm provenance attaches a signed attestation pointing at the source commit, which
       # requires a public repository. Publishing --provenance from a private repo fails with
@@ -94,11 +105,18 @@ jobs:
           git tag -a "$tag" -m "$tag"
           git push origin "$tag"
 
-      # One package. @tokenchit/core is private and bundled into this tarball by esbuild,
-      # so there is nothing to publish first and no ordering to get wrong.
+      # @tokenchit/core is private and esbuild inlines it into both tarballs, so there is
+      # nothing to publish first and no ordering to get wrong. Neither package declares a
+      # runtime dependency on the other.
       - name: Publish @tokenchit/cli
-        if: steps.check.outputs.publish == 'true'
+        if: steps.check.outputs.cli == 'true'
         run: npm publish -w @tokenchit/cli --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @tokenchit/mcp
+        if: steps.check.outputs.mcp == 'true'
+        run: npm publish -w @tokenchit/mcp --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -112,7 +130,12 @@ jobs:
             echo "npx @tokenchit/cli@${{ steps.check.outputs.version }} init"
             echo '```'
             echo
-            echo "- [@tokenchit/cli](https://www.npmjs.com/package/@tokenchit/cli)"
+            if [ "${{ steps.check.outputs.cli }}" = "true" ]; then
+              echo "- [@tokenchit/cli](https://www.npmjs.com/package/@tokenchit/cli)"
+            fi
+            if [ "${{ steps.check.outputs.mcp }}" = "true" ]; then
+              echo "- [@tokenchit/mcp](https://www.npmjs.com/package/@tokenchit/mcp)"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Nothing to release

--- a/README.md
+++ b/README.md
@@ -139,6 +139,35 @@ activity, and a run that finds an unchanged card makes no commit. On a quiet rep
 schedule can switch itself off. `workflow_dispatch` is there so you can start it again, and
 the run summary says which happened.
 
+## From an agent, not a terminal
+
+There is an MCP server in `packages/mcp`, so a model can answer questions about your usage
+instead of you reading a table:
+
+```json
+{
+  "mcpServers": {
+    "tokenchit": { "command": "npx", "args": ["-y", "@tokenchit/mcp@latest"] }
+  }
+}
+```
+
+Four tools — `get_usage`, `get_daily_usage`, `get_recap` and `detect_agents`. All of them
+read the same logs the CLI reads, and **none of them can make a network request**: the
+`net.isolated` test covers `packages/mcp/src` alongside the CLI, and unlike the CLI this
+package has no allowlisted module, so every file under it must be clean. Adding a `fetch`
+anywhere in it fails the suite.
+
+Two things it does that a plain data dump would not. Every figure ships with its caveat as a
+sibling field, because a model handed `equivCostUsd` on its own will report it to you as
+money you spent — and it is not. And a tool that fails answers with `isError` rather than a
+transport error, so "no logs on this machine" reaches the model as something it can relay
+instead of something it has to guess at.
+
+It reads the ledger and never writes it. `sync` banks what it saw because you asked it to; a
+tool call is a question, and a question that mutates state on disk is a surprise you cannot
+see or undo.
+
 ## Privacy
 
 `sync` and `recap` make no network request at all.
@@ -148,7 +177,8 @@ model names, and your handle — never prompts, replies, file paths, branch name
 names. `--dry-run` prints the exact bytes so you can check rather than take our word.
 
 Five tests in `packages/cli/test/privacy.test.js` enforce this on every push, including one
-that fails if any file outside `net.ts` can open a socket.
+that fails if any file outside `net.ts` can open a socket — across the CLI, the core engine
+and the MCP server.
 
 ## The board
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,52 @@ tokenchit whoami         who this machine is signed in as
 Common flags: `--out`, `--theme auto|light|dark`, `--layout default|compact`, `--json`,
 `--dry-run`.
 
+## Keeping the card fresh
+
+The card is a file, which is the point — and a file does not update itself. Re-running
+`generate` is the honest answer, but nobody remembers to.
+
+There is an action in this repository for the half a runner can actually do:
+
+```yaml
+# .github/workflows/card.yml
+name: card
+on:
+  schedule: [{ cron: "0 6 * * *" }]
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: iyashjayesh/tokenchit@v1
+        with:
+          handle: your-handle
+```
+
+**It does not read your logs, and it cannot.** An Actions runner has no access to
+`~/.claude` or `~/.codex`, so nothing on a runner can regenerate a card from source — you
+still run `publish` from the machine that has the logs. What the action does is re-fetch the
+card you already published and commit it, so the SVG in your README stops drifting away from
+your real numbers while readers keep loading a committed file rather than an endpoint.
+
+It refuses to overwrite a good card with a bad response: a non-SVG body, a non-200, or the
+placeholder card the endpoint returns for a handle with nothing on the board. That last one
+matters — without it a typo in `handle` commits an empty card on a schedule, silently,
+forever.
+
+Inputs are `handle` (required), `output`, `layout`, `theme`, `agents`, `hide`, `commit` and
+`commit-message`; `layout`, `theme`, `agents` and `hide` are the same options the embed
+endpoint takes. It outputs `changed` so you can gate later steps on a real update.
+
+One thing to know: GitHub disables scheduled workflows in a repository after 60 days with no
+activity, and a run that finds an unchanged card makes no commit. On a quiet repository the
+schedule can switch itself off. `workflow_dispatch` is there so you can start it again, and
+the run summary says which happened.
+
 ## Privacy
 
 `sync` and `recap` make no network request at all.

--- a/action.yml
+++ b/action.yml
@@ -70,10 +70,36 @@ runs:
       run: |
         set -euo pipefail
 
-        # Reject a handle that could escape the path or the URL before it reaches either.
-        if ! printf '%s' "$TC_HANDLE" | grep -qE '^[A-Za-z0-9][A-Za-z0-9-]{0,38}$'; then
-          echo "::error::'$TC_HANDLE' is not a valid GitHub handle."
-          exit 1
+        # Every input is checked before it reaches a path or a URL. `handle` was the only one
+        # guarded at first, which left the input that is *actually* a path unvalidated, and let
+        # the four query values through raw — where an `&` or `#` silently rewrites the request
+        # rather than failing. These are all closed sets, so validating beats escaping: a typo
+        # gets an error naming the field instead of a card that quietly ignores the option.
+        die() { echo "::error::$1"; exit 1; }
+
+        printf '%s' "$TC_HANDLE" | grep -qE '^[A-Za-z0-9][A-Za-z0-9-]{0,38}$' \
+          || die "'$TC_HANDLE' is not a valid GitHub handle."
+
+        # Relative, inside the workspace, no traversal. `output` is written to and committed,
+        # so `../../x.svg` would write outside the checkout.
+        case "$TC_OUT" in
+          "" ) die "output must not be empty." ;;
+          /* ) die "output must be a relative path, not '$TC_OUT'." ;;
+          *..* ) die "output must not contain '..' — got '$TC_OUT'." ;;
+        esac
+
+        printf '%s' "$TC_LAYOUT" | grep -qE '^(default|compact)$' \
+          || die "layout must be 'default' or 'compact', not '$TC_LAYOUT'."
+        printf '%s' "$TC_THEME" | grep -qE '^(auto|light|dark)$' \
+          || die "theme must be 'auto', 'light' or 'dark', not '$TC_THEME'."
+
+        if [ -n "$TC_AGENTS" ]; then
+          printf '%s' "$TC_AGENTS" | grep -qE '^[a-z][a-z-]*(,[a-z][a-z-]*)*$' \
+            || die "agents must be a comma-separated list of agent ids, not '$TC_AGENTS'."
+        fi
+        if [ -n "$TC_HIDE" ]; then
+          printf '%s' "$TC_HIDE" | grep -qE '^(spend|streak|mix)(,(spend|streak|mix))*$' \
+            || die "hide must be a comma-separated subset of spend,streak,mix — got '$TC_HIDE'."
         fi
 
         query="layout=${TC_LAYOUT}&theme=${TC_THEME}"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,140 @@
+# Marketplace requires action.yml at the repository root, so this sits beside the monorepo
+# rather than under packages/. It is a composite action: no Docker image to build, no
+# JavaScript bundle to keep in sync with the CLI, and nothing to publish separately.
+#
+# What it does NOT do, deliberately: read your logs. An Actions runner has no access to
+# ~/.claude or ~/.codex, so there is no version of this that regenerates the card from
+# source. The CLI does that on your machine. This refreshes the committed copy of a card
+# you have already published, which is the half of the problem a runner can actually solve.
+name: tokenchit card
+description: Refresh your committed tokenchit card so the SVG in your README never goes stale.
+author: Yash Chauhan
+
+branding:
+  icon: activity
+  color: green
+
+inputs:
+  handle:
+    description: GitHub handle whose published card to fetch. Must have run `tokenchit publish` at least once.
+    required: true
+  output:
+    description: Path to write the SVG to, relative to the repository root.
+    required: false
+    default: tokenchit.svg
+  layout:
+    description: default (495px) or compact (340px).
+    required: false
+    default: default
+  theme:
+    description: auto follows GitHub dark mode; light or dark force one.
+    required: false
+    default: auto
+  agents:
+    description: Comma-separated allowlist, e.g. "claude-code,codex". Empty means all.
+    required: false
+    default: ""
+  hide:
+    description: Comma-separated fields to drop from the card - any of spend, streak, mix.
+    required: false
+    default: ""
+  commit:
+    description: Commit and push the card when it changed. Set false to leave it in the working tree.
+    required: false
+    default: "true"
+  commit-message:
+    description: Commit message used when the card changed.
+    required: false
+    default: "chore: refresh tokenchit card"
+
+outputs:
+  changed:
+    description: "true when the fetched card differed from the committed one."
+    value: ${{ steps.fetch.outputs.changed }}
+  path:
+    description: Path the card was written to.
+    value: ${{ steps.fetch.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - id: fetch
+      shell: bash
+      env:
+        TC_HANDLE: ${{ inputs.handle }}
+        TC_OUT: ${{ inputs.output }}
+        TC_LAYOUT: ${{ inputs.layout }}
+        TC_THEME: ${{ inputs.theme }}
+        TC_AGENTS: ${{ inputs.agents }}
+        TC_HIDE: ${{ inputs.hide }}
+      run: |
+        set -euo pipefail
+
+        # Reject a handle that could escape the path or the URL before it reaches either.
+        if ! printf '%s' "$TC_HANDLE" | grep -qE '^[A-Za-z0-9][A-Za-z0-9-]{0,38}$'; then
+          echo "::error::'$TC_HANDLE' is not a valid GitHub handle."
+          exit 1
+        fi
+
+        query="layout=${TC_LAYOUT}&theme=${TC_THEME}"
+        [ -n "$TC_AGENTS" ] && query="${query}&agents=${TC_AGENTS}"
+        [ -n "$TC_HIDE" ] && query="${query}&hide=${TC_HIDE}"
+        url="https://tokenchit.app/api/card/${TC_HANDLE}.svg?${query}"
+
+        tmp="$(mktemp)"
+        code="$(curl -sS -L --max-time 30 --retry 3 --retry-delay 2 \
+                     -o "$tmp" -w '%{http_code}' "$url" || echo 000)"
+
+        if [ "$code" != "200" ]; then
+          echo "::error::tokenchit.app returned HTTP $code for @${TC_HANDLE}."
+          exit 1
+        fi
+
+        if ! head -c 400 "$tmp" | grep -qi '<svg'; then
+          echo "::error::Response was not an SVG. Refusing to overwrite ${TC_OUT}."
+          exit 1
+        fi
+
+        # The endpoint renders a placeholder card rather than 404ing for a handle with
+        # nothing on the board, so HTTP 200 is not proof of a real card. Without this check
+        # a typo in `handle` commits an empty card on a schedule, forever, silently. The
+        # placeholder is identified by the string it prints, not by its size: a compact card
+        # with everything hidden is 6KB and a size threshold between the two would be a guess.
+        if grep -q 'NOT PUBLISHED YET' "$tmp"; then
+          echo "::error::@${TC_HANDLE} has nothing on the board, so the endpoint returned an empty card."
+          echo "::error::Run \`tokenchit publish\` on the machine with your logs first, and check the handle is spelt right."
+          exit 1
+        fi
+
+        mkdir -p "$(dirname "$TC_OUT")"
+
+        if [ -f "$TC_OUT" ] && cmp -s "$tmp" "$TC_OUT"; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "Card is unchanged."
+        else
+          mv "$tmp" "$TC_OUT"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "Card updated at ${TC_OUT}."
+        fi
+        echo "path=${TC_OUT}" >> "$GITHUB_OUTPUT"
+
+    - if: inputs.commit == 'true' && steps.fetch.outputs.changed == 'true'
+      shell: bash
+      env:
+        TC_OUT: ${{ inputs.output }}
+        TC_MSG: ${{ inputs.commit-message }}
+      run: |
+        set -euo pipefail
+        git config user.name  "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -- "$TC_OUT"
+
+        # `git add` can still stage nothing when the path is gitignored, and an empty commit
+        # would push a message with no change behind it. Check the index, not the file.
+        if git diff --cached --quiet; then
+          echo "::warning::${TC_OUT} changed on disk but staged nothing - is it gitignored?"
+          exit 0
+        fi
+
+        git commit -m "$TC_MSG"
+        git push

--- a/apps/site/app/board/page.tsx
+++ b/apps/site/app/board/page.tsx
@@ -41,6 +41,9 @@ export const metadata: Metadata = {
     description: BOARD_DESCRIPTION,
     path: "/board",
   }),
+  /* The window and agent filters are query parameters on this same path, so without a
+     canonical every combination is a separate URL advertising the same page. */
+  alternates: { canonical: "/board" },
 };
 
 /** Gold, silver, bronze. Only the top three; everyone else takes the default fill. */

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+
 import { SiteHeader } from "@/components/site-header";
 import { Hero } from "@/components/hero";
 import { CardSection } from "@/components/card-section";
@@ -27,6 +29,10 @@ import { SiteFooter } from "@/components/site-footer";
  * and the copy promises a row goes stale "within the hour", so five minutes is comfortably
  * inside what was advertised while keeping the marketing page effectively static.
  */
+/* Title, description and openGraph come from the root layout; only the canonical is stated
+   here, because the layout cannot name a path that is right for every route beneath it. */
+export const metadata: Metadata = { alternates: { canonical: "/" } };
+
 export const revalidate = 300;
 
 export default async function Page() {

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -10,6 +10,7 @@ import { readFeatured } from "@/lib/featured";
 import { Verification } from "@/components/verification";
 import { Privacy } from "@/components/privacy";
 import { Recap } from "@/components/recap";
+import { ClosingCta } from "@/components/closing-cta";
 import { SiteFooter } from "@/components/site-footer";
 
 /**
@@ -62,6 +63,8 @@ export default async function Page() {
         <Verification />
         <Privacy />
         <Recap />
+        {/* The command appeared once, in the hero, five sections above this. */}
+        <ClosingCta />
       </main>
       <SiteFooter />
     </>

--- a/apps/site/app/sitemap.ts
+++ b/apps/site/app/sitemap.ts
@@ -1,11 +1,12 @@
 import type { MetadataRoute } from "next";
 
+import { AGENT_PAGES } from "@/lib/agents";
 import { readBoard } from "@/lib/board-query";
 import { DEFAULT_WINDOW } from "@/lib/board";
 import { SITE_URL } from "@/lib/site";
 
 /**
- * The two static pages, plus every profile currently on the board.
+ * The static pages, plus one page per supported agent, plus every profile on the board.
  *
  * Built from `readBoard` rather than a `listHandles` helper, because the board query already
  * excludes rows held for review — a flagged profile withholds its figures, and pointing a
@@ -22,6 +23,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return [
     { url: SITE_URL, changeFrequency: "weekly", priority: 1 },
     { url: `${SITE_URL}/board`, changeFrequency: "daily", priority: 0.8 },
+    /* Ranked above profiles and below the board: these are the pages someone searching for
+       "claude code token usage" should land on, and there are three of them rather than
+       thirty-four. */
+    ...AGENT_PAGES.map((a) => ({
+      url: `${SITE_URL}/tool/${a.key}`,
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    })),
     ...rows.map((r) => ({
       url: `${SITE_URL}/u/${r.handle}`,
       lastModified: r.lastPublished ? new Date(r.lastPublished) : undefined,

--- a/apps/site/app/tool/[agent]/page.tsx
+++ b/apps/site/app/tool/[agent]/page.tsx
@@ -1,0 +1,233 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { agentColour, formatTokens, formatUsd } from "@tokenchit/core";
+
+import { PageShell } from "@/components/page-shell";
+import { SectionHeading } from "@/components/section-heading";
+import { CopyButton } from "@/components/copy-button";
+import { AGENT_PAGES, agentPage, codeSpans, UNSUPPORTED } from "@/lib/agents";
+import { readBoard } from "@/lib/board-query";
+import { cmd, PRIMARY_COMMAND } from "@/lib/cli";
+import { openGraphFor } from "@/lib/site";
+
+import styles from "./tool.module.css";
+
+/* Long enough that a crawler and a reader see the same figures, short enough that a new
+   publisher shows up the same day. The board itself revalidates at 300s; this page is a
+   landing page rather than a live ranking, so it does not need to keep pace with it. */
+export const revalidate = 3600;
+
+/** The three routes are known at build time, so all three prerender. */
+export function generateStaticParams() {
+  return AGENT_PAGES.map((a) => ({ agent: a.key }));
+}
+
+/* Anything outside the three is a 404 rather than a rendered-on-demand page: the set is
+   closed, and an invented `/tool/anything` would be a crawlable page about a tool that does
+   not exist. */
+export const dynamicParams = false;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ agent: string }>;
+}): Promise<Metadata> {
+  const { agent } = await params;
+  const page = agentPage(agent);
+  if (!page) return {};
+
+  const title = `${page.name} token usage · tokenchit`;
+  const description =
+    `Read your local ${page.name} logs and render your token usage as an SVG card you ` +
+    `commit to your repo. No account, no upload, and no hosted badge to depend on.`;
+
+  return {
+    title,
+    description,
+    openGraph: openGraphFor({ title, description, path: `/tool/${page.key}` }),
+    alternates: { canonical: `/tool/${page.key}` },
+  };
+}
+
+/** Renders `backticked` spans in the agent content as code. */
+function Prose({ text, className }: { text: string; className?: string }) {
+  return (
+    <p className={className}>
+      {codeSpans(text).map((part, i) =>
+        part.code ? <code key={i}>{part.value}</code> : <span key={i}>{part.value}</span>,
+      )}
+    </p>
+  );
+}
+
+export default async function ToolPage({
+  params,
+}: {
+  params: Promise<{ agent: string }>;
+}) {
+  const { agent } = await params;
+  const page = agentPage(agent);
+  if (!page) notFound();
+
+  /* Ranked by this agent's tokens only. `readBoard` applies the filter to every aggregate
+     that feeds a row, so the figures below are this agent's usage rather than each
+     developer's combined total next to this agent's rank. */
+  const rows = await readBoard("year", 10, 0, page.key).catch(() => []);
+  const ranked = rows.filter((r) => r.tokens > 0);
+  const others = AGENT_PAGES.filter((a) => a.key !== page.key);
+  const syncCommand = cmd("sync");
+
+  return (
+    <PageShell crumbs={[{ href: `/tool/${page.key}`, label: page.label }]}>
+      <header className={styles.hero}>
+        <p className={styles.eyebrow}>Supported agent</p>
+        <h1 className={styles.h1}>
+          Your <span className={styles.mark}>{page.name}</span> usage, as a file in your repo.
+        </h1>
+        <p className={styles.lede}>
+          tokenchit reads the {page.name} logs already on your machine and renders one
+          embeddable card straight into your repository. The card is a file you commit, not a
+          URL you depend on — nothing to rate-limit, nothing to go down.
+        </p>
+
+        <div className={styles.cmdRow}>
+          <code className={styles.cmd}>
+            <span className={styles.prompt}>$</span> {PRIMARY_COMMAND}
+          </code>
+          <CopyButton value={PRIMARY_COMMAND} variant="lime" event="tool-page-command" />
+        </div>
+        <p className={styles.free}>
+          Free and MIT. No account is needed to read your own numbers — publishing to the
+          board is a separate, opt-in command.
+        </p>
+      </header>
+
+      <section className={styles.section}>
+        <SectionHeading n={1} title="What it reads" />
+        <Prose text={page.what} className={styles.body} />
+        <div className={styles.source}>
+          <span className={styles.sourceLabel}>Source</span>
+          <code className={styles.sourcePath}>{page.source}</code>
+        </div>
+        <p className={styles.note}>
+          Nothing else is read, and nothing is sent. <code>{syncCommand}</code> and{" "}
+          <code>{cmd("recap")}</code> make no network request at all; five tests in the repo
+          fail on every push if that stops being true.
+        </p>
+      </section>
+
+      <section className={styles.section}>
+        <SectionHeading n={2} title="What it cannot tell you" tone="coral" />
+        <div className={styles.caveat}>
+          <h3 className={styles.caveatHeading}>{page.caveat.heading}</h3>
+          <Prose text={page.caveat.body} className={styles.body} />
+        </div>
+        <p className={styles.note}>
+          Equivalent cost is not what you paid either. It is what these tokens would cost at
+          list API rates, and most agent usage runs under a subscription where no per-token
+          charge ever happens.
+        </p>
+      </section>
+
+      {ranked.length > 0 && (
+        <section className={styles.section}>
+          <SectionHeading n={3} title={`On the board, by ${page.label}`} />
+          <p className={styles.body}>
+            Developers who chose to publish, ranked by {page.label} tokens over the last year.
+            Figures are self-reported and bounded for plausibility, not audited.
+          </p>
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th scope="col">Rank</th>
+                  <th scope="col">Developer</th>
+                  <th scope="col" className={styles.num}>
+                    {page.label} tokens
+                  </th>
+                  <th scope="col" className={styles.num}>
+                    Equiv. cost
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {ranked.map((r, i) => (
+                  <tr key={r.handle}>
+                    <td className={styles.rank}>{i + 1}</td>
+                    <td>
+                      <Link href={`/u/${r.handle}`} className={styles.handle}>
+                        <span
+                          className={styles.dot}
+                          style={{ background: agentColour(page.key) }}
+                          aria-hidden="true"
+                        />
+                        @{r.handle}
+                      </Link>
+                    </td>
+                    <td className={styles.num}>{formatTokens(r.tokens)}</td>
+                    <td className={styles.num}>{formatUsd(r.equivCostUsd)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <Link href="/board" className={styles.more}>
+            See the full board →
+          </Link>
+        </section>
+      )}
+
+      <section className={styles.section}>
+        <SectionHeading n={ranked.length > 0 ? 4 : 3} title="The other agents" />
+        <p className={styles.body}>
+          One command covers all of them at once, and the card shows the mix.
+        </p>
+        <ul className={styles.others}>
+          {others.map((a) => (
+            <li key={a.key}>
+              <Link href={`/tool/${a.key}`} className={styles.otherLink}>
+                <span
+                  className={styles.dot}
+                  style={{ background: agentColour(a.key) }}
+                  aria-hidden="true"
+                />
+                {a.name}
+                <code className={styles.otherPath}>{a.source}</code>
+              </Link>
+            </li>
+          ))}
+        </ul>
+        <p className={styles.note}>
+          Detected and deliberately unsupported:{" "}
+          {UNSUPPORTED.map((u, i) => (
+            <span key={u.name}>
+              {i > 0 && " "}
+              <strong>{u.name}</strong> {u.reason}
+            </span>
+          ))}
+        </p>
+      </section>
+
+      <section className={styles.cta}>
+        <h2 className={styles.ctaHeading}>Read your own numbers</h2>
+        <p className={styles.body}>
+          One command. It finds your agents, shows your stats and writes the card. Publishing
+          is a separate step you have to ask for.
+        </p>
+        <div className={styles.cmdRow}>
+          <code className={styles.cmd}>
+            <span className={styles.prompt}>$</span> {PRIMARY_COMMAND}
+          </code>
+          <CopyButton value={PRIMARY_COMMAND} variant="lime" event="tool-page-command" />
+        </div>
+        <p className={styles.note}>
+          Or <code>{syncCommand}</code> on its own to see the figures without writing
+          anything. Source at{" "}
+          <a href="https://github.com/iyashjayesh/tokenchit">github.com/iyashjayesh/tokenchit</a>.
+        </p>
+      </section>
+    </PageShell>
+  );
+}

--- a/apps/site/app/tool/[agent]/tool.module.css
+++ b/apps/site/app/tool/[agent]/tool.module.css
@@ -1,0 +1,341 @@
+/* The landing-page vocabulary, reused: 2px ink rules, hard offset shadows, 9-12px uppercase
+   mono for labels, and the display face only at heading sizes. Nothing new is invented here —
+   a per-agent page that looked like a different site would read as a doorway page. */
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding-block: 40px 44px;
+  border-bottom: 2px solid var(--ink);
+}
+
+.eyebrow {
+  margin: 0;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.h1 {
+  margin: 0;
+  font-family: var(--font-display), system-ui, sans-serif;
+  font-size: clamp(2rem, 5.2vw, 3.4rem);
+  font-weight: 800;
+  line-height: 1.03;
+  letter-spacing: -0.03em;
+  color: var(--ink);
+  text-wrap: balance;
+  max-width: 22ch;
+}
+
+.mark {
+  background: var(--lime);
+  box-shadow: 0 0 0 6px var(--lime);
+  /* Without this the highlight breaks flush against the glyphs on a wrap. */
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+.lede {
+  margin: 0;
+  max-width: 58ch;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.cmdRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 0;
+  max-width: 100%;
+}
+
+.cmd {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  padding: 14px 16px;
+  border: 2px solid var(--ink);
+  background: var(--surface);
+  box-shadow: 5px 5px 0 var(--lime);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 13px;
+  white-space: nowrap;
+  color: var(--ink);
+}
+
+.prompt {
+  color: var(--text-faint);
+  margin-right: 6px;
+}
+
+.free {
+  margin: 0;
+  max-width: 58ch;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 11px;
+  line-height: 1.6;
+  color: var(--text-dim);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-block: 44px;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.body {
+  margin: 0;
+  max-width: 62ch;
+  font-size: 14.5px;
+  line-height: 1.65;
+  color: var(--text-muted);
+}
+
+.note {
+  margin: 0;
+  max-width: 62ch;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--text-dim);
+}
+
+.note code,
+.body code {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.9em;
+  background: var(--surface-alt);
+  border: 1px solid var(--hairline);
+  padding: 1px 5px;
+}
+
+.note a {
+  color: var(--ink);
+  text-underline-offset: 3px;
+}
+
+.source {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0;
+  border: 2px solid var(--ink);
+  background: var(--surface);
+}
+
+.sourceLabel {
+  flex: none;
+  padding: 11px 14px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+}
+
+.sourcePath {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  padding: 11px 14px;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 12.5px;
+  white-space: nowrap;
+  color: var(--ink);
+}
+
+.caveat {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px 22px;
+  border: 2px solid var(--ink);
+  border-left: 8px solid var(--coral);
+  background: var(--surface);
+}
+
+.caveatHeading {
+  margin: 0;
+  font-family: var(--font-display), system-ui, sans-serif;
+  font-size: 17px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+  color: var(--ink);
+}
+
+.tableWrap {
+  overflow-x: auto;
+  border: 2px solid var(--ink);
+  background: var(--surface);
+  box-shadow: 6px 6px 0 var(--hairline);
+}
+
+.table {
+  width: 100%;
+  min-width: 520px;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.table th {
+  padding: 11px 16px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.table td {
+  padding: 11px 16px;
+  border-bottom: 1px solid var(--hairline);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  color: var(--text-muted);
+  vertical-align: middle;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  color: var(--ink);
+}
+
+.rank {
+  width: 1%;
+  color: var(--text-faint);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.handle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ink);
+  font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.handle:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  flex: none;
+  border: 1px solid var(--ink);
+}
+
+.more,
+.otherLink {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink);
+  text-underline-offset: 3px;
+}
+
+.others {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0;
+  border: 2px solid var(--ink);
+  background: var(--surface);
+}
+
+.others li {
+  border-right: 1px solid var(--hairline);
+}
+
+.others li:last-child {
+  border-right: 0;
+}
+
+.otherLink {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 16px 18px;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 14px;
+  text-decoration: none;
+}
+
+.otherLink:hover {
+  background: var(--surface-alt);
+}
+
+.otherPath {
+  font-size: 10.5px;
+  font-weight: 400;
+  color: var(--text-dim);
+  overflow-wrap: anywhere;
+}
+
+.cta {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 28px 26px;
+  margin-block: 44px 0;
+  border: 2px solid var(--ink);
+  background: var(--surface-alt);
+  box-shadow: 8px 8px 0 var(--ink);
+}
+
+.ctaHeading {
+  margin: 0;
+  font-family: var(--font-display), system-ui, sans-serif;
+  font-size: clamp(1.4rem, 3.2vw, 1.9rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  color: var(--ink);
+}
+
+@media (max-width: 640px) {
+  .others li {
+    border-right: 0;
+    border-bottom: 1px solid var(--hairline);
+  }
+
+  .others li:last-child {
+    border-bottom: 0;
+  }
+
+  .cta {
+    box-shadow: 5px 5px 0 var(--ink);
+  }
+}

--- a/apps/site/app/u/[handle]/page.tsx
+++ b/apps/site/app/u/[handle]/page.tsx
@@ -57,6 +57,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description: summary,
       path: `/u/${profile.handle}`,
     }),
+    /* Handles are case-insensitive in the route and sanitised here, so /u/Foo and /u/foo
+       both render; the canonical names the sanitised one. */
+    alternates: { canonical: `/u/${profile.handle}` },
     twitter: { card: "summary_large_image" },
   };
 }

--- a/apps/site/components/closing-cta.module.css
+++ b/apps/site/components/closing-cta.module.css
@@ -1,0 +1,184 @@
+.section {
+  padding: clamp(30px, 4vw, 56px) 0;
+  border-top: 3px solid var(--ink);
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: clamp(22px, 3vw, 34px);
+  border: 2px solid var(--ink);
+  background: var(--surface-alt);
+  box-shadow: 8px 8px 0 var(--ink);
+}
+
+.head {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.h2 {
+  margin: 0;
+  font-family: var(--font-display), system-ui, sans-serif;
+  font-size: clamp(1.6rem, 4vw, 2.5rem);
+  font-weight: 800;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  color: var(--ink);
+  text-wrap: balance;
+}
+
+.lede {
+  margin: 0;
+  max-width: 56em;
+  font-size: 13px;
+  line-height: 1.75;
+  color: var(--text-muted);
+}
+
+.cmdRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+
+.cmd {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  padding: 14px 16px;
+  border: 2px solid var(--ink);
+  background: var(--surface);
+  font-size: 13px;
+  white-space: nowrap;
+  color: var(--ink);
+}
+
+.prompt {
+  color: var(--text-faint);
+  margin-right: 6px;
+}
+
+.note {
+  margin: 0;
+  max-width: 56em;
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--text-dim);
+}
+
+.note code {
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  padding: 1px 5px;
+}
+
+.asks {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0;
+  border: 2px solid var(--ink);
+  background: var(--surface);
+}
+
+.ask {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 15px 17px;
+  border-right: 1px solid var(--hairline);
+}
+
+.ask:last-child {
+  border-right: 0;
+}
+
+.ask:hover {
+  background: var(--tint-lime);
+}
+
+.askLabel {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.askValue {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.ask:hover .askValue {
+  color: var(--coral-text);
+}
+
+.agents {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 18px;
+}
+
+.agentsLabel {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.agentList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+}
+
+.agentLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 11px;
+  border: 1px solid var(--ink);
+  background: var(--surface);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.agentLink:hover {
+  background: var(--lime);
+  color: var(--ink);
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border: 1px solid var(--ink);
+}
+
+@media (max-width: 640px) {
+  .panel {
+    box-shadow: 5px 5px 0 var(--ink);
+  }
+
+  .ask {
+    border-right: 0;
+    border-bottom: 1px solid var(--hairline);
+  }
+
+  .ask:last-child {
+    border-bottom: 0;
+  }
+}

--- a/apps/site/components/closing-cta.tsx
+++ b/apps/site/components/closing-cta.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+
+import { agentColour } from "@tokenchit/core";
+
+import { CopyButton } from "@/components/copy-button";
+import { AGENT_PAGES } from "@/lib/agents";
+import { cmd, PRIMARY_COMMAND } from "@/lib/cli";
+
+import styles from "./closing-cta.module.css";
+
+const REPO = "https://github.com/iyashjayesh/tokenchit";
+
+/**
+ * The last block on the landing page.
+ *
+ * The install command appeared exactly once, in the hero. After five sections of detail the
+ * page ended on the recap heatmap and a three-link footer, so a reader convinced by section
+ * 04 had to scroll back past everything to act on it.
+ *
+ * It also carries the two things the page had no place for: a way to say what is wrong with
+ * it, and a reason to come back. Every section above explains the tool; none of them asked
+ * for anything.
+ */
+export function ClosingCta() {
+  const syncCommand = cmd("sync");
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.panel}>
+        <div className={styles.head}>
+          <h2 className={styles.h2}>Read your own numbers.</h2>
+          <p className={styles.lede}>
+            One command. It finds your agents, prints your stats and writes the card. Free,
+            MIT, and no account — publishing to the board is a separate step you have to ask
+            for.
+          </p>
+        </div>
+
+        <div className={styles.cmdRow}>
+          <code className={styles.cmd}>
+            <span className={styles.prompt}>$</span> {PRIMARY_COMMAND}
+          </code>
+          <CopyButton
+            value={PRIMARY_COMMAND}
+            variant="lime"
+            event="closing-install"
+            idleLabel="copy"
+            copiedLabel="copied"
+          />
+        </div>
+
+        <p className={styles.note}>
+          Or <code>{syncCommand}</code> to see the figures without writing anything. It makes
+          no network request.
+        </p>
+
+        <div className={styles.asks}>
+          {/* The site had no channel of any kind. A tool whose whole argument is "check this
+              rather than take our word" needs somewhere for the reader who checked and
+              disagrees. */}
+          <a className={styles.ask} href={`${REPO}/issues/new`}>
+            <span className={styles.askLabel}>Something wrong?</span>
+            <span className={styles.askValue}>Open an issue →</span>
+          </a>
+          <a className={styles.ask} href={REPO}>
+            <span className={styles.askLabel}>Want to follow along?</span>
+            <span className={styles.askValue}>Star the repo →</span>
+          </a>
+        </div>
+      </div>
+
+      <nav className={styles.agents} aria-label="Per-agent pages">
+        <span className={styles.agentsLabel}>Per agent</span>
+        <ul className={styles.agentList}>
+          {AGENT_PAGES.map((a) => (
+            <li key={a.key}>
+              <Link href={`/tool/${a.key}`} className={styles.agentLink}>
+                <span
+                  className={styles.dot}
+                  style={{ background: agentColour(a.key) }}
+                  aria-hidden="true"
+                />
+                {a.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </section>
+  );
+}

--- a/apps/site/components/copy-button.module.css
+++ b/apps/site/components/copy-button.module.css
@@ -37,9 +37,18 @@
   color: var(--ink);
 }
 
-/* Snippet panel headers: inverted fill on hover. */
+/* Snippet panel headers: inverted fill on hover.
+
+   `min-height` rather than more padding: at 9.5px type with 3px of it, these measured 23px,
+   one short of the 24x24 WCAG 2.2 SC 2.5.8 asks of a pointer target. Raising the padding
+   would have changed the chip's proportions everywhere it appears; a floor only affects the
+   case that was under it, and the flex centring keeps the label where it already sat. */
 .lime,
 .yellow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 24px;
   border: 2px solid var(--ink);
   padding: 3px 8px;
   font-size: 9.5px;

--- a/apps/site/components/hero.module.css
+++ b/apps/site/components/hero.module.css
@@ -168,8 +168,16 @@
 
 /* The one line on this page that says other people are here. Under the install command,
    because it answers the question the command provokes: "and then what?" */
-.proof {
+/* Sits directly under the command, tighter than .proof so the two read as one block
+   rather than two unrelated footnotes. */
+.free {
   margin: 14px 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.proof {
+  margin: 6px 0 0;
   font-size: 12px;
   color: var(--text-dim);
 }

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { formatTokens, formatUsd } from "@tokenchit/core";
+import { formatTokens } from "@tokenchit/core";
 
 import { CopyButton } from "./copy-button";
 import type { BoardTotals } from "@/lib/board-totals";
@@ -51,17 +51,29 @@ export function Hero({ preview, totals }: { preview: Featured; totals: BoardTota
           />
         </div>
 
+        {/* Free is stated here because the page never said it anywhere. "MIT" sits in the
+            header and the footer, but that is a licence, not a price, and a reader scanning
+            for the catch did not find the answer — which reads as "pricing later" rather
+            than "there is none". */}
+        <p className={styles.free}>
+          Free, MIT, and no account needed to read your own numbers.
+        </p>
+
         {/* Proof that the board is a place rather than a demo. The figures already existed
             and only /board showed them, so the page invited people to join something whose
             size it never mentioned. Absent rather than zeroed when the query fails — "0
-            developers" is a worse claim than no claim. */}
+            developers" is a worse claim than no claim.
+
+            Equivalent cost is deliberately not here. It was the largest number on the page
+            and the one the page spends three paragraphs explaining is not real money, so a
+            cold reader met the claim well before the caveat. It still leads the board and
+            section 02, where the explanation is next to it. */}
         {totals && totals.developers > 0 && (
           <p className={styles.proof}>
             <Link href="/board" className={styles.proofLink}>
               {totals.developers} {totals.developers === 1 ? "developer" : "developers"}
             </Link>{" "}
-            on the board · {formatTokens(totals.tokens)} tokens ·{" "}
-            {formatUsd(totals.equivCostUsd)} equiv. cost
+            on the board · {formatTokens(totals.tokens)} tokens
           </p>
         )}
       </div>

--- a/apps/site/lib/agents.ts
+++ b/apps/site/lib/agents.ts
@@ -1,0 +1,125 @@
+import type { BoardAgent } from "./board";
+
+/**
+ * What the site says about each agent, on its own page.
+ *
+ * Paired with `packages/core/src/adapters/*` — `source` here must match the glob that
+ * adapter actually reads, and `caveat` must match what the CLI prints. It is duplicated
+ * rather than imported because `@tokenchit/core/adapters` pulls in `node:fs` and
+ * `node:sqlite`, and importing it for three strings would drag both into this route's
+ * bundle for no gain. If an adapter's source path changes, change it here too.
+ */
+export type AgentPage = {
+  key: BoardAgent;
+  /** As written on the card and in prose. */
+  label: string;
+  /** Title case, for the page heading and title tag. */
+  name: string;
+  /** Where the adapter reads. Verbatim from the adapter. */
+  source: string;
+  /** One line: what the log actually is. */
+  what: string;
+  /**
+   * The thing someone will otherwise be surprised by. Every agent has one, and a page that
+   * only listed the good news would be the kind of page this project is arguing against.
+   */
+  caveat: { heading: string; body: string };
+};
+
+export const AGENT_PAGES: AgentPage[] = [
+  {
+    key: "claude-code",
+    label: "claude code",
+    name: "Claude Code",
+    source: "~/.claude*/projects/**/*.jsonl",
+    what:
+      "Claude Code writes a JSONL transcript per session. Every profile directory is read, " +
+      "not just the default one, so a machine with more than one config still reports a " +
+      "single total.",
+    caveat: {
+      heading: "Your total will be lower than the Stats panel's",
+      body:
+        "Claude Code rewrites an assistant message in the transcript as it streams, and each " +
+        "rewrite leaves a usage record carrying the same growing figures — so one API call " +
+        "can appear several times. The Stats panel sums them as written; tokenchit collapses " +
+        "them to one row per call. On the machines measured the panel ran between 1.15x and " +
+        "2.18x higher, and the factor moved day to day, so there is no constant to divide " +
+        "out. `sync` prints both figures and the gap rather than picking one for you.",
+    },
+  },
+  {
+    key: "codex",
+    label: "codex",
+    name: "Codex",
+    source: "~/.codex/sessions/**/rollout-*.jsonl",
+    what:
+      "Codex writes one rollout file per session, under a dated directory tree. Token counts " +
+      "come from the same usage records the API returned.",
+    caveat: {
+      heading: "There is no cumulative cache to fall back on",
+      body:
+        "Unlike Claude Code, Codex keeps no running total outside the transcripts. That makes " +
+        "the figure straightforward while the files are there, and unrecoverable once they " +
+        "are gone: a number derived from logs cannot include logs that no longer exist. " +
+        "tokenchit banks each day it sees in a local ledger so a later rotation does not " +
+        "erase history it has already read.",
+    },
+  },
+  {
+    key: "opencode",
+    label: "opencode",
+    name: "OpenCode",
+    source: "~/.local/share/opencode/opencode.db",
+    what:
+      "OpenCode records usage in a SQLite database rather than flat files. Reading it uses " +
+      "Node's built-in `node:sqlite`, which is why the CLI needs Node 22 or newer.",
+    caveat: {
+      heading: "Tokens are counted; some of the cost is not",
+      body:
+        "OpenCode routes to whatever model you point it at, including self-hosted and bundled " +
+        "ones with no public per-token price. Those are counted in the token total and left " +
+        "out of the equivalent-cost figure, because inventing a rate for them would make the " +
+        "cost look complete when it is not. The card reports the share of tokens that are " +
+        "priced so you can see how much of the figure is covered.",
+    },
+  },
+];
+
+export const agentPage = (key: string): AgentPage | undefined =>
+  AGENT_PAGES.find((a) => a.key === key);
+
+/**
+ * Agents that are detected and deliberately not supported.
+ *
+ * Named on every agent page rather than omitted: "tokenchit does not see Copilot" and
+ * "Copilot does not record what tokenchit would need" are different claims, and only one of
+ * them is a bug worth filing.
+ */
+export const UNSUPPORTED = [
+  {
+    name: "Copilot CLI",
+    reason: "records only a live context gauge, so there is no per-call token count to read.",
+  },
+  {
+    name: "Gemini CLI",
+    reason: "writes transcripts that carry no token counts at all.",
+  },
+] as const;
+
+/**
+ * Split prose on backticks so `like this` can render as a `<code>` element.
+ *
+ * The content above is plain strings, which is what makes it readable in the file and
+ * greppable against the adapters. Without this the backticks reached the page as literal
+ * characters — visible in the prerendered HTML, which is how it was caught.
+ *
+ * Odd indices are the code spans, because splitting on a delimiter always yields
+ * text/delim/text; an unclosed backtick therefore renders as text rather than swallowing the
+ * rest of the sentence.
+ */
+export function codeSpans(text: string): { code: boolean; value: string }[] {
+  return text
+    .split("`")
+    .map((value, i) => ({ code: i % 2 === 1, value }))
+    .filter((part) => part.value.length > 0);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,6 +1819,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@tokenchit/mcp": {
+      "resolved": "packages/mcp",
+      "link": true
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -7256,6 +7260,57 @@
       }
     },
     "packages/core/node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "packages/mcp": {
+      "name": "@tokenchit/mcp",
+      "version": "0.8.0",
+      "license": "MIT",
+      "bin": {
+        "tokenchit-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^26.4.0",
+        "esbuild": "^0.28.2",
+        "typescript": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "packages/mcp/node_modules/typescript": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "npm run build -w @tokenchit/core && npm run build -w @tokenchit/cli && npm run build -w tokenchit-site",
+    "build": "npm run build -w @tokenchit/core && npm run build -w @tokenchit/cli && npm run build -w @tokenchit/mcp && npm run build -w tokenchit-site",
     "build:core": "npm run build -w @tokenchit/core",
     "dev": "npm run dev -w tokenchit-site",
-    "test": "npm run build:core && npm run build -w @tokenchit/cli && npm run test -w @tokenchit/core && npm run test -w @tokenchit/cli && npm run test -w tokenchit-site",
+    "test": "npm run build:core && npm run build -w @tokenchit/cli && npm run build -w @tokenchit/mcp && npm run test -w @tokenchit/core && npm run test -w @tokenchit/cli && npm run test -w @tokenchit/mcp && npm run test -w tokenchit-site",
     "cli": "node packages/cli/dist/index.js",
     "db:migrate": "node apps/site/db/migrate.mjs",
-    "version:set": "node scripts/version.mjs"
+    "version:set": "node scripts/version.mjs",
+    "mcp": "node packages/mcp/dist/index.js"
   }
 }

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { relative, resolve } from "node:path";
 
 import {
@@ -14,7 +15,7 @@ import { claudeContext, estimatedTotal } from "../claude-context.js";
 import { scan } from "../scan.js";
 import { readAuth } from "../auth.js";
 import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
-import { bold, dim, fail, green, grey, link, say, spin, warn, yellow } from "../ui.js";
+import { asUrlPath, bold, dim, fail, green, grey, link, say, spin, warn, yellow } from "../ui.js";
 import { canOpenBrowser, openBrowser } from "../desktop.js";
 import { post } from "../net.js";
 import { signIn, signInOptions } from "./login.js";
@@ -176,9 +177,18 @@ export async function publish(argv: string[], version: string): Promise<number> 
    * card — people who had published a row and never took the last step, because the command
    * that put them on the board did not ask them to.
    */
-  const card = relative(process.cwd(), resolve(config.output));
-  say(`  ${grey("embed")}     ![tokenchit — @${payload.handle} AI coding agent usage](./${card})`);
-  say(`  ${grey("commit")}    git add ${card} && git commit -m "chore: update tokenchit"`);
+  const target = resolve(config.output);
+  const card = relative(process.cwd(), target);
+
+  /* Only offered when the card is actually on disk. `publish` does not write one, so someone
+     who ran `init` then `publish` has no file — and `git add <card>` would fail with "did not
+     match any files", which is a worse first experience than not being told. */
+  if (existsSync(target)) {
+    say(`  ${grey("embed")}     ![tokenchit — @${payload.handle} AI coding agent usage](./${asUrlPath(card)})`);
+    say(`  ${grey("commit")}    git add ${card} && git commit -m "chore: update tokenchit"`);
+  } else {
+    say(`  ${grey("the card")}   ${bold("tokenchit sync")} ${dim(`— writes ${card}, which is the point of the row above`)}`);
+  }
   say();
 
   /*

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,3 +1,5 @@
+import { relative, resolve } from "node:path";
+
 import {
   buildPayload,
   formatTokens,
@@ -159,6 +161,24 @@ export async function publish(argv: string[], version: string): Promise<number> 
   const profile = `${api}/u/${payload.handle}`;
   say(`  ${grey("your profile")}   ${link(profile)}`);
   say(`  ${grey("leaderboard")}    ${link(`${api}/board`)}`);
+  say();
+
+  /*
+   * The embed line, repeated here.
+   *
+   * `sync` prints it, and `generate` therefore shows it once on the way past — but `publish`
+   * run on its own never mentioned the card at all, and `publish` is the command someone
+   * re-runs. So the whole flow ended on two links to someone else's website, for a tool whose
+   * entire argument is that the card belongs in your repo.
+   *
+   * Measured rather than assumed: of the 34 rows on the board at the time of writing, two
+   * carried a card in the author's profile README. Twelve more had a profile README and no
+   * card — people who had published a row and never took the last step, because the command
+   * that put them on the board did not ask them to.
+   */
+  const card = relative(process.cwd(), resolve(config.output));
+  say(`  ${grey("embed")}     ![tokenchit — @${payload.handle} AI coding agent usage](./${card})`);
+  say(`  ${grey("commit")}    git add ${card} && git commit -m "chore: update tokenchit"`);
   say();
 
   /*

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -17,7 +17,7 @@ import { CONFIG_FILE, DEFAULT_CONFIG, readConfig } from "../config.js";
 import { claudeContext, estimatedTotal } from "../claude-context.js";
 import { scan } from "../scan.js";
 import { renderStats } from "../stats-view.js";
-import { bold, dim, green, grey, note, say, spin, under, warn, yellow } from "../ui.js";
+import { asUrlPath, bold, dim, green, grey, note, say, spin, under, warn, yellow } from "../ui.js";
 
 const LAYOUTS = ["default", "compact"] as const satisfies readonly Layout[];
 const THEMES = ["auto", "light", "dark"] as const satisfies readonly Theme[];
@@ -208,7 +208,7 @@ export async function sync(argv: string[], chained = false): Promise<number> {
   say(`${green("✓")} wrote ${bold(rel)} ${dim(`(${svg.length} bytes)`)}`);
 
   say();
-  say(`  ${grey("embed")}     ![tokenchit — @${handle} AI coding agent usage](./${rel})`);
+  say(`  ${grey("embed")}     ![tokenchit — @${handle} AI coding agent usage](./${asUrlPath(rel)})`);
   // Committing on the user's behalf is not ours to decide — a tool that reads your logs
   // should not also decide what lands in your history on its first run.
   say(`  ${grey("commit")}    git add ${rel} && git commit -m "chore: update tokenchit"`);

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -244,3 +244,13 @@ export function muteSqliteWarning(): void {
     if (listeners.length === 0) process.stderr.write(`${w.name}: ${w.message}\n`);
   });
 }
+
+/**
+ * A repo-relative path as a markdown URL.
+ *
+ * `relative()` returns `\`-separated paths on Windows, and a markdown image path with
+ * backslashes in it does not resolve — so the one line whose entire job is to be pasted into
+ * a README was broken on Windows in both `sync` and `publish`. Separate from the plain path
+ * because the shell line beside it wants the native separator.
+ */
+export const asUrlPath = (rel: string): string => rel.split("\\").join("/");

--- a/packages/cli/test/privacy.test.js
+++ b/packages/cli/test/privacy.test.js
@@ -15,6 +15,10 @@ const CLI = join(HERE, "..", "dist", "index.js");
 const FIXTURE_HOME = join(HERE, "fixtures", "home");
 const SRC = join(HERE, "..", "src");
 const CORE_SRC = join(HERE, "..", "..", "core", "src");
+/* The MCP server is in scope for the same guarantee. It hands local figures to a model, which
+   is exactly the surface where an added "just fetch the board too" would be least visible —
+   and unlike the CLI it has no allowlisted module at all, so every file under it must be clean. */
+const MCP_SRC = join(HERE, "..", "..", "mcp", "src");
 
 /**
  * These four tests are the ones the site prints as `privacy.spec.ts` output, under the
@@ -133,7 +137,7 @@ test("net.isolated", async () => {
   const ALLOWED = join(SRC, "net.ts");
   const offenders = [];
 
-  for (const root of [SRC, CORE_SRC]) {
+  for (const root of [SRC, CORE_SRC, MCP_SRC]) {
     for (const file of await walk(root)) {
       if (file === ALLOWED) continue;
       const text = await readFile(file, "utf8");

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -18,9 +18,9 @@ Reads the logs Claude Code, Codex and OpenCode already write on your machine. No
 
 | tool | what it answers |
 | --- | --- |
-| `get_usage` | totals, streak, active days, per-agent mix and per-model breakdown, over all time and the last year / 30 days / 7 days |
-| `get_daily_usage` | tokens per local calendar day, plus by weekday and by hour |
-| `get_recap` | year in review — headline tiles, per-agent split, busiest hour range, day-by-day activity |
+| `get_usage` | totals, streak, active days, per-agent mix and per-model breakdown, over all time, the current calendar year so far, and the last 30 / 7 days |
+| `get_daily_usage` | tokens per local calendar day for the last N days, idle days included as zero |
+| `get_recap` | year in review for one calendar year — headline tiles, per-agent split, busiest hour range, activity by weekday and hour |
 | `detect_agents` | which agents are on this machine, where each reads from, and what cannot be supported |
 
 ## It cannot make a network request

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,57 @@
+# @tokenchit/mcp
+
+MCP server for your local AI coding agent usage. Ask a model how many tokens you burned this
+week instead of reading a table.
+
+```json
+{
+  "mcpServers": {
+    "tokenchit": { "command": "npx", "args": ["-y", "@tokenchit/mcp@latest"] }
+  }
+}
+```
+
+Reads the logs Claude Code, Codex and OpenCode already write on your machine. Node 22 or newer
+— OpenCode support uses the built-in `node:sqlite`.
+
+## Tools
+
+| tool | what it answers |
+| --- | --- |
+| `get_usage` | totals, streak, active days, per-agent mix and per-model breakdown, over all time and the last year / 30 days / 7 days |
+| `get_daily_usage` | tokens per local calendar day, plus by weekday and by hour |
+| `get_recap` | year in review — headline tiles, per-agent split, busiest hour range, day-by-day activity |
+| `detect_agents` | which agents are on this machine, where each reads from, and what cannot be supported |
+
+## It cannot make a network request
+
+Not a policy sentence. `net.isolated` in `packages/cli/test/privacy.test.js` reads every source
+file under `packages/mcp/src` and fails if any of them can open a socket — and unlike the CLI,
+this package has **no allowlisted module at all**, so every file must be clean. It runs on
+every push.
+
+The ledger is read and never written. `tokenchit sync` banks what it saw because you asked it
+to; a tool call is a question, and a question that mutates state on disk is a surprise you
+cannot see or undo. Asking twice changes nothing.
+
+## Two things the figures are not
+
+**They will not match Claude Code's Stats panel.** Claude Code rewrites an assistant message in
+the transcript as it streams, and each rewrite leaves a usage record carrying the same growing
+figures — so one API call can appear several times. The panel sums them as written; this
+deduplicates by message id. On the machines measured the panel ran 1.15x to 2.18x higher, and
+the factor moved day to day, so there is no constant to divide out.
+
+**Equivalent cost is not money you paid.** It is what the tokens would cost at list API rates.
+Most agent usage runs under a subscription where no per-token charge ever happens, and models
+with no public price are counted in the token total and left out of the cost figure. Every tool
+returns that caveat as a field beside the number, because a figure handed to a model without
+one gets reported to you as a bill.
+
+## The rest of it
+
+[`@tokenchit/cli`](https://www.npmjs.com/package/@tokenchit/cli) renders the same numbers as an
+SVG card you commit to your repo, and optionally publishes a row to a public board. Source and
+full docs: [github.com/iyashjayesh/tokenchit](https://github.com/iyashjayesh/tokenchit).
+
+MIT.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@tokenchit/mcp",
+  "version": "0.8.0",
+  "description": "MCP server exposing your local AI coding agent usage. Reads logs on your machine and makes no network request.",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "claude-code",
+    "codex",
+    "opencode",
+    "tokens",
+    "usage",
+    "ai-agents"
+  ],
+  "license": "MIT",
+  "author": "Yash Chauhan (https://github.com/iyashjayesh)",
+  "homepage": "https://github.com/iyashjayesh/tokenchit#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iyashjayesh/tokenchit.git",
+    "directory": "packages/mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/iyashjayesh/tokenchit/issues"
+  },
+  "type": "module",
+  "bin": {
+    "tokenchit-mcp": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json && npm run bundle",
+    "bundle": "esbuild src/index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --packages=bundle",
+    "dev": "tsc -p tsconfig.json --watch",
+    "test": "node --test test/*.test.js",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "@types/node": "^26.4.0",
+    "esbuild": "^0.28.2",
+    "typescript": "^7.0.2"
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import pkg from "../package.json" with { type: "json" };
+
 import { byName, tools } from "./tools.js";
 
 /*
@@ -32,7 +34,12 @@ import { byName, tools } from "./tools.js";
 
 /** Latest revision this server has been checked against. */
 const PROTOCOL_VERSION = "2025-06-18";
-const SERVER_INFO = { name: "tokenchit", version: "0.8.0" };
+
+/* Read from the package rather than written out here. scripts/version.mjs bumps
+   packages/mcp/package.json, so a literal would have started reporting a version this server
+   is not from the very next release — in the one field a client logs and a bug report
+   quotes. esbuild inlines the import at bundle time, so nothing reads a file at runtime. */
+const SERVER_INFO = { name: "tokenchit", version: pkg.version };
 
 type Id = string | number | null;
 type Request = { jsonrpc: "2.0"; id?: Id; method: string; params?: Record<string, unknown> };
@@ -150,7 +157,18 @@ let pending = 0;
 let inputEnded = false;
 
 const settle = (): void => {
-  if (inputEnded && pending === 0) process.exit(0);
+  if (!inputEnded || pending > 0) return;
+
+  /*
+   * Set the code and let the loop end, rather than calling `process.exit`.
+   *
+   * stdout is always a pipe under stdio transport, and Node's pipe writes are asynchronous:
+   * `process.exit` does not flush them, so a reply larger than the 64KB pipe buffer was
+   * truncated on the way out. `get_daily_usage` with a decade of history clears that easily.
+   * Nothing else holds the loop open once stdin has ended and no call is in flight.
+   */
+  process.exitCode = 0;
+  process.stdin.destroy();
 };
 
 process.stdin.setEncoding("utf8");
@@ -165,13 +183,29 @@ process.stdin.on("data", (chunk: string) => {
 
     if (!line) continue;
 
-    let req: Request;
+    let parsed: unknown;
     try {
-      req = JSON.parse(line) as Request;
+      parsed = JSON.parse(line);
     } catch {
       fail(null, PARSE_ERROR, "invalid JSON");
       continue;
     }
+
+    /*
+     * `null`, a number and a bare string are all valid JSON and none of them have an `id`.
+     * Dispatching one threw inside `handle`, and the catch below then threw the *same*
+     * TypeError re-reading `req.id` — so the promise rejected unhandled and took the process
+     * with it. One `null` frame killed the server, which is exactly what the malformed-input
+     * test was meant to rule out and did not, because it only covered unparseable bytes.
+     */
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      fail(null, INVALID_REQUEST, "request must be a JSON object");
+      continue;
+    }
+
+    const req = parsed as Request;
+    // Captured before dispatch so the handler below cannot fail on the same access.
+    const id = req.id ?? null;
 
     // Requests are handled in arrival order but not serialised: a client may pipeline, and
     // each reply carries its own id.
@@ -179,7 +213,7 @@ process.stdin.on("data", (chunk: string) => {
     void handle(req)
       .catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
-        fail(req.id ?? null, INTERNAL_ERROR, message);
+        fail(id, INTERNAL_ERROR, message);
       })
       .finally(() => {
         pending -= 1;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+import { byName, tools } from "./tools.js";
+
+/*
+ * The OpenCode adapter reads a SQLite database through `node:sqlite`, which is still flagged
+ * experimental and prints a warning on load. It goes to stderr so it cannot corrupt the
+ * protocol stream, but an MCP client surfaces stderr as the server's log, where an unexplained
+ * warning on every start reads as a fault in this package. Only that one is dropped: removing
+ * the default listener wholesale would hide deprecations worth seeing.
+ */
+{
+  const warnings = process.listeners("warning");
+  process.removeAllListeners("warning");
+  process.on("warning", (warning) => {
+    if (warning.name === "ExperimentalWarning" && /SQLite/i.test(warning.message)) return;
+    for (const listener of warnings) listener(warning);
+  });
+}
+
+/*
+ * A stdio MCP server, written against the wire format rather than against the official SDK.
+ *
+ * The SDK is the normal choice and this is a deliberate departure: the whole claim this
+ * package makes is that it cannot phone home, and `net.isolated` proves that by reading
+ * source. A dependency tree moves most of the code out of reach of that test, so the trust
+ * surface would grow by more than the SDK saves. What is actually needed here is three
+ * request types over newline-delimited JSON-RPC, and that is small enough to audit.
+ *
+ * The one rule that matters: stdout carries protocol frames and nothing else. Every
+ * diagnostic goes to stderr, or it corrupts the stream.
+ */
+
+/** Latest revision this server has been checked against. */
+const PROTOCOL_VERSION = "2025-06-18";
+const SERVER_INFO = { name: "tokenchit", version: "0.8.0" };
+
+type Id = string | number | null;
+type Request = { jsonrpc: "2.0"; id?: Id; method: string; params?: Record<string, unknown> };
+
+const send = (msg: unknown): void => {
+  process.stdout.write(`${JSON.stringify(msg)}\n`);
+};
+
+const reply = (id: Id, result: unknown): void => send({ jsonrpc: "2.0", id, result });
+
+const fail = (id: Id, code: number, message: string): void =>
+  send({ jsonrpc: "2.0", id, error: { code, message } });
+
+/** JSON-RPC codes, plus the one MCP adds for an unknown tool. */
+const PARSE_ERROR = -32700;
+const INVALID_REQUEST = -32600;
+const METHOD_NOT_FOUND = -32601;
+const INTERNAL_ERROR = -32603;
+
+async function handle(req: Request): Promise<void> {
+  const id = req.id ?? null;
+  const isNotification = req.id === undefined;
+
+  switch (req.method) {
+    case "initialize":
+      reply(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+        instructions:
+          "Reads AI coding agent logs already on this machine. Every figure is local and " +
+          "no tool here makes a network request. Token totals are deduplicated by message " +
+          "id and will read lower than Claude Code's own Stats panel; equivalent cost is " +
+          "list API rates, not money paid.",
+      });
+      return;
+
+    // Sent by the client once it is ready. It carries no id and expects no answer; replying
+    // to a notification is a protocol violation, not a harmless extra frame.
+    case "notifications/initialized":
+      return;
+
+    case "ping":
+      if (!isNotification) reply(id, {});
+      return;
+
+    case "tools/list":
+      reply(id, {
+        tools: tools.map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+        })),
+      });
+      return;
+
+    case "tools/call": {
+      const name = req.params?.name;
+      if (typeof name !== "string") {
+        fail(id, INVALID_REQUEST, "params.name is required");
+        return;
+      }
+
+      const tool = byName.get(name);
+      if (!tool) {
+        fail(id, METHOD_NOT_FOUND, `unknown tool: ${name}`);
+        return;
+      }
+
+      const args =
+        req.params?.arguments && typeof req.params.arguments === "object"
+          ? (req.params.arguments as Record<string, unknown>)
+          : {};
+
+      try {
+        const out = await tool.run(args);
+        reply(id, { content: [{ type: "text", text: JSON.stringify(out, null, 2) }] });
+      } catch (err) {
+        /*
+         * A tool that throws is reported through `isError` on a successful result, not as a
+         * JSON-RPC error. The distinction is the point: a transport error is the server's
+         * fault and the model cannot act on it, whereas "no logs on this machine" is an
+         * answer the model should read and relay.
+         */
+        const message = err instanceof Error ? err.message : String(err);
+        reply(id, { content: [{ type: "text", text: `tokenchit: ${message}` }], isError: true });
+      }
+      return;
+    }
+
+    default:
+      // Unknown notifications are ignored by design — a client is allowed to send ones this
+      // server has never heard of, and answering them would be the bug.
+      if (!isNotification) fail(id, METHOD_NOT_FOUND, `unknown method: ${req.method}`);
+  }
+}
+
+/*
+ * Frame on newlines, and buffer whatever arrives mid-line.
+ *
+ * stdin delivers arbitrary chunks, so a frame can be split across two reads and two frames
+ * can arrive in one. Parsing per chunk works right up until a payload gets big enough to be
+ * split, which is exactly when a recap of a large corpus goes out.
+ */
+let buffer = "";
+
+/*
+ * In-flight tool calls, so shutdown can wait for them.
+ *
+ * Without this, `process.exit` on stdin end tore down the process while a `tools/call` was
+ * still reading logs, and the reply was never written — reproducible by piping requests in
+ * rather than holding the pipe open, which is also how anyone first tries this by hand.
+ */
+let pending = 0;
+let inputEnded = false;
+
+const settle = (): void => {
+  if (inputEnded && pending === 0) process.exit(0);
+};
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk: string) => {
+  buffer += chunk;
+
+  let cut = buffer.indexOf("\n");
+  while (cut !== -1) {
+    const line = buffer.slice(0, cut).trim();
+    buffer = buffer.slice(cut + 1);
+    cut = buffer.indexOf("\n");
+
+    if (!line) continue;
+
+    let req: Request;
+    try {
+      req = JSON.parse(line) as Request;
+    } catch {
+      fail(null, PARSE_ERROR, "invalid JSON");
+      continue;
+    }
+
+    // Requests are handled in arrival order but not serialised: a client may pipeline, and
+    // each reply carries its own id.
+    pending += 1;
+    void handle(req)
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        fail(req.id ?? null, INTERNAL_ERROR, message);
+      })
+      .finally(() => {
+        pending -= 1;
+        settle();
+      });
+  }
+});
+
+// The client closing stdin is the shutdown signal; there is no separate exit handshake.
+// Exiting is deferred until every accepted request has answered, so a reply is never lost
+// to the shutdown that arrived behind it.
+process.stdin.on("end", () => {
+  inputEnded = true;
+  settle();
+});

--- a/packages/mcp/src/stats.ts
+++ b/packages/mcp/src/stats.ts
@@ -20,13 +20,30 @@ export const ALL_AGENTS: readonly AgentId[] = adapters.map((a) => a.id);
  * disk is a surprise the caller cannot see or undo. Reading the bank still hands the caller
  * its recovered days; not writing it means asking twice changes nothing.
  */
-export async function read(agents?: readonly AgentId[]): Promise<Read> {
+export async function read(
+  agents?: readonly AgentId[],
+  /**
+   * Report on one calendar year only.
+   *
+   * Threaded into `aggregate` rather than only into `buildRecap`, because `buildRecap` uses
+   * it for the streak tile and nothing else — every other figure it returns comes from the
+   * stats it is handed. `aggregate` is what filters the events, and skipping it is how
+   * `get_recap({ year: 2021 })` came to return this year's totals under a 2021 heading.
+   * `packages/core/src/aggregate.ts` carries a comment about this exact bug being fixed once
+   * already for `recap --year`; this is the second time.
+   */
+  year?: number,
+): Promise<Read> {
   const only = agents?.length ? agents : ALL_AGENTS;
   const ledger = await readLedger();
   const recovered: Recovered = { days: 0, tokens: 0 };
 
+  /* The year filter belongs to the aggregation and not the read: the ledger must still bank
+     every day it sees, or asking for one year would prune the bank to that year. Same
+     reasoning as the CLI's `scan`. */
   const stats = await aggregate(
     recordAndReplay(readAll([...only]), ledger, only, recovered),
+    year === undefined ? {} : { year },
   );
 
   return { stats, recovered };

--- a/packages/mcp/src/stats.ts
+++ b/packages/mcp/src/stats.ts
@@ -1,0 +1,52 @@
+import {
+  adapters,
+  readAll,
+  readLedger,
+  recordAndReplay,
+  type Recovered,
+} from "@tokenchit/core/adapters";
+import { aggregate, type AgentId, type Detection, type Stats } from "@tokenchit/core";
+
+export type Read = { stats: Stats; recovered: Recovered };
+
+export const ALL_AGENTS: readonly AgentId[] = adapters.map((a) => a.id);
+
+/**
+ * Read the logs and aggregate them, the same way the CLI's `scan` does — with one deliberate
+ * difference: the ledger is read and never written.
+ *
+ * The CLI banks what it saw because someone running `sync` wants rotated days preserved for
+ * next time. An MCP tool call is a question, and a question that quietly mutates state on
+ * disk is a surprise the caller cannot see or undo. Reading the bank still hands the caller
+ * its recovered days; not writing it means asking twice changes nothing.
+ */
+export async function read(agents?: readonly AgentId[]): Promise<Read> {
+  const only = agents?.length ? agents : ALL_AGENTS;
+  const ledger = await readLedger();
+  const recovered: Recovered = { days: 0, tokens: 0 };
+
+  const stats = await aggregate(
+    recordAndReplay(readAll([...only]), ledger, only, recovered),
+  );
+
+  return { stats, recovered };
+}
+
+export type Detected = {
+  agent: AgentId;
+  name: string;
+  state: Detection;
+  source: string;
+};
+
+/** Which agents this machine has, and whether they carry data worth reading. */
+export function detect(): Promise<Detected[]> {
+  return Promise.all(
+    adapters.map(async (a) => ({
+      agent: a.id,
+      name: a.name,
+      state: await a.detect(),
+      source: a.source,
+    })),
+  );
+}

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -40,6 +40,9 @@ const asAgents = (raw: unknown): AgentId[] | undefined => {
 };
 
 const clampDays = (raw: unknown, fallback: number): number => {
+  // `Number(null)` is 0, which clamped to 1 — so a client sending `days: null` to mean
+  // "unset" got a single day instead of the default. Absent and null are the same intent.
+  if (raw === undefined || raw === null) return fallback;
   const n = typeof raw === "number" ? raw : Number(raw);
   if (!Number.isFinite(n)) return fallback;
   return Math.min(3650, Math.max(1, Math.trunc(n)));
@@ -53,10 +56,23 @@ const clampDays = (raw: unknown, fallback: number): number => {
  * treated as "not asked" rather than as an error, because the current year is the useful
  * answer to a malformed year and a rejection is not.
  */
-const asYear = (raw: unknown, now: Date): number | undefined => {
-  if (typeof raw !== "number" || !Number.isFinite(raw)) return undefined;
+const asYear = (raw: unknown, now: Date): number => {
+  /*
+   * Always a real year, never "no filter".
+   *
+   * Returning undefined for an omitted year left `aggregate` unfiltered while `buildRecap`
+   * still stamped the current year on the result — so `get_recap` with no arguments reported
+   * all-time totals headed 2026. That is the default call, and it is wrong for anyone with
+   * more than one year of history. `packages/cli/src/commands/recap.ts` resolves its default
+   * the same way and carries a comment saying exactly this.
+   *
+   * Out of range is treated as omitted rather than as an error: the payload states the year
+   * it actually used, so a model can see what it got, and a hard failure is a worse answer to
+   * a plausible guess.
+   */
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return now.getFullYear();
   const year = Math.trunc(raw);
-  return year >= 2020 && year <= now.getFullYear() ? year : undefined;
+  return year >= 2020 && year <= now.getFullYear() ? year : now.getFullYear();
 };
 
 /** Local `YYYY-MM-DD` for each of the last `days` calendar days, oldest first. */
@@ -197,7 +213,7 @@ export const tools: Tool[] = [
       const now = new Date();
       const year = asYear(args.year, now);
       const { stats } = await read(asAgents(args.agents), year);
-      const recap = buildRecap(stats, year === undefined ? {} : { year });
+      const recap = buildRecap(stats, { year });
 
       return {
         year: recap.year,

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,0 +1,198 @@
+import { buildRecap, formatTokens, type AgentId, type Stats } from "@tokenchit/core";
+
+import { ALL_AGENTS, detect, read } from "./stats.js";
+
+export type Tool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  run(args: Record<string, unknown>): Promise<unknown>;
+};
+
+/** The `agents` argument, shared by every tool that takes one. */
+const AGENTS_ARG = {
+  type: "array",
+  items: { type: "string", enum: [...ALL_AGENTS] },
+  description: "Restrict the read to these agents. Omit for all of them.",
+} as const;
+
+/**
+ * Every number a caller might quote comes back with the caveat attached.
+ *
+ * A model asked "how much have I spent on Claude Code" will otherwise read `equivCostUsd`
+ * and answer in dollars, which is wrong in a way the user cannot detect: most agent usage
+ * runs under a subscription where no per-token charge ever happens. Returning the caveat as
+ * a sibling field of the figure is the only version of this that survives summarisation.
+ */
+const COST_CAVEAT =
+  "Not money anyone paid. This is what these tokens would cost at list API rates; " +
+  "most agent usage runs under a subscription with no per-token charge. Models with no " +
+  "public price are counted in tokens and omitted here.";
+
+const PANEL_CAVEAT =
+  "This will not match Claude Code's own Stats panel, which counts each API call once per " +
+  "streaming rewrite and so reads high. These figures are deduplicated by message id.";
+
+const asAgents = (raw: unknown): AgentId[] | undefined => {
+  if (!Array.isArray(raw)) return undefined;
+  const valid = raw.filter((a): a is AgentId => ALL_AGENTS.includes(a as AgentId));
+  return valid.length ? valid : undefined;
+};
+
+const clampDays = (raw: unknown, fallback: number): number => {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(3650, Math.max(1, Math.trunc(n)));
+};
+
+const windowOf = (w: Stats["windows"][keyof Stats["windows"]]) => ({
+  tokens: w.tokens,
+  tokensHuman: formatTokens(w.tokens),
+  equivCostUsd: Number(w.equivCostUsd.toFixed(2)),
+  apiCalls: w.events,
+});
+
+export const tools: Tool[] = [
+  {
+    name: "get_usage",
+    description:
+      "Total local AI coding agent usage: tokens, equivalent cost, streak, active days, " +
+      "per-agent mix and per-model breakdown, over all time and the last year, 30 days and " +
+      "7 days. Reads logs on this machine; makes no network request.",
+    inputSchema: {
+      type: "object",
+      properties: { agents: AGENTS_ARG },
+      additionalProperties: false,
+    },
+    async run(args) {
+      const { stats, recovered } = await read(asAgents(args.agents));
+      return {
+        tokens: stats.tokens,
+        tokensHuman: formatTokens(stats.tokens),
+        equivCostUsd: Number(stats.equivCostUsd.toFixed(2)),
+        equivCostNote: COST_CAVEAT,
+        // A caller quoting the cost needs to know how much of the total it covers. At 0.6
+        // the figure is missing 40% of the usage and saying "$X" unqualified is misleading.
+        pricedShareOfTokens: Number(stats.pricedShare.toFixed(4)),
+        streakDays: stats.streakDays,
+        activeDays: stats.activeDays,
+        firstDay: stats.firstDay,
+        lastDay: stats.lastDay,
+        byAgent: Object.fromEntries(stats.byAgent),
+        mix: stats.mix,
+        windows: {
+          all: windowOf(stats.windows.all),
+          year: windowOf(stats.windows.year),
+          last30Days: windowOf(stats.windows.d30),
+          last7Days: windowOf(stats.windows.d7),
+        },
+        topModels: stats.models.slice(0, 10),
+        recoveredFromLedger: recovered,
+        accuracyNote: PANEL_CAVEAT,
+      };
+    },
+  },
+
+  {
+    name: "get_daily_usage",
+    description:
+      "Tokens per local calendar day, most recent last. Use this for questions about a " +
+      "specific stretch of time rather than a lifetime total.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        days: {
+          type: "integer",
+          minimum: 1,
+          maximum: 3650,
+          default: 30,
+          description: "How many days back to return, counting from the most recent day with data.",
+        },
+        agents: AGENTS_ARG,
+      },
+      additionalProperties: false,
+    },
+    async run(args) {
+      const { stats } = await read(asAgents(args.agents));
+      const days = clampDays(args.days, 30);
+      const series = [...stats.byDay.entries()]
+        .map(([day, tokens]) => ({ day, tokens }))
+        .slice(-days);
+
+      return {
+        days: series,
+        // Idle days inside the range are present with 0 rather than skipped, so a caller can
+        // count gaps. Days before `firstDay` are simply absent — the logs did not exist yet,
+        // which is not the same claim as "you used nothing".
+        requestedDays: days,
+        returnedDays: series.length,
+        totalInRange: series.reduce((a, d) => a + d.tokens, 0),
+        byWeekdayMondayFirst: stats.byWeekday,
+        byHourLocal: stats.byHour,
+        accuracyNote: PANEL_CAVEAT,
+      };
+    },
+  },
+
+  {
+    name: "get_recap",
+    description:
+      "Year in review: headline tiles, per-agent and per-model breakdown, the busiest hour " +
+      "range and a day-by-hour activity grid. The same figures `tokenchit recap` renders.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        year: {
+          type: "integer",
+          minimum: 2020,
+          maximum: 2100,
+          description: "Calendar year. Omit for the current one.",
+        },
+        agents: AGENTS_ARG,
+      },
+      additionalProperties: false,
+    },
+    async run(args) {
+      const { stats } = await read(asAgents(args.agents));
+      const year = typeof args.year === "number" ? Math.trunc(args.year) : undefined;
+      const recap = buildRecap(stats, year === undefined ? {} : { year });
+
+      return {
+        year: recap.year,
+        tiles: recap.tiles,
+        agents: recap.agents,
+        models: recap.models,
+        peakHours: recap.peak,
+        activeDays: recap.activeDays,
+        tokens: recap.tokens,
+        // The colour ramp is for the SVG. A caller wants the numbers.
+        activityByDay: recap.rows.map((r) => ({ day: r.day, tokens: r.tokens, busiest: r.busiest })),
+        equivCostNote: COST_CAVEAT,
+        accuracyNote: PANEL_CAVEAT,
+      };
+    },
+  },
+
+  {
+    name: "detect_agents",
+    description:
+      "Which coding agents are installed on this machine, where each one's logs live, and " +
+      "whether they hold readable usage. Call this first when a usage read comes back empty.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    async run() {
+      const found = await detect();
+      return {
+        agents: found,
+        supported: found.filter((a) => a.state === "ready").map((a) => a.agent),
+        // Named rather than omitted: "Copilot is missing" and "Copilot cannot be supported"
+        // are different answers, and only one of them is a bug report.
+        unsupported: [
+          { agent: "copilot-cli", reason: "records only a live context gauge, not token totals" },
+          { agent: "gemini-cli", reason: "transcripts carry no token counts" },
+        ],
+      };
+    },
+  },
+];
+
+export const byName = new Map(tools.map((t) => [t.name, t]));

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,4 +1,4 @@
-import { buildRecap, formatTokens, type AgentId, type Stats } from "@tokenchit/core";
+import { buildRecap, formatTokens, localDay, type AgentId, type Stats } from "@tokenchit/core";
 
 import { ALL_AGENTS, detect, read } from "./stats.js";
 
@@ -45,6 +45,31 @@ const clampDays = (raw: unknown, fallback: number): number => {
   return Math.min(3650, Math.max(1, Math.trunc(n)));
 };
 
+/**
+ * A year the logs could plausibly cover, or undefined.
+ *
+ * The JSON schema states the bounds but nothing enforces them at runtime — a client that
+ * ignores the schema could ask for 2030 and get all-time data stamped 2030. Out-of-range is
+ * treated as "not asked" rather than as an error, because the current year is the useful
+ * answer to a malformed year and a rejection is not.
+ */
+const asYear = (raw: unknown, now: Date): number | undefined => {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return undefined;
+  const year = Math.trunc(raw);
+  return year >= 2020 && year <= now.getFullYear() ? year : undefined;
+};
+
+/** Local `YYYY-MM-DD` for each of the last `days` calendar days, oldest first. */
+function calendarRange(days: number, now: Date): string[] {
+  const out: string[] = [];
+  for (let i = days - 1; i >= 0; i -= 1) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    out.push(localDay(d));
+  }
+  return out;
+}
+
 const windowOf = (w: Stats["windows"][keyof Stats["windows"]]) => ({
   tokens: w.tokens,
   tokensHuman: formatTokens(w.tokens),
@@ -57,8 +82,9 @@ export const tools: Tool[] = [
     name: "get_usage",
     description:
       "Total local AI coding agent usage: tokens, equivalent cost, streak, active days, " +
-      "per-agent mix and per-model breakdown, over all time and the last year, 30 days and " +
-      "7 days. Reads logs on this machine; makes no network request.",
+      "per-agent mix and per-model breakdown. Windows are all time, the current calendar " +
+      "year so far, the last 30 days and the last 7 days. Reads logs on this machine; " +
+      "makes no network request.",
     inputSchema: {
       type: "object",
       properties: { agents: AGENTS_ARG },
@@ -82,7 +108,10 @@ export const tools: Tool[] = [
         mix: stats.mix,
         windows: {
           all: windowOf(stats.windows.all),
-          year: windowOf(stats.windows.year),
+          /* Named for what it is. As `year`, sitting beside `last30Days` and `last7Days`, it
+             read as a trailing twelve months — so asked in mid-January a model would report
+             two weeks of usage as someone's year. */
+          yearToDate: windowOf(stats.windows.year),
           last30Days: windowOf(stats.windows.d30),
           last7Days: windowOf(stats.windows.d7),
         },
@@ -106,7 +135,7 @@ export const tools: Tool[] = [
           minimum: 1,
           maximum: 3650,
           default: 30,
-          description: "How many days back to return, counting from the most recent day with data.",
+          description: "How many calendar days back to return, ending today. Idle days are included as zero.",
         },
         agents: AGENTS_ARG,
       },
@@ -115,20 +144,31 @@ export const tools: Tool[] = [
     async run(args) {
       const { stats } = await read(asAgents(args.agents));
       const days = clampDays(args.days, 30);
-      const series = [...stats.byDay.entries()]
-        .map(([day, tokens]) => ({ day, tokens }))
-        .slice(-days);
+
+      /*
+       * Built from a calendar range rather than by slicing the map.
+       *
+       * `stats.byDay` only carries days that had events, so `.slice(-days)` returned the last
+       * `days` *active* days — on a sparse corpus that was two entries a month apart returned
+       * as "the last 3 days", with a total a model would quote as a three-day figure. It also
+       * disagreed with `get_usage`'s last7Days/last30Days for the same machine, which is the
+       * kind of inconsistency that makes every number here suspect.
+       */
+      const series = calendarRange(days, new Date()).map((day) => ({
+        day,
+        tokens: stats.byDay.get(day) ?? 0,
+      }));
 
       return {
         days: series,
-        // Idle days inside the range are present with 0 rather than skipped, so a caller can
-        // count gaps. Days before `firstDay` are simply absent — the logs did not exist yet,
-        // which is not the same claim as "you used nothing".
         requestedDays: days,
         returnedDays: series.length,
         totalInRange: series.reduce((a, d) => a + d.tokens, 0),
-        byWeekdayMondayFirst: stats.byWeekday,
-        byHourLocal: stats.byHour,
+        /* Lifetime, not windowed — these come from the whole corpus and are here for shape
+           questions ("when do I work"), not for the range above. */
+        lifetimeByWeekdayMondayFirst: stats.byWeekday,
+        lifetimeByHourLocal: stats.byHour,
+        firstDayWithData: stats.firstDay,
         accuracyNote: PANEL_CAVEAT,
       };
     },
@@ -137,8 +177,9 @@ export const tools: Tool[] = [
   {
     name: "get_recap",
     description:
-      "Year in review: headline tiles, per-agent and per-model breakdown, the busiest hour " +
-      "range and a day-by-hour activity grid. The same figures `tokenchit recap` renders.",
+      "Year in review for one calendar year: headline tiles, per-agent and per-model " +
+      "breakdown, the busiest hour range, and activity aggregated by weekday and hour (not " +
+      "by date). The same figures `tokenchit recap` renders.",
     inputSchema: {
       type: "object",
       properties: {
@@ -153,8 +194,9 @@ export const tools: Tool[] = [
       additionalProperties: false,
     },
     async run(args) {
-      const { stats } = await read(asAgents(args.agents));
-      const year = typeof args.year === "number" ? Math.trunc(args.year) : undefined;
+      const now = new Date();
+      const year = asYear(args.year, now);
+      const { stats } = await read(asAgents(args.agents), year);
       const recap = buildRecap(stats, year === undefined ? {} : { year });
 
       return {
@@ -165,8 +207,21 @@ export const tools: Tool[] = [
         peakHours: recap.peak,
         activeDays: recap.activeDays,
         tokens: recap.tokens,
-        // The colour ramp is for the SVG. A caller wants the numbers.
-        activityByDay: recap.rows.map((r) => ({ day: r.day, tokens: r.tokens, busiest: r.busiest })),
+        /*
+         * Weekday buckets, named as such.
+         *
+         * `recap.rows` is `WEEKDAYS.map(...)`, so `day` is "MON".."SUN" — this was returned
+         * as `activityByDay`, which a model asked "which days was I busiest" would read as
+         * dates. The hour dimension was also being dropped: `levels` is the 0-4 ramp per
+         * hour and is the only part of the grid worth handing over, the colours being for
+         * the SVG.
+         */
+        activityByWeekday: recap.rows.map((r) => ({
+          weekday: r.day,
+          tokens: r.tokens,
+          busiest: r.busiest,
+          byHourLevel: r.levels,
+        })),
         equivCostNote: COST_CAVEAT,
         accuracyNote: PANEL_CAVEAT,
       };

--- a/packages/mcp/test/protocol.test.js
+++ b/packages/mcp/test/protocol.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { test } from "node:test";
@@ -348,4 +348,106 @@ test("initialize reports the package version", async () => {
   const { messages } = await talk([rpc(1, "initialize", {})]);
 
   assert.equal(find(messages, 1).result.serverInfo.version, pkg.version);
+});
+
+/**
+ * A HOME whose Claude Code transcript spans two calendar years.
+ *
+ * The committed fixture is all one year, so it cannot tell "this year" apart from "all time"
+ * — which is exactly how a recap that ignored the year passed the suite. Built here rather
+ * than committed because only these two tests need it.
+ */
+async function twoYearHome() {
+  const home = await mkdtemp(join(tmpdir(), "tokenchit-mcp-2y-"));
+  const dir = join(home, ".claude", "projects", "demo");
+  await mkdir(dir, { recursive: true });
+
+  const event = (ts, id, output) => ({
+    type: "assistant",
+    requestId: `r-${id}`,
+    timestamp: ts,
+    message: {
+      id,
+      role: "assistant",
+      model: "claude-opus-5",
+      content: [{ type: "text", text: "x" }],
+      usage: {
+        input_tokens: 0,
+        output_tokens: output,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  });
+
+  const thisYear = new Date().getFullYear();
+  const rows = [
+    // Two days in a past year, then one in the current one. Deliberately lopsided: if the
+    // year filter is skipped, the current year's figure picks up the past year's bulk.
+    event(`${thisYear - 1}-03-10T10:00:01.000Z`, "past-a", 2000),
+    event(`${thisYear - 1}-03-11T10:00:01.000Z`, "past-b", 3000),
+    event(`${thisYear}-06-01T10:00:01.000Z`, "now-a", 100),
+  ];
+
+  await writeFile(join(dir, "session.jsonl"), rows.map((r) => JSON.stringify(r)).join("\n"));
+  return { home, thisYear, pastYear: thisYear - 1, pastTokens: 5000, currentTokens: 100 };
+}
+
+/** As `talk`, against a caller-supplied HOME. */
+async function talkIn(home, frames) {
+  const xdg = await mkdtemp(join(tmpdir(), "tokenchit-mcp-test-"));
+  const child = spawn(process.execPath, [SERVER], {
+    env: { ...process.env, HOME: home, USERPROFILE: home, CLAUDE_CONFIG_DIR: "", XDG_CONFIG_HOME: xdg },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let out = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (c) => (out += c));
+  for (const f of frames) child.stdin.write(`${JSON.stringify(f)}\n`);
+  child.stdin.end();
+
+  await new Promise((resolve) => child.on("close", resolve));
+  return out.split("\n").filter((l) => l.trim()).map((l) => JSON.parse(l));
+}
+
+test("get_recap with no year defaults to a real year, not to all time", async () => {
+  /* The default call. `aggregate` was left unfiltered while `buildRecap` still stamped the
+     current year on the result, so `get_recap({})` reported every year's tokens headed with
+     this one — wrong for anyone with more than one year of history, and invisible on a
+     single-year fixture. recap.ts resolves its default the same way for the same reason. */
+  const fx = await twoYearHome();
+  const [omitted, explicit] = await Promise.all([
+    talkIn(fx.home, [call(1, "get_recap")]),
+    talkIn(fx.home, [call(1, "get_recap", { year: fx.thisYear })]),
+  ]);
+
+  const a = payload(find(omitted, 1));
+  const b = payload(find(explicit, 1));
+
+  assert.equal(a.year, fx.thisYear);
+  assert.equal(a.tokens, fx.currentTokens, "omitting the year must not pick up the past year");
+  assert.deepEqual(a.tokens, b.tokens, "omitted and explicit current year must agree");
+  assert.notEqual(a.tokens, fx.pastTokens + fx.currentTokens, "not an all-time total");
+});
+
+test("get_recap scopes a past year against a corpus that spans two", async () => {
+  const fx = await twoYearHome();
+  const messages = await talkIn(fx.home, [call(1, "get_recap", { year: fx.pastYear })]);
+  const out = payload(find(messages, 1));
+
+  assert.equal(out.year, fx.pastYear);
+  assert.equal(out.tokens, fx.pastTokens);
+});
+
+test("days: null means unset, not zero", async () => {
+  // `Number(null)` is 0, which clamped to 1 — so a client sending null to mean "use the
+  // default" got a single day. Absent and null are the same intent.
+  const [nulled, absent] = await Promise.all([
+    talk([call(1, "get_daily_usage", { days: null })]),
+    talk([call(1, "get_daily_usage")]),
+  ]);
+
+  assert.equal(payload(find(nulled.messages, 1)).requestedDays, 30);
+  assert.equal(payload(find(absent.messages, 1)).requestedDays, 30);
 });

--- a/packages/mcp/test/protocol.test.js
+++ b/packages/mcp/test/protocol.test.js
@@ -118,9 +118,12 @@ test("get_usage returns figures with both caveats attached", async () => {
   assert.match(out.equivCostNote, /subscription/i);
   assert.match(out.accuracyNote, /Stats panel/i);
   assert.ok("pricedShareOfTokens" in out, "cost coverage is stated");
-  for (const w of ["all", "year", "last30Days", "last7Days"]) {
+  /* `yearToDate`, not `year`: beside last30Days/last7Days the old name read as a trailing
+     twelve months, and aggregate() builds the bucket from 1 January. */
+  for (const w of ["all", "yearToDate", "last30Days", "last7Days"]) {
     assert.ok(w in out.windows, `windows.${w}`);
   }
+  assert.ok(!("year" in out.windows), "the ambiguous `year` key is gone");
 });
 
 test("get_usage honours the agents filter", async () => {
@@ -146,9 +149,8 @@ test("get_daily_usage clamps the range and reports what it returned", async () =
   const out = payload(find(messages, 1));
 
   assert.equal(out.requestedDays, 7);
-  assert.ok(out.returnedDays <= 7);
-  assert.equal(out.byWeekdayMondayFirst.length, 7);
-  assert.equal(out.byHourLocal.length, 24);
+  assert.equal(out.lifetimeByWeekdayMondayFirst.length, 7);
+  assert.equal(out.lifetimeByHourLocal.length, 24);
 });
 
 test("get_recap returns tiles and a per-agent split", async () => {
@@ -158,7 +160,7 @@ test("get_recap returns tiles and a per-agent split", async () => {
   assert.equal(typeof out.year, "number");
   assert.ok("totalTokens" in out.tiles);
   assert.ok(Array.isArray(out.agents));
-  assert.ok(Array.isArray(out.activityByDay));
+  assert.ok(Array.isArray(out.activityByWeekday));
 });
 
 test("an unknown tool is a JSON-RPC error, a failing tool is not", async () => {
@@ -249,4 +251,101 @@ test("a frame split across reads is still parsed", async () => {
 
   assert.equal(messages.length, 1);
   assert.ok(messages[0].result.tools.length > 0);
+});
+
+/* ---------------------------------------------------------------------------
+   Regressions. Each of these is a bug that shipped past the tests above, so
+   each one names the wrong behaviour rather than just asserting the right one.
+   --------------------------------------------------------------------------- */
+
+test("get_recap scopes every figure to the year, not just the streak", async () => {
+  // `buildRecap` uses `year` for the longestStreak tile and nothing else; the rest of the
+  // figures come from the stats it is handed. Without threading `year` into `aggregate`,
+  // asking for 2021 returned this year's totals under a 2021 heading.
+  const [now, old] = await Promise.all([
+    talk([call(1, "get_recap")]),
+    talk([call(1, "get_recap", { year: 2021 })]),
+  ]);
+
+  const current = payload(find(now.messages, 1));
+  const past = payload(find(old.messages, 1));
+
+  assert.ok(current.tokens > 0, "the fixture has usage in the current year");
+  assert.equal(past.year, 2021);
+  assert.equal(past.tokens, 0, "2021 has no usage in the fixture");
+  assert.equal(past.activeDays, 0);
+  assert.notEqual(past.tokens, current.tokens, "a past year must not echo the current one");
+});
+
+test("get_recap ignores a year the logs cannot cover", async () => {
+  // The schema states 2020-2100 and nothing enforced it, so `year: 2030` returned all-time
+  // data stamped 2030. A future year is treated as "not asked" rather than as an error.
+  const { messages } = await talk([call(1, "get_recap", { year: 2030 })]);
+  const out = payload(find(messages, 1));
+
+  assert.equal(out.year, new Date().getFullYear());
+});
+
+test("get_daily_usage returns calendar days, not the last N active days", async () => {
+  // `stats.byDay` is sparse, so slicing it returned the last N *active* days — on this
+  // fixture, two days a month apart returned as "the last 3 days".
+  const { messages } = await talk([call(1, "get_daily_usage", { days: 3 })]);
+  const out = payload(find(messages, 1));
+
+  assert.equal(out.returnedDays, 3, "three days requested, three returned");
+  assert.equal(out.days.length, 3);
+
+  const dates = out.days.map((d) => d.day);
+  assert.deepEqual(dates, [...dates].sort(), "ascending");
+  for (let i = 1; i < dates.length; i += 1) {
+    const gap = Date.parse(`${dates[i]}T12:00:00Z`) - Date.parse(`${dates[i - 1]}T12:00:00Z`);
+    assert.equal(gap, 86_400_000, `${dates[i - 1]} -> ${dates[i]} is one day`);
+  }
+});
+
+test("a valid-JSON non-object does not kill the server", async () => {
+  // `null` has no `id`, so dispatching it threw, and the catch threw the same TypeError
+  // re-reading `req.id` — the rejection went unhandled and took the process with it. One
+  // frame ended the session. The test above only covered unparseable bytes.
+  const xdg = await mkdtemp(join(tmpdir(), "tokenchit-mcp-test-"));
+  const child = spawn(process.execPath, [SERVER], {
+    env: { ...process.env, HOME: FIXTURE_HOME, CLAUDE_CONFIG_DIR: "", XDG_CONFIG_HOME: xdg },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let out = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (c) => (out += c));
+
+  for (const frame of ["null", "42", '"a string"', "[1,2]"]) child.stdin.write(`${frame}\n`);
+  child.stdin.write(`${JSON.stringify(rpc(7, "tools/list"))}\n`);
+  child.stdin.end();
+
+  const code = await new Promise((resolve) => child.on("close", resolve));
+  const messages = out.split("\n").filter((l) => l.trim()).map((l) => JSON.parse(l));
+
+  assert.equal(code, 0, "the server exited cleanly rather than crashing");
+  for (const m of messages.filter((m) => m.error)) assert.equal(m.error.code, -32600);
+  assert.ok(find(messages, 7).result.tools.length > 0, "the frame behind them was still served");
+});
+
+test("a reply larger than the pipe buffer is not truncated", async () => {
+  /* stdout is a pipe under stdio transport and Node's pipe writes are async, so
+     `process.exit` dropped anything still buffered past ~64KB. Ten years of days clears
+     that comfortably; the shutdown test above only ever sent tiny payloads. */
+  const { messages, raw } = await talk([call(1, "get_daily_usage", { days: 3650 })]);
+
+  assert.ok(raw.length > 65_536, `payload must exceed the pipe buffer, got ${raw.length}`);
+  const out = payload(find(messages, 1));
+  assert.equal(out.returnedDays, 3650, "every day survived the write");
+});
+
+test("initialize reports the package version", async () => {
+  // A literal here silently drifted from package.json on the next release, in the one field
+  // a client logs and a bug report quotes.
+  const { readFile } = await import("node:fs/promises");
+  const pkg = JSON.parse(await readFile(join(HERE, "..", "package.json"), "utf8"));
+  const { messages } = await talk([rpc(1, "initialize", {})]);
+
+  assert.equal(find(messages, 1).result.serverInfo.version, pkg.version);
 });

--- a/packages/mcp/test/protocol.test.js
+++ b/packages/mcp/test/protocol.test.js
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SERVER = join(HERE, "..", "dist", "index.js");
+/* The CLI's fixture home, reused rather than duplicated: two copies of the same transcripts
+   drift, and a figure that differs between the CLI and this server is the bug most worth
+   catching. */
+const FIXTURE_HOME = join(HERE, "..", "..", "cli", "test", "fixtures", "home");
+
+/**
+ * Send some frames, close stdin, and collect what came back.
+ *
+ * Closing stdin immediately is deliberate and is itself the regression test for the
+ * shutdown race: the server must finish answering everything it accepted before exiting.
+ */
+async function talk(frames) {
+  const xdg = await mkdtemp(join(tmpdir(), "tokenchit-mcp-test-"));
+
+  const child = spawn(process.execPath, [SERVER], {
+    env: {
+      ...process.env,
+      HOME: FIXTURE_HOME,
+      USERPROFILE: FIXTURE_HOME,
+      // This machine sets CLAUDE_CONFIG_DIR and the adapter honours it, so it has to be
+      // cleared or the fixture is ignored and the test reads real logs.
+      CLAUDE_CONFIG_DIR: "",
+      XDG_CONFIG_HOME: xdg,
+      NO_COLOR: "1",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let out = "";
+  let err = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (c) => (out += c));
+  child.stderr.on("data", (c) => (err += c));
+
+  for (const f of frames) child.stdin.write(`${JSON.stringify(f)}\n`);
+  child.stdin.end();
+
+  const code = await new Promise((resolve) => child.on("close", resolve));
+  const messages = out
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+
+  return { messages, err, code, raw: out };
+}
+
+const rpc = (id, method, params) => ({ jsonrpc: "2.0", id, method, ...(params ? { params } : {}) });
+const call = (id, name, args = {}) => rpc(id, "tools/call", { name, arguments: args });
+const find = (messages, id) => messages.find((m) => m.id === id);
+const payload = (message) => JSON.parse(message.result.content[0].text);
+
+test("initialize advertises tools and a protocol version", async () => {
+  const { messages } = await talk([rpc(1, "initialize", { protocolVersion: "2025-06-18" })]);
+  const res = find(messages, 1).result;
+
+  assert.equal(typeof res.protocolVersion, "string");
+  assert.deepEqual(Object.keys(res.capabilities), ["tools"]);
+  assert.equal(res.serverInfo.name, "tokenchit");
+  // The instructions carry the two caveats a model would otherwise get wrong unprompted.
+  assert.match(res.instructions, /network request/i);
+  assert.match(res.instructions, /list API rates/i);
+});
+
+test("tools/list names every tool with a schema", async () => {
+  const { messages } = await talk([rpc(1, "tools/list")]);
+  const { tools } = find(messages, 1).result;
+
+  assert.deepEqual(
+    tools.map((t) => t.name).sort(),
+    ["detect_agents", "get_daily_usage", "get_recap", "get_usage"],
+  );
+  for (const t of tools) {
+    assert.equal(t.inputSchema.type, "object", `${t.name} has an object schema`);
+    assert.ok(t.description.length > 20, `${t.name} is described`);
+  }
+});
+
+test("a tool call still answers when stdin closes behind it", async () => {
+  // The shutdown race: the server used to exit on stdin end while a read was in flight, so
+  // this reply was silently dropped. Two calls, so a partial drain would also show up.
+  const { messages, code } = await talk([call(1, "detect_agents"), call(2, "get_usage")]);
+
+  assert.ok(find(messages, 1), "detect_agents answered");
+  assert.ok(find(messages, 2), "get_usage answered");
+  assert.equal(code, 0);
+});
+
+test("detect_agents reads the fixture and names what it cannot support", async () => {
+  const { messages } = await talk([call(1, "detect_agents")]);
+  const out = payload(find(messages, 1));
+
+  assert.deepEqual(out.agents.map((a) => a.agent).sort(), ["claude-code", "codex", "opencode"]);
+  for (const a of out.agents) assert.ok(a.source, `${a.agent} says where it reads from`);
+  assert.deepEqual(out.unsupported.map((u) => u.agent), ["copilot-cli", "gemini-cli"]);
+  for (const u of out.unsupported) assert.ok(u.reason, `${u.agent} says why`);
+});
+
+test("get_usage returns figures with both caveats attached", async () => {
+  const { messages } = await talk([call(1, "get_usage")]);
+  const out = payload(find(messages, 1));
+
+  assert.equal(typeof out.tokens, "number");
+  assert.ok(out.tokens > 0, "the fixture has usage");
+  assert.equal(typeof out.tokensHuman, "string");
+  /* The caveats are asserted because they are the whole reason the figures are safe to hand
+     to a model: without them `equivCostUsd` gets reported to a user as money they spent. */
+  assert.match(out.equivCostNote, /subscription/i);
+  assert.match(out.accuracyNote, /Stats panel/i);
+  assert.ok("pricedShareOfTokens" in out, "cost coverage is stated");
+  for (const w of ["all", "year", "last30Days", "last7Days"]) {
+    assert.ok(w in out.windows, `windows.${w}`);
+  }
+});
+
+test("get_usage honours the agents filter", async () => {
+  const { messages } = await talk([call(1, "get_usage", { agents: ["claude-code"] })]);
+  const out = payload(find(messages, 1));
+
+  assert.deepEqual(Object.keys(out.byAgent), ["claude-code"]);
+});
+
+test("an unknown agent in the filter does not silently read everything", async () => {
+  const [all, bogus] = await Promise.all([
+    talk([call(1, "get_usage")]),
+    talk([call(1, "get_usage", { agents: ["not-an-agent"] })]),
+  ]);
+
+  /* An unrecognised filter falls back to every agent rather than to none — returning zero
+     would read as "you have no usage", which is a wrong answer rather than a rejected one. */
+  assert.equal(payload(find(bogus.messages, 1)).tokens, payload(find(all.messages, 1)).tokens);
+});
+
+test("get_daily_usage clamps the range and reports what it returned", async () => {
+  const { messages } = await talk([call(1, "get_daily_usage", { days: 7 })]);
+  const out = payload(find(messages, 1));
+
+  assert.equal(out.requestedDays, 7);
+  assert.ok(out.returnedDays <= 7);
+  assert.equal(out.byWeekdayMondayFirst.length, 7);
+  assert.equal(out.byHourLocal.length, 24);
+});
+
+test("get_recap returns tiles and a per-agent split", async () => {
+  const { messages } = await talk([call(1, "get_recap")]);
+  const out = payload(find(messages, 1));
+
+  assert.equal(typeof out.year, "number");
+  assert.ok("totalTokens" in out.tiles);
+  assert.ok(Array.isArray(out.agents));
+  assert.ok(Array.isArray(out.activityByDay));
+});
+
+test("an unknown tool is a JSON-RPC error, a failing tool is not", async () => {
+  const { messages } = await talk([call(1, "no_such_tool")]);
+  const msg = find(messages, 1);
+
+  assert.equal(msg.error.code, -32601);
+  assert.match(msg.error.message, /unknown tool/);
+});
+
+test("malformed input is reported without killing the server", async () => {
+  const xdg = await mkdtemp(join(tmpdir(), "tokenchit-mcp-test-"));
+  const child = spawn(process.execPath, [SERVER], {
+    env: { ...process.env, HOME: FIXTURE_HOME, CLAUDE_CONFIG_DIR: "", XDG_CONFIG_HOME: xdg },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let out = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (c) => (out += c));
+
+  child.stdin.write("this is not json\n");
+  child.stdin.write(`${JSON.stringify(rpc(2, "tools/list"))}\n`);
+  child.stdin.end();
+
+  await new Promise((resolve) => child.on("close", resolve));
+  const messages = out.split("\n").filter((l) => l.trim()).map((l) => JSON.parse(l));
+
+  assert.equal(messages[0].error.code, -32700);
+  // The frame after the bad one is still served: one unparseable line must not end the session.
+  assert.ok(find(messages, 2).result.tools.length > 0);
+});
+
+test("a notification is not answered", async () => {
+  const { messages } = await talk([
+    { jsonrpc: "2.0", method: "notifications/initialized" },
+    { jsonrpc: "2.0", method: "notifications/something/unheard/of" },
+    rpc(9, "tools/list"),
+  ]);
+
+  // Exactly one reply, for the one request that carried an id.
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].id, 9);
+});
+
+test("stdout carries protocol frames and nothing else", async () => {
+  /* The rule that makes stdio transport work at all. A stray console.log anywhere under
+     these calls corrupts the stream, and it corrupts it for the client rather than here,
+     so it has to be caught by a test. */
+  const { raw, err } = await talk([
+    rpc(1, "initialize", {}),
+    call(2, "get_usage"),
+    call(3, "get_recap"),
+    call(4, "detect_agents"),
+  ]);
+
+  for (const line of raw.split("\n").filter((l) => l.trim())) {
+    assert.doesNotThrow(() => JSON.parse(line), `stdout line is JSON: ${line.slice(0, 80)}`);
+    assert.equal(JSON.parse(line).jsonrpc, "2.0");
+  }
+  // The SQLite experimental warning is filtered, so a clean run says nothing at all.
+  assert.equal(err.trim(), "", `stderr should be quiet, got: ${err.slice(0, 200)}`);
+});
+
+test("a frame split across reads is still parsed", async () => {
+  const xdg = await mkdtemp(join(tmpdir(), "tokenchit-mcp-test-"));
+  const child = spawn(process.execPath, [SERVER], {
+    env: { ...process.env, HOME: FIXTURE_HOME, CLAUDE_CONFIG_DIR: "", XDG_CONFIG_HOME: xdg },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let out = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (c) => (out += c));
+
+  // Deliberately mid-object, in three writes. Parsing per chunk passes every hand test and
+  // then fails on the first payload big enough for the kernel to split.
+  const frame = JSON.stringify(rpc(1, "tools/list"));
+  child.stdin.write(frame.slice(0, 12));
+  await new Promise((r) => setTimeout(r, 30));
+  child.stdin.write(frame.slice(12, 25));
+  await new Promise((r) => setTimeout(r, 30));
+  child.stdin.write(`${frame.slice(25)}\n`);
+  child.stdin.end();
+
+  await new Promise((resolve) => child.on("close", resolve));
+  const messages = out.split("\n").filter((l) => l.trim()).map((l) => JSON.parse(l));
+
+  assert.equal(messages.length, 1);
+  assert.ok(messages[0].result.tools.length > 0);
+});

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": ".build",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -4,9 +4,9 @@
  *
  *   node scripts/version.mjs 0.2.0
  *
- * Only @tokenchit/cli is published; core is private and bundled into it. Both are bumped
- * anyway so the repo does not carry two versions that quietly diverge, and the release
- * workflow refuses to publish when the tag disagrees with the CLI.
+ * @tokenchit/cli and @tokenchit/mcp are published; core is private and bundled into both.
+ * All three are bumped together so the repo does not carry versions that quietly diverge,
+ * and the release workflow refuses to publish when the tag disagrees with the CLI.
  */
 import { readFile, writeFile } from "node:fs/promises";
 
@@ -18,7 +18,11 @@ if (!version || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version)) {
 
 // apps/site depends on the private core package with "*" precisely so it never needs
 // bumping here; pinning it is what broke `npm ci` on the first release.
-for (const file of ["packages/core/package.json", "packages/cli/package.json"]) {
+for (const file of [
+  "packages/core/package.json",
+  "packages/cli/package.json",
+  "packages/mcp/package.json",
+]) {
   const pkg = JSON.parse(await readFile(file, "utf8"));
   pkg.version = version;
   if (pkg.dependencies?.["@tokenchit/core"]) {


### PR DESCRIPTION
Distribution surfaces, because the remaining reach for a CLI is where people already are rather than more posts about it. Three parts: a GitHub Action, an MCP server, and the landing pages every channel sends people to.

## The action

The card is a file, which is the point — and a file does not update itself. Re-running `generate` is the honest answer and nobody remembers to, so the SVG in a README drifts away from the numbers it claims to show.

A runner cannot fix that at the source: it has no access to `~/.claude` or `~/.codex`, so nothing on CI can regenerate a card from logs. It can do the other half — re-fetch the card you already published and commit it, which keeps readers on a committed file rather than an endpoint while the figures stay current.

The guard that matters is the placeholder check. The embed endpoint renders an empty card rather than 404ing for a handle with nothing on the board, so **HTTP 200 is not proof of a real card**, and a typo in `handle` would otherwise commit an empty card on a schedule, silently, forever. It keys on the `NOT PUBLISHED YET` string rather than a size threshold: the smallest real card measured is 6.1KB against the placeholder's 2.0KB, and any cutoff between them is a guess that a future layout change breaks.

`action.yml` is at the repository root because Marketplace requires it there. `.github/workflows/card.yml` refreshes this repository's own card, so a broken action shows up as a red run here before it shows up for anyone else.

One caveat documented rather than hidden: GitHub disables scheduled workflows after 60 days with no repository activity, and a run that finds an unchanged card makes no commit, so on a quiet repository the schedule can switch itself off.

## The MCP server

A CLI answers someone who already opened a terminal to ask. The people this is for spend the day inside an agent, and "how many tokens did I burn this week" is a question they would rather ask there.

Four tools over stdio — `get_usage`, `get_daily_usage`, `get_recap`, `detect_agents` — reading the same logs through the same aggregation, so the figures cannot drift from the card.

- **Every figure ships with its caveat as a sibling field.** A model handed `equivCostUsd` alone will report it as money the user spent, which is wrong in a way the user cannot detect. Beside the number is the only place a caveat survives summarisation.
- **The ledger is read and never written.** `sync` banks what it saw because someone asked it to; a tool call is a question, and a question that mutates state on disk is a surprise the caller cannot see or undo.
- **The transport is written against the wire format, not the official SDK.** The claim this package makes is that it cannot phone home, and `net.isolated` proves that by reading source — a dependency tree moves most of the code out of that test's reach, so the trust surface would grow by more than the SDK saves.

`net.isolated` now covers `packages/mcp/src` with **no allowlisted module at all**, so every file under it must be clean. Verified by adding a `fetch` and watching the suite fail, then removing it.

## The pages

`/tool/claude-code`, `/tool/codex`, `/tool/opencode`. Each states what that adapter reads and the path it reads from, ranks the board by that agent's tokens alone, and carries the caveat specific to it — the Stats panel discrepancy for Claude Code, the absence of any cumulative cache for Codex, unpriced models for OpenCode. Three prerendered pages rather than one thin template, because a page per tool that only swapped a noun would be a doorway page. `dynamicParams` is false, so anything outside the three 404s rather than rendering a crawlable page about a tool that does not exist.

Two landing-page fixes alongside them:

- **The hero now says free.** "MIT" sat in the header and footer, but that is a licence rather than a price, and a reader scanning for the catch never found the answer.
- **Equivalent cost comes out of the hero figure line.** It was the largest number on the page and the one the page spends three paragraphs explaining is not real money, so a cold reader met the claim well before the caveat. It still leads the board and section 02, where the explanation sits beside it.
- **A closing block.** The install command appeared once, in the hero, five sections above the end. It also carries the two things the site had no place for: somewhere to say what is wrong, and a reason to come back.

## Bugs found while testing rather than after shipping

- **MCP shutdown race.** Exiting on stdin end tore down the process with a read still in flight, so the reply was dropped. Reproducible by piping frames in instead of holding the pipe open — which is how anyone first tries this by hand.
- **MCP frame splitting.** Parsing per chunk worked until a frame got big enough for the kernel to split it, which is precisely when a large recap goes out.
- **Literal backticks.** The agent copy reached the page as backtick characters rather than `<code>`. Caught by reading the prerendered HTML.

The first two have regression tests.

## Verification

- `npm test` — 73 / 33 / 14 / 4, all passing. The 14 are new.
- The action's fetch, compare and guard paths were run against the live endpoint: idempotent on a second run, and the placeholder guard checked for false positives across four handles and three layout variants.
- The MCP server was driven over real stdio through `initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`, an unknown tool, and malformed input. Figures match the board row for `@iyashjayesh` (14.0B tokens, 32-day streak). `stdout` carries only JSON-RPC frames and `stderr` is silent on a clean run, both asserted.
- All three agent pages prerender as SSG, were checked in a browser against the live database, and their metadata, canonical and OG tags were read out of the built HTML.

## Needs a human

- **Marketplace publication** is a UI step — cut a release and tick "Publish this Action to the Marketplace". `action.yml` is valid and carries `branding`.
- **`@tokenchit/mcp` is unpublished.** The release workflow gates on `packages/cli/package.json` only, so publishing it is a deliberate separate step. It is also the gate on being listed in `awesome-mcp-servers` (94.7k stars) and `modelcontextprotocol/servers` (90.2k) — neither will take a package nobody can install.


## Review pass before landing

A review of this branch found nine defects, three of them serious. All are fixed in `3ecd60e`, and each now has a test that fails without the fix — the suite as written passed through every one of them. Test count went 14 → 20.

The three worth calling out, all reproduced against the built server:

- **`get_recap` reported all-time figures under any year asked for.** `buildRecap` uses `year` for the longest-streak tile only; every other field comes from the stats handed to it, and `year` was never threaded into `aggregate`. `{year: 2021}` returned this year's totals. `aggregate.ts:36` documents this exact bug being fixed once already for `recap --year` — this was a second instance in a new caller.
- **A valid-JSON non-object killed the process.** `null` has no `id`, so dispatch threw and the catch threw the same TypeError re-reading `req.id`; the rejection went unhandled. One frame ended the session. The malformed-input test only covered unparseable bytes.
- **`get_daily_usage` returned the last N active days, not calendar days.** `stats.byDay` is sparse and the code sliced by position, so `days: 3` could return two days a month apart with a total a model would quote as a three-day figure — and it disagreed with `get_usage`'s own `last7Days`.

Also: `process.exit` truncating replies past the ~64KB pipe buffer (a decade of days is 249KB); a `serverInfo.version` literal `scripts/version.mjs` does not touch; `windows.year` being year-to-date while named as a trailing year; `activityByDay` being weekday buckets named as dates and dropping the advertised hour grid; `action.yml` validating `handle` but not `output`, so `../../x.svg` escaped the workspace, plus four query inputs interpolated raw; and `relative()` output used inside a markdown URL, which is backslash-separated on Windows — fixed in `sync` too, where it predates this branch.
