### PR TITLE
Add a Dockerfile for the MCP server

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "iyashjayesh"
+  ]
+}

--- a/packages/mcp/Dockerfile
+++ b/packages/mcp/Dockerfile
@@ -1,0 +1,18 @@
+# For Glama's listing check, which starts the server and confirms it answers an
+# introspection request (initialize, then tools/list).
+#
+# Installs the published package rather than building from this repo: it is what a user
+# actually runs, so a green check here means the thing on npm works rather than the thing in
+# this tree. Override the version at build time with --build-arg VERSION=x.y.z.
+#
+# There are no agent logs inside a container, so the usage tools answer zero. That is the
+# correct answer to "what is on this machine" when the machine is empty, and introspection —
+# which is what the check exercises — does not read the disk at all.
+FROM node:22-alpine
+
+ARG VERSION=latest
+RUN npm install -g "@tokenchit/mcp@${VERSION}"
+
+# stdio transport: the protocol runs over stdin/stdout, so nothing is exposed and nothing is
+# served. A container that published a port would be advertising a surface this has not got.
+ENTRYPOINT ["tokenchit-mcp"]

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -23,6 +23,18 @@ Reads the logs Claude Code, Codex and OpenCode already write on your machine. No
 | `get_recap` | year in review for one calendar year — headline tiles, per-agent split, busiest hour range, activity by weekday and hour |
 | `detect_agents` | which agents are on this machine, where each reads from, and what cannot be supported |
 
+## Docker
+
+```bash
+docker build -t tokenchit-mcp packages/mcp
+docker run -i --rm tokenchit-mcp
+```
+
+Installs the published package rather than building from source, so a working image proves the
+thing on npm works. There are no agent logs inside a container, so the usage tools answer
+zero — the right answer to "what is on this machine" when the machine is empty. Introspection
+does not read the disk at all.
+
 ## It cannot make a network request
 
 Not a policy sentence. `net.isolated` in `packages/cli/test/privacy.test.js` reads every source


### PR DESCRIPTION
Glama's listing check starts a server in a container and confirms it answers an introspection request, and `awesome-mcp-servers` now requires a passing Glama listing before it will accept an entry — so this unblocks #14221 there.

Installs the published package rather than building from this repo: that is what a user actually runs, so a green check means the artifact on npm works rather than the one in this tree. `--build-arg VERSION=` overrides the tag.

No port is published, because the transport is stdio.

**Verified against `node:22-alpine`:**

| check | result |
|---|---|
| `initialize` | serverInfo + protocol version |
| `tools/list` | all four tools |
| `detect_agents` | all three correctly reported absent |
| `get_usage` | 0 tokens, `isError: false` — degrades rather than failing |
| stderr | empty |
| image | 165 MB |

`node:sqlite` loads under musl, so the OpenCode adapter does not bring the image down on start — that was the one real risk with an alpine base.